### PR TITLE
feat: add GitHub change tracking for QA artifact provenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Commands are installed by copying markdown files to `~/.claude/commands/`. Skill
 commands/
 ├── confluence/    # Confluence page operations (6 commands, cf-*)
 ├── github/        # GitHub tracking and traceability (4 commands, gh-*)
-├── jira/          # Jira ticket tracing and conversion (6 commands, jr-*)
+├── jira/          # Jira ticket tracing and conversion (7 commands, jr-*)
 ├── project/       # Project management commands (8 commands, pm-*)
 ├── testlink/      # TestLink CRUD and execution (18 commands, tl-*)
 ├── test-workflow/ # Test planning and case workflows (13 commands, tw-*)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI QA Workflow is a QA automation toolkit that connects AI coding agents with test management systems through MCP (Model Context Protocol) integrations. It provides 54 slash commands for end-to-end test automation across Jira, Confluence, TestLink, and Playwright.
+AI QA Workflow is a QA automation toolkit that connects AI coding agents with test management systems through MCP (Model Context Protocol) integrations. It provides 58 slash commands for end-to-end test automation across Jira, Confluence, TestLink, Playwright, and GitHub.
 
 ## Git Workflow
 
@@ -63,6 +63,7 @@ Commands are installed by copying markdown files to `~/.claude/commands/`. Skill
 ```
 commands/
 ├── confluence/    # Confluence page operations (6 commands, cf-*)
+├── github/        # GitHub tracking and traceability (4 commands, gh-*)
 ├── jira/          # Jira ticket tracing and conversion (6 commands, jr-*)
 ├── project/       # Project management commands (8 commands, pm-*)
 ├── testlink/      # TestLink CRUD and execution (18 commands, tl-*)
@@ -76,7 +77,8 @@ skills/
 ├── syncing-testlink/     # Import test cases into TestLink, build test plan
 ├── executing-tests/      # Execute TestLink plan via browser automation
 ├── creating-demo/        # Create PPTX demo with browser-verified screenshots
-└── analyzing-logs/       # Analyze Robot Framework logs, report failures
+├── analyzing-logs/       # Analyze Robot Framework logs, report failures
+└── tracking-changes/     # Track QA artifact changes in GitHub
 docs/
 ├── integrations/  # MCP server setup guides
 ├── workflows/     # End-to-end test lifecycle guide
@@ -116,6 +118,24 @@ Commands expect these MCP servers configured in the IDE:
    ```
 3. Run `make install` to deploy
 4. Commit only the source file in `commands/`
+
+## Skills
+
+Skills are loaded on demand. The agent reads this table to decide which skill to invoke.
+
+| Skill | Trigger Condition |
+|-------|-------------------|
+| `receiving-tickets` | When given a Jira ticket ID to investigate or start a new QA project |
+| `planning-tests` | When requirements are gathered and a test plan is needed |
+| `designing-cases` | When a test plan exists and detailed test cases need to be written |
+| `drafting-review-email` | When test artifacts are ready for stakeholder review |
+| `syncing-testlink` | When test cases need to be imported into TestLink |
+| `executing-tests` | When a TestLink test plan is ready for browser-based execution |
+| `creating-demo` | When a demo presentation needs to be created from test results |
+| `analyzing-logs` | When Robot Framework logs need failure analysis |
+| `tracking-changes` | When QA artifacts are created, modified, or reviewed — track in GitHub |
+
+Skills are thin routers — each SKILL.md contains the step sequence and progress checklist, delegating to commands for implementation details. Do not load all skills at once; load only when the trigger condition matches.
 
 ## Key Workflows
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ help:
 	@echo "  make uninstall-workflow - Remove workflow section from CLAUDE.md"
 	@echo "  make help             - Show this help message"
 	@echo ""
-	@echo "Skills (8 total) installed to:"
+	@echo "Skills (9 total) installed to:"
 	@echo "  ~/.claude/skills/<name>/SKILL.md"
 	@echo ""
 	@echo "Variables (GNU standard):"

--- a/commands/github/gh-close.md
+++ b/commands/github/gh-close.md
@@ -1,0 +1,124 @@
+# Close GitHub Tracking Issue
+
+```
+Close a GitHub tracking issue with a summary of completed work.
+
+Issue Number: {{input}}
+
+## PURPOSE
+
+Closes a QA tracking issue after all tasks are complete. Adds a summary
+comment documenting what was done, linking to the PR if applicable.
+
+---
+
+## WORKFLOW
+
+```
+/gh-close 12
+    │
+    ├─► Step 1: Verify Completion
+    │   - Fetch issue body: gh issue view <number> --json body,title,labels
+    │   - Parse task list: count checked vs unchecked
+    │   - If unchecked tasks remain:
+    │     • Warn: "Issue #12 has 2 unchecked tasks. Close anyway? (y/n)"
+    │     • If user says no, stop
+    │     • If user says yes, proceed (partial completion)
+    │
+    ├─► Step 2: Generate Summary Comment
+    │   - List completed tasks
+    │   - List skipped/deferred tasks (if any)
+    │   - Reference PR number if current branch has a PR
+    │   - Note artifacts created or modified
+    │
+    ├─► Step 3: Close Issue
+    │   - Add summary comment: gh issue comment <number> --body "<summary>"
+    │   - Close: gh issue close <number>
+    │   - If a PR exists that addresses this issue, prefer closing via
+    │     "Fixes #N" in the PR description instead
+    │
+    └─► Step 4: Report
+        - Print closed issue number and URL
+        - Print summary of completed work
+        - Suggest next action (next open issue from /gh-status)
+```
+
+---
+
+## SUMMARY COMMENT TEMPLATE
+
+```markdown
+## Completed
+
+- [x] Task 1 description
+- [x] Task 2 description
+- [x] Task 3 description
+
+## Deferred
+<!-- Only if there are unchecked tasks -->
+- [ ] Task 4 — deferred: waiting on PM confirmation
+
+## Artifacts Modified
+- `test_plan/sections/04_Test_Strategy.md`
+- `test_cases/TS-02_Session_Validation.md`
+- `test_cases/TS-04_Timeout_Edge_Case.md` (new)
+
+## PR
+Closes via PR #14
+```
+
+---
+
+## EXAMPLES
+
+### Example 1: All tasks complete
+
+```bash
+/gh-close 12
+```
+
+**Output:**
+```
+Issue #12 closed: "Review feedback: rewrite TS-02, add TS-04"
+All 4/4 tasks completed.
+Artifacts: TS-02 updated, TS-04 created, TS-01 precondition fixed, TS-03 scope clarified.
+Next open issue: #15 "Sync to TestLink" (4 tasks)
+```
+
+### Example 2: Partial completion
+
+```bash
+/gh-close 12
+```
+
+**Output:**
+```
+⚠ Issue #12 has 1 unchecked task:
+  - [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
+
+Close anyway? (y/n)
+
+> y
+
+Issue #12 closed with 3/4 tasks completed.
+Deferred: TS-03 scope clarification (waiting on PM).
+```
+
+### Example 3: Close via PR
+
+If you have a branch with changes for this issue, include "Fixes #12" in the PR description. The issue will auto-close when the PR merges.
+
+```bash
+gh pr create --title "[QA] Address review feedback for PROJ-12345" \
+  --body "Fixes #12" --milestone "PROJ-12345 — User Session Management"
+```
+
+---
+
+## API Notes
+
+- Uses `gh` CLI (GitHub CLI)
+- Prefer closing via PR "Fixes #N" for automatic traceability
+- Summary comment provides a final record of what was done
+- Deferred tasks should be tracked in a new issue if follow-up is needed
+```

--- a/commands/github/gh-init.md
+++ b/commands/github/gh-init.md
@@ -1,0 +1,77 @@
+# Initialize GitHub Tracking for a QA Project
+
+```
+Set up GitHub milestone and labels to track QA artifact changes for a Jira ticket.
+
+Jira Ticket: {{input}}
+
+## PURPOSE
+
+Creates a GitHub milestone and ensures standard labels exist so all QA work
+(test plans, test cases, reviews, syncs) is tracked with full change history.
+
+---
+
+## WORKFLOW
+
+```
+/gh-init PROJ-12345
+    │
+    ├─► Step 1: Verify GitHub Access
+    │   - Run: gh auth status
+    │   - Run: gh repo view --json name,owner
+    │   - Confirm we are in a GitHub-backed repository
+    │
+    ├─► Step 2: Create Labels (idempotent)
+    │   - Create labels if they do not already exist:
+    │     • qa:plan       (color: #1d76db) — Test plan changes
+    │     • qa:case       (color: #0e8a16) — Test case changes
+    │     • qa:review     (color: #e4e669) — Review feedback
+    │     • qa:sync       (color: #d93f0b) — TestLink sync
+    │     • qa:execute    (color: #c5def5) — Test execution
+    │     • priority:high (color: #b60205) — High priority
+    │     • priority:med  (color: #fbca04) — Medium priority
+    │     • priority:low  (color: #0e8a16) — Low priority
+    │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+    │
+    ├─► Step 3: Create Milestone
+    │   - Title: "PROJ-12345 — [Short Description from Jira ticket]"
+    │   - Description: "QA tracking for Jira ticket PROJ-12345. Requirement source: [Jira URL]"
+    │   - Use: gh api repos/{owner}/{repo}/milestones --method POST
+    │   - If milestone with same title exists, skip creation and use existing
+    │
+    └─► Step 4: Report
+        - Print milestone number and URL
+        - Print label summary
+        - Print next step: "Run /gh-track to create tracking issues"
+```
+
+---
+
+## EXAMPLE
+
+```bash
+/gh-init PROJ-12345
+```
+
+**Output:**
+```
+GitHub tracking initialized for PROJ-12345
+
+Milestone: #3 "PROJ-12345 — User Session Management"
+URL: https://github.com/owner/repo/milestone/3
+
+Labels verified: qa:plan, qa:case, qa:review, qa:sync, qa:execute
+
+Next: Use /gh-track to create tracking issues under this milestone.
+```
+
+---
+
+## API Notes
+
+- Uses `gh` CLI (GitHub CLI) — must be authenticated
+- Labels use `--force` flag so existing labels are updated, not duplicated
+- Milestone creation checks for existing milestone with same title first
+- Jira URL format: https://your-domain.atlassian.net/browse/PROJ-12345
+```

--- a/commands/github/gh-status.md
+++ b/commands/github/gh-status.md
@@ -1,0 +1,109 @@
+# GitHub QA Tracking Status
+
+```
+Show open tracking issues and pending tasks for a QA project.
+
+Milestone or Ticket: {{input}}
+
+## PURPOSE
+
+Lists all GitHub issues under a milestone, showing what QA work is done and
+what remains. Gives the agent session-start context to resume work.
+
+---
+
+## WORKFLOW
+
+```
+/gh-status PROJ-12345
+    │
+    ├─► Step 1: Find Milestone
+    │   - Search milestones matching the ticket ID
+    │   - Use: gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title | contains("PROJ-12345"))'
+    │   - If not found: "No milestone found. Run /gh-init PROJ-12345 first."
+    │
+    ├─► Step 2: List Issues
+    │   - Fetch all issues (open + closed) under the milestone
+    │   - Use: gh issue list --milestone "<title>" --state all --json number,title,state,labels,body
+    │
+    ├─► Step 3: Parse Open Tasks
+    │   - For each open issue, count checked vs unchecked tasks in body
+    │   - Extract unchecked items (lines matching "- [ ]")
+    │
+    └─► Step 4: Report
+        - Print summary table
+        - Print open tasks list
+        - Suggest next action
+```
+
+---
+
+## OUTPUT FORMAT
+
+```
+## QA Tracking Status: PROJ-12345 — User Session Management
+
+### Summary
+| # | Title | Labels | Tasks | Status |
+|---|-------|--------|-------|--------|
+| #8 | Create test plan | qa:plan | 4/4 | ✅ Closed |
+| #10 | Design test cases | qa:case | 6/6 | ✅ Closed |
+| #12 | Review feedback: TS-02, TS-04 | qa:review | 2/4 | 🔴 Open |
+| #15 | Sync to TestLink | qa:sync | 0/4 | 🔴 Open |
+
+### Open Tasks
+
+**#12 — Review feedback: TS-02, TS-04** (2 remaining)
+- [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
+- [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
+
+**#15 — Sync to TestLink** (4 remaining)
+- [ ] Create/update test suites
+- [ ] Sync test cases (diff: skip/update/create)
+- [ ] Create test plan and assign cases
+- [ ] Verify count matches local
+
+### Suggested Next Action
+Pick up issue #12 — 2 tasks remaining from PM review feedback.
+```
+
+---
+
+## EXAMPLE
+
+```bash
+/gh-status PROJ-12345
+```
+
+---
+
+## USE CASES
+
+### Session Start
+Run at the beginning of a new session to see where you left off:
+```
+/gh-status PROJ-12345
+```
+The agent reads open tasks and resumes work without asking the user.
+
+### Progress Check
+Run mid-session to see how much work remains:
+```
+/gh-status PROJ-12345
+```
+
+### Milestone Completion
+When all issues are closed, the milestone can be closed:
+```
+gh api repos/{owner}/{repo}/milestones/{number} --method PATCH -f state=closed
+```
+
+---
+
+## API Notes
+
+- Uses `gh` CLI (GitHub CLI)
+- Parses task lists from issue bodies (GitHub-flavored markdown checkboxes)
+- Shows both open and closed issues for complete picture
+- Milestone search is case-insensitive substring match on ticket ID
+```

--- a/commands/github/gh-track.md
+++ b/commands/github/gh-track.md
@@ -1,0 +1,162 @@
+# Create GitHub Tracking Issue
+
+```
+Create a GitHub issue to track a QA artifact change with checklist and provenance.
+
+Task Description: {{input}}
+
+## PURPOSE
+
+Creates a GitHub issue under a milestone to track a specific QA activity
+(test plan creation, test case design, review feedback, TestLink sync).
+Each issue captures what changed, why, and what tasks remain.
+
+---
+
+## WORKFLOW
+
+```
+/gh-track "Create test plan for PROJ-12345"
+    │
+    ├─► Step 1: Determine Context
+    │   - Identify the milestone (from project folder name or user input)
+    │   - Detect activity type from context:
+    │     • Creating/updating test plan → label: qa:plan
+    │     • Creating/updating test cases → label: qa:case
+    │     • Review feedback or change request → label: qa:review
+    │     • Syncing to TestLink → label: qa:sync
+    │     • Executing tests → label: qa:execute
+    │   - Detect priority (default: priority:med)
+    │
+    ├─► Step 2: Build Issue Body
+    │   - Source: where this work comes from (Jira ticket, review, PR, conversation)
+    │   - Rationale: why this change is needed
+    │   - Checklist: break work into checkable tasks
+    │   - References: link to related issues, Jira tickets, Confluence pages
+    │   - Use markdown template below
+    │
+    ├─► Step 3: Create Issue
+    │   - Use: gh issue create --title "<title>" --body "<body>"
+    │           --milestone "<milestone>" --label "<labels>"
+    │   - Title format: "[QA] <action> for <ticket>"
+    │     Examples:
+    │     • "[QA] Create test plan for PROJ-12345"
+    │     • "[QA] Review feedback: rewrite TS-02, add TS-04"
+    │     • "[QA] Sync test cases to TestLink"
+    │
+    └─► Step 4: Report
+        - Print issue number and URL
+        - Print checklist summary (N tasks)
+```
+
+---
+
+## ISSUE BODY TEMPLATE
+
+```markdown
+## Source
+<!-- Where this work comes from -->
+- **Jira ticket**: PROJ-12345
+- **Trigger**: [e.g., "Initial test planning" / "PM review feedback" / "Code change in PR #42"]
+
+## Rationale
+<!-- Why this change is needed -->
+[Brief explanation of why this work matters]
+
+## Tasks
+<!-- Break into checkable items -->
+- [ ] Task 1 description
+- [ ] Task 2 description
+- [ ] Task 3 description
+
+## References
+<!-- Related issues, docs, links -->
+- Jira: [PROJ-12345](https://your-domain.atlassian.net/browse/PROJ-12345)
+- Related: #N (if applicable)
+
+## Artifacts
+<!-- Files created or modified -->
+- `test_plan/sections/04_Test_Strategy.md`
+- `test_cases/TS-02_Session_Validation.md`
+```
+
+---
+
+## EXAMPLES
+
+### Example 1: Track test plan creation
+
+```bash
+/gh-track "Create test plan for PROJ-12345"
+```
+
+**Issue created:**
+```
+#8: [QA] Create test plan for PROJ-12345
+Labels: qa:plan, priority:high
+Milestone: PROJ-12345 — User Session Management
+
+Tasks:
+- [ ] Detect ticket type (feature/bugfix/enhance)
+- [ ] Write test plan sections 01-06
+- [ ] Review coverage matrix
+- [ ] Publish to Confluence
+```
+
+### Example 2: Track review feedback
+
+```bash
+/gh-track "PM review: rewrite TS-02, add TS-04, clarify TS-03 scope"
+```
+
+**Issue created:**
+```
+#12: [QA] Review feedback: rewrite TS-02, add TS-04, clarify TS-03
+Labels: qa:review, priority:med
+Milestone: PROJ-12345 — User Session Management
+
+Tasks:
+- [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
+- [ ] Add TS-04 timeout edge case for session renewal
+- [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
+```
+
+### Example 3: Track TestLink sync
+
+```bash
+/gh-track "Sync updated test cases to TestLink"
+```
+
+**Issue created:**
+```
+#15: [QA] Sync test cases to TestLink for PROJ-12345
+Labels: qa:sync, priority:med
+Milestone: PROJ-12345 — User Session Management
+
+Tasks:
+- [ ] Create/update test suites
+- [ ] Sync test cases (diff: skip/update/create)
+- [ ] Create test plan and assign cases
+- [ ] Verify count matches local
+```
+
+---
+
+## UPDATING TASK STATUS
+
+When working through tasks, update the issue body checkboxes:
+- Use: gh issue edit <number> --body "<updated body>"
+- Or add a comment with progress: gh issue comment <number> --body "<update>"
+
+When all tasks are complete, close the issue with `/gh-close`.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI (GitHub CLI)
+- Milestone must exist first (run `/gh-init` if needed)
+- Labels must exist (created by `/gh-init`)
+- Issue title should be concise but descriptive
+- Body uses GitHub-flavored markdown with task lists
+```

--- a/docs/design/enhancement-study-2026-03-10.md
+++ b/docs/design/enhancement-study-2026-03-10.md
@@ -1,0 +1,106 @@
+# Enhancement Study: Issue-Driven AI Agent Workflow
+
+**Date**: 2026-03-10
+**Source**: LinkedIn post "How I Made an AI Code Agent Follow a Real Development Process"
+**Projects Studied**: ai-qa-workflow (this repo), ollama37 (target), everything-claude-code (reference)
+
+## Context
+
+This study analyzes how ai-qa-workflow can be enhanced based on patterns from ollama37 and everything-claude-code. The LinkedIn post advocates two key ideas: (1) break work into tracked issues before writing code, and (2) organize the agent's memory in layers.
+
+## Current State: ai-qa-workflow
+
+- 58 slash commands across 7 categories (confluence, github, jira, project, testlink, test-workflow, utility)
+- 9 agent skills as thin routers with progress checklists
+- 6-phase QA lifecycle: Discover → Plan → Design → Manage → Automate → Execute
+- External system integrations: Jira, Confluence, TestLink, Playwright, GitHub
+- Command-as-Documentation pattern
+- Detect-and-route orchestration (feature/bugfix/enhancement)
+
+## Patterns from ollama37
+
+- `/plan` and `/implement` skills for GitHub Issue-driven development
+- 7-step implementation workflow: Understand → Start → Implement → Failure Protocol → Success → Partial Fix → Post-Merge
+- GitHub Issues as persistent memory across sessions
+- Labels (type, priority, component) and cross-references (`Depends on #N`, `Fixes #N`)
+- 12 skills listed in CLAUDE.md with trigger conditions
+- 3-layer memory: CLAUDE.md (governance) → Skills (when/what) → Commands (how)
+- Failure protocol: comment on issue, apply `status:blocked` label
+- CI integration via `/ci` skill
+
+## Patterns from everything-claude-code
+
+- 47 slash commands, 80+ skills, 13-16 specialized subagents
+- `/plan` requires explicit user approval before proceeding
+- `/verify` with 6-step quality gates (Build → Types → Lint → Tests → Logs → Git Status)
+- `/tdd` enforcing RED-GREEN-REFACTOR cycle
+- Instinct system for cross-session learning with confidence scoring
+- Orchestration pattern chaining agents through handoff documents
+- All work stays agent-internal (optimizes for speed within agent)
+
+## Identified Enhancement Areas
+
+### Item 1: GitHub Change Tracking for QA Artifacts (IMPLEMENTED)
+
+**Reframed**: This is not about adding dev workflow. It's about **requirements provenance** — tracking why test plans and test cases change, where requests come from, and what work remains.
+
+The insight from ollama37: GitHub Issues survive between sessions. When the agent forgets, the issue history preserves what was attempted, what failed, and what was decided. This is a QA input, not a dev artifact.
+
+**What was built:**
+- `commands/github/gh-init.md` — Initialize milestone + labels for a Jira ticket
+- `commands/github/gh-track.md` — Create tracking issue with checklist and provenance
+- `commands/github/gh-status.md` — Show open work and pending tasks (session recovery)
+- `commands/github/gh-close.md` — Close issue with completion summary
+- `skills/tracking-changes/SKILL.md` — Orchestrates when to track alongside existing skills
+
+**How it fits the QA flow:**
+```
+Jira (PROJ-12345)          ← WHY we're testing (requirement source)
+  │
+GitHub Milestone           ← Tracks all QA work for this ticket
+  ├── Issue: test plan     ← What was created, checklist of sections
+  ├── Issue: test cases    ← What was designed, scenario list
+  ├── Issue: review        ← Feedback tasks with provenance
+  ├── Issue: sync          ← TestLink sync record
+  └── PRs with diffs       ← Exactly what changed in each file
+  │
+Test Artifacts             ← test_plan/, test_cases/ files with revision history
+```
+
+### Item 2: CLAUDE.md Skill Trigger Table (IMPLEMENTED)
+
+Added a `## Skills` section to CLAUDE.md with a trigger table listing all 9 skills and their trigger conditions. The agent reads this table at session start to decide which skill to invoke.
+
+No rewrite was needed — only a new section added.
+
+### Item 3: Failure Protocol in Skills (PENDING — needs further discussion)
+
+Add structured failure handling to skills: comment on tracking issue, apply labels, document partial progress.
+
+**Note**: With GitHub tracking now in place, this becomes more feasible. The `/gh-track` command already supports documenting blocked tasks. The question is whether to formalize a failure protocol into each skill's checklist (e.g., "if step 3 fails, run `/gh-track` with failure details").
+
+### Item 4: CI/CD Integration (PENDING — needs further discussion)
+
+Add commands for triggering and monitoring CI pipelines.
+
+**Note**: CI is typically a dev concern. For QA, the relevant integration might be triggering test suites and collecting results rather than build pipelines. Need to scope this to QA-specific CI needs (e.g., automated test execution reporting).
+
+### Item 5: Revision History Enhancement (PENDING — needs further discussion)
+
+Enhance `06_Revision_History.md` in test plans and change logs in test cases with:
+- **Source** column (where the change came from)
+- **Rationale** section (why, not just what)
+- **Task checklist** per revision (what's done, what's open)
+- **Details section** below the summary table for full context
+
+This pairs with GitHub tracking: the revision history references GitHub issue numbers, while the issues contain the full discussion and diffs.
+
+## Summary
+
+| Item | Enhancement | Status | Fit with QA Focus |
+|------|------------|--------|-------------------|
+| 1 | GitHub Change Tracking | IMPLEMENTED | High — requirements provenance |
+| 2 | CLAUDE.md Skill Trigger Table | IMPLEMENTED | High — project infrastructure |
+| 3 | Failure Protocol | PENDING | Medium — needs QA scoping |
+| 4 | CI/CD Integration | PENDING | Medium — needs QA scoping |
+| 5 | Revision History Enhancement | PENDING | High — pairs with GitHub tracking |

--- a/skills/tracking-changes/SKILL.md
+++ b/skills/tracking-changes/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: tracking-changes
+description: |
+  Tracks QA artifact changes in GitHub using milestones, issues, and PRs.
+  Use when starting a new QA project (to initialize tracking), when creating
+  or modifying test plans or test cases, when receiving review feedback,
+  when syncing to TestLink, or when resuming work in a new session.
+disable-model-invocation: true
+---
+
+# tracking-changes
+
+Tracks QA artifact changes in GitHub with full provenance: what changed, why, and what's still open.
+
+## Progress Checklist
+
+Copy and track your progress:
+
+```
+- [ ] Step 1: Initialize tracking (first time only)
+- [ ] Step 2: Create tracking issue for current work
+- [ ] Step 3: Work through tasks, update checkboxes
+- [ ] Step 4: Close issue when tasks are complete
+```
+
+## When to Track
+
+The agent should create or update tracking issues at these points:
+
+| After This Skill/Command | Action |
+|--------------------------|--------|
+| `/receiving-tickets` | Run `/gh-init` to create milestone, then `/gh-track` to log project setup |
+| `/planning-tests` | Run `/gh-track` to log test plan creation |
+| `/designing-cases` | Run `/gh-track` to log test case design |
+| Review feedback from user | Run `/gh-track` to capture feedback as checklist |
+| `/syncing-testlink` | Run `/gh-track` to log TestLink sync |
+| `/executing-tests` | Run `/gh-track` to log test execution |
+| Test plan or test case edits | Run `/gh-track` to log what changed and why |
+| Session start (resuming work) | Run `/gh-status` to see open tasks |
+
+## Steps
+
+### Step 1: Initialize Tracking (First Time Only)
+
+Run `/gh-init` with the Jira ticket ID to create a GitHub milestone and ensure labels exist.
+
+Skip if milestone already exists for this ticket.
+
+### Step 2: Create Tracking Issue
+
+Run `/gh-track` to create a GitHub issue under the milestone. The agent should:
+
+1. **Detect the activity type** from context (plan, case, review, sync, execute)
+2. **Write the source** — where this work comes from (Jira ticket, review, PR, conversation)
+3. **Write the rationale** — why this change is needed
+4. **Break into tasks** — checkable items for each piece of work
+5. **List references** — related issues, Jira tickets, Confluence pages
+
+### Step 3: Work Through Tasks
+
+As the agent completes each task:
+
+1. Update the issue body to check off completed items
+2. Add comments for significant findings or decisions
+3. If blocked, comment with details and move to next task
+
+### Step 4: Close Issue
+
+Run `/gh-close` when all tasks are complete (or when closing with deferred items).
+
+If changes were committed, prefer closing via PR with "Fixes #N" in the description.
+
+## Session Recovery
+
+At the start of a new session, if the user is resuming work on an existing project:
+
+1. Run `/gh-status` to see open issues and pending tasks
+2. Pick up the first open issue or ask the user which to continue
+3. Resume work from the unchecked tasks
+
+## Expected Input
+
+Jira ticket ID (for `/gh-init`) or task description (for `/gh-track`).
+
+## Integration with Existing Skills
+
+This skill does NOT replace any existing skill. It runs alongside them:
+
+```
+/receiving-tickets → creates project folder    (existing)
+                   → /gh-init + /gh-track      (tracking layer)
+
+/planning-tests    → creates test plan         (existing)
+                   → /gh-track                 (tracking layer)
+
+/designing-cases   → creates test cases        (existing)
+                   → /gh-track                 (tracking layer)
+
+Review feedback    → edits test plan/cases     (existing)
+                   → /gh-track                 (tracking layer)
+
+/syncing-testlink  → syncs to TestLink         (existing)
+                   → /gh-track                 (tracking layer)
+```

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -2,96 +2,63 @@
 
 This section provides AI coding agents with QA workflow guidance powered by MCP integrations.
 
-### Quick Start
+### Skills
 
-Use these slash commands for end-to-end test automation:
+Skills are loaded on demand. Use the matching skill when the trigger condition applies.
 
-| Phase | Command | Purpose |
-|-------|---------|---------|
-| Discover | `/jira-trace TICKET-ID` | Gather requirements from Jira/Confluence |
-| Plan | `/test-planning-checklist` | Create TEST_PLAN.md |
-| Design | `/test-case-design-checklist` | Create TEST_CASES.md |
-| Manage | `/create-test-case` | Import to TestLink |
-| Execute | `/create-test-execution` | Record test results |
+| Skill | Trigger Condition |
+|-------|-------------------|
+| `receiving-tickets` | When given a Jira ticket ID to investigate or start a new QA project |
+| `planning-tests` | When requirements are gathered and a test plan is needed |
+| `designing-cases` | When a test plan exists and detailed test cases need to be written |
+| `drafting-review-email` | When test artifacts are ready for stakeholder review |
+| `syncing-testlink` | When test cases need to be imported into TestLink |
+| `executing-tests` | When a TestLink test plan is ready for browser-based execution |
+| `creating-demo` | When a demo presentation needs to be created from test results |
+| `analyzing-logs` | When Robot Framework logs need failure analysis |
+| `tracking-changes` | When QA artifacts are created, modified, or reviewed — track in GitHub |
+
+### Test Lifecycle
+
+| Phase | Skill | Key Commands |
+|-------|-------|--------------|
+| Discover | `receiving-tickets` | `/jr-trace` |
+| Plan | `planning-tests` | `/tw-plan-init` → `/tw-plan-feature\|enhance\|bugfix` |
+| Design | `designing-cases` | `/tw-case-init` → `/tw-case-feature\|enhance\|bugfix` |
+| Manage | `syncing-testlink` | `/tl-create-suite`, `/tl-create-case`, `/tl-create-plan` |
+| Execute | `executing-tests` | `/tl-execute-case`, `/tl-create-execution` |
+| Track | `tracking-changes` | `/gh-init`, `/gh-track`, `/gh-status`, `/gh-close` |
+
+### Change Tracking
+
+Track QA artifact changes in GitHub for provenance and session recovery:
+
+```
+/gh-init PROJ-12345        # Create milestone + labels (once per ticket)
+/gh-track "description"    # Create tracking issue with checklist
+/gh-status PROJ-12345      # Show open work (use at session start)
+/gh-close 12               # Close completed issue
+```
 
 ### MCP Dependencies
 
 These MCP servers must be configured:
-- **mcp-atlassian** - Jira/Confluence access
-- **testlink-mcp** - TestLink API access
-- **playwright-mcp** - Browser automation (optional)
-
-### Test Lifecycle Workflow
-
-**Phase 1: Discover Requirements**
-```
-/jira-trace PROJ-123
-```
-Creates folder with requirements, related tickets, and Confluence docs.
-
-**Phase 2: Create Test Plan**
-```
-/test-planning-checklist
-```
-Generates TEST_PLAN.md with test strategy, scope, and entry/exit criteria.
-
-**Phase 3: Design Test Cases**
-```
-/test-case-design-checklist
-```
-Transforms TEST_PLAN.md into detailed TEST_CASES.md with unique IDs.
-
-**Phase 4: Manage in TestLink**
-```
-/list-projects          # Find project ID
-/list-test-suites       # Find or create suite
-/create-test-case       # Import each test case
-/create-test-plan       # Create test plan
-/add-test-case-to-test-plan  # Assign cases to plan
-```
-
-**Phase 5: Automate Tests**
-Create YAML test files using [test-framework-template](https://github.com/dogkeeper886/test-framework-template):
-```yaml
-id: TC-AUTH-001
-name: User Login Test
-suite: integration
-steps:
-  - name: Login request
-    command: curl -X POST /api/login
-criteria: |
-  Verify login returns 200 and valid token
-```
-
-**Phase 6: Execute and Report**
-```bash
-npm test                    # Run tests
-/create-test-execution      # Record results in TestLink
-```
+- **mcp-atlassian** — Jira/Confluence access
+- **testlink-mcp** — TestLink API access
+- **playwright-mcp** — Browser automation (optional)
 
 ### Available Commands
 
-**Jira/Confluence:**
-- `/jira-trace` - Trace ticket with related items
-- `/jira-to-confluence` - Convert ticket to Confluence page
-- `/jira-to-testlink` - Convert ticket to TestLink case
+**GitHub (gh-*):** `/gh-init`, `/gh-track`, `/gh-status`, `/gh-close`
 
-**Test Planning:**
-- `/test-planning-checklist` - Create test plan
-- `/test-case-design-checklist` - Design test cases
-- `/identify-test-type` - Categorize test type
+**Jira (jr-*):** `/jr-trace`, `/jr-trace-fetch`, `/jr-trace-structure`, `/jr-trace-docs`, `/jr-trace-verify`, `/jr-issue-summary`
 
-**TestLink:**
-- `/list-projects`, `/list-test-suites`, `/list-test-cases`
-- `/create-test-suite`, `/create-test-case`, `/create-test-plan`
-- `/get-test-case`, `/update-test-case`, `/delete-test-case`
-- `/add-test-case-to-test-plan`, `/create-build`
-- `/create-test-execution`, `/read-test-execution`
+**Confluence (cf-*):** `/cf-create-page`, `/cf-update-page`, `/cf-review-page`, `/cf-page-summary`, `/cf-to-markdown`, `/cf-format-guide`
 
-**Confluence:**
-- `/create-confluence-page`, `/read-confluence-page`
-- `/update-confluence-page`, `/delete-confluence-page`
+**Test Workflow (tw-*):** `/tw-plan-init`, `/tw-plan-feature`, `/tw-plan-enhance`, `/tw-plan-bugfix`, `/tw-plan-review`, `/tw-diagrams`, `/tw-case-init`, `/tw-case-feature`, `/tw-case-enhance`, `/tw-case-bugfix`, `/tw-case-review`, `/tw-templates`, `/tw-script-review`
 
-**Utilities:**
-- `/rewrite-text` - Improve text clarity
-- `/analyze-log` - Analyze log files
+**TestLink (tl-*):** `/tl-list-projects`, `/tl-create-suite`, `/tl-list-suites`, `/tl-update-suite`, `/tl-create-case`, `/tl-get-case`, `/tl-list-cases`, `/tl-update-case`, `/tl-identify-type`, `/tl-create-plan`, `/tl-get-cases-for-plan`, `/tl-add-case-to-plan`, `/tl-execute-case`, `/tl-read-execution`, `/tl-create-execution`, `/tl-format`, `/tl-sync`, `/tl-list-requirements`
+
+**Project (pm-*):** `/pm-init`, `/pm-demo-content`, `/pm-demo-review`, `/pm-demo-ppt`, `/pm-demo-email`, `/pm-meeting-invite`, `/pm-bug-report`, `/pm-scrum-task`
+
+**Utility:** `/rewrite-text`, `/robot-log-analyzer`

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -51,7 +51,7 @@ These MCP servers must be configured:
 
 **GitHub (gh-*):** `/gh-init`, `/gh-track`, `/gh-status`, `/gh-close`
 
-**Jira (jr-*):** `/jr-trace`, `/jr-trace-fetch`, `/jr-trace-structure`, `/jr-trace-docs`, `/jr-trace-verify`, `/jr-issue-summary`
+**Jira (jr-*):** `/jr-trace`, `/jr-trace-fetch`, `/jr-trace-structure`, `/jr-trace-docs`, `/jr-trace-verify`, `/jr-issue-summary`, `/jr-to-markdown`
 
 **Confluence (cf-*):** `/cf-create-page`, `/cf-update-page`, `/cf-review-page`, `/cf-page-summary`, `/cf-to-markdown`, `/cf-format-guide`
 


### PR DESCRIPTION
## Summary
- Add 4 GitHub commands (`gh-init`, `gh-track`, `gh-status`, `gh-close`) and `tracking-changes` skill to track QA artifact changes with full provenance — what changed, why, and what's still open
- Add skill trigger table to CLAUDE.md so the agent knows when to load each skill without reading the skills/ directory
- Rewrite `templates/CLAUDE.md` with current command names, skill triggers, and change tracking quick-start (old template had stale command names)
- Fix pre-existing jira command count (6 → 7) and add missing `/jr-to-markdown` to template

## Design Decisions
- GitHub tracks QA artifact changes (provenance), Jira remains the requirement source — no overlap
- Uses `gh` CLI (not MCP) for GitHub operations — no new MCP dependency
- `tracking-changes` skill runs alongside existing skills, never replaces them
- Enhancement study doc at `docs/design/enhancement-study-2026-03-10.md` captures the analysis of ollama37 and everything-claude-code patterns

## Test plan
- [ ] Run `make install` and verify new commands appear in `~/.claude/commands/`
- [ ] Run `make install-skills` and verify `tracking-changes` skill appears in `~/.claude/skills/`
- [ ] Run `make install-workflow` on a test project and verify the template appends correctly
- [ ] Verify `/gh-init PROJ-12345` creates milestone and labels via `gh` CLI
- [ ] Verify `/gh-track` creates issue with checklist under milestone
- [ ] Verify `/gh-status` shows open issues and pending tasks
- [ ] Verify `/gh-close` closes issue with summary comment
- [ ] Run info leak check: `grep -ri "ACX-\|GPDL\|Guest Pass\|RuckusOne" commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)