### PR TITLE
fix: nested markdown fences in GitHub command files

### DIFF
--- a/commands/github/gh-close.md
+++ b/commands/github/gh-close.md
@@ -14,58 +14,54 @@ comment documenting what was done, linking to the PR if applicable.
 
 ## WORKFLOW
 
-```
-/gh-close 12
-    │
-    ├─► Step 1: Verify Completion
-    │   - Fetch issue body: gh issue view <number> --json body,title,labels
-    │   - Parse task list: count checked vs unchecked
-    │   - If unchecked tasks remain:
-    │     • Warn: "Issue #12 has 2 unchecked tasks. Close anyway? (y/n)"
-    │     • If user says no, stop
-    │     • If user says yes, proceed (partial completion)
-    │
-    ├─► Step 2: Generate Summary Comment
-    │   - List completed tasks
-    │   - List skipped/deferred tasks (if any)
-    │   - Reference PR number if current branch has a PR
-    │   - Note artifacts created or modified
-    │
-    ├─► Step 3: Close Issue
-    │   - Add summary comment: gh issue comment <number> --body "<summary>"
-    │   - Close: gh issue close <number>
-    │   - If a PR exists that addresses this issue, prefer closing via
-    │     "Fixes #N" in the PR description instead
-    │
-    └─► Step 4: Report
-        - Print closed issue number and URL
-        - Print summary of completed work
-        - Suggest next action (next open issue from /gh-status)
-```
+    /gh-close 12
+        │
+        ├─► Step 1: Verify Completion
+        │   - Fetch issue body: gh issue view <number> --json body,title,labels
+        │   - Parse task list: count checked vs unchecked
+        │   - If unchecked tasks remain:
+        │     • Warn: "Issue #12 has 2 unchecked tasks. Close anyway? (y/n)"
+        │     • If user says no, stop
+        │     • If user says yes, proceed (partial completion)
+        │
+        ├─► Step 2: Generate Summary Comment
+        │   - List completed tasks
+        │   - List skipped/deferred tasks (if any)
+        │   - Reference PR number if current branch has a PR
+        │   - Note artifacts created or modified
+        │
+        ├─► Step 3: Close Issue
+        │   - Add summary comment: gh issue comment <number> --body "<summary>"
+        │   - Close: gh issue close <number>
+        │   - If a PR exists that addresses this issue, prefer closing via
+        │     "Fixes #N" in the PR description instead
+        │
+        └─► Step 4: Report
+            - Print closed issue number and URL
+            - Print summary of completed work
+            - Suggest next action (next open issue from /gh-status)
 
 ---
 
 ## SUMMARY COMMENT TEMPLATE
 
-```markdown
-## Completed
+    ## Completed
 
-- [x] Task 1 description
-- [x] Task 2 description
-- [x] Task 3 description
+    - [x] Task 1 description
+    - [x] Task 2 description
+    - [x] Task 3 description
 
-## Deferred
-<!-- Only if there are unchecked tasks -->
-- [ ] Task 4 — deferred: waiting on PM confirmation
+    ## Deferred
+    <!-- Only if there are unchecked tasks -->
+    - [ ] Task 4 — deferred: waiting on PM confirmation
 
-## Artifacts Modified
-- `test_plan/sections/04_Test_Strategy.md`
-- `test_cases/TS-02_Session_Validation.md`
-- `test_cases/TS-04_Timeout_Edge_Case.md` (new)
+    ## Artifacts Modified
+    - `test_plan/sections/04_Test_Strategy.md`
+    - `test_cases/TS-02_Session_Validation.md`
+    - `test_cases/TS-04_Timeout_Edge_Case.md` (new)
 
-## PR
-Closes via PR #14
-```
+    ## PR
+    Closes via PR #14
 
 ---
 
@@ -73,45 +69,37 @@ Closes via PR #14
 
 ### Example 1: All tasks complete
 
-```bash
-/gh-close 12
-```
+    /gh-close 12
 
 **Output:**
-```
-Issue #12 closed: "Review feedback: rewrite TS-02, add TS-04"
-All 4/4 tasks completed.
-Artifacts: TS-02 updated, TS-04 created, TS-01 precondition fixed, TS-03 scope clarified.
-Next open issue: #15 "Sync to TestLink" (4 tasks)
-```
+
+    Issue #12 closed: "Review feedback: rewrite TS-02, add TS-04"
+    All 4/4 tasks completed.
+    Artifacts: TS-02 updated, TS-04 created, TS-01 precondition fixed, TS-03 scope clarified.
+    Next open issue: #15 "Sync to TestLink" (4 tasks)
 
 ### Example 2: Partial completion
 
-```bash
-/gh-close 12
-```
+    /gh-close 12
 
 **Output:**
-```
-⚠ Issue #12 has 1 unchecked task:
-  - [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
 
-Close anyway? (y/n)
+    ⚠ Issue #12 has 1 unchecked task:
+      - [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
 
-> y
+    Close anyway? (y/n)
 
-Issue #12 closed with 3/4 tasks completed.
-Deferred: TS-03 scope clarification (waiting on PM).
-```
+    > y
+
+    Issue #12 closed with 3/4 tasks completed.
+    Deferred: TS-03 scope clarification (waiting on PM).
 
 ### Example 3: Close via PR
 
 If you have a branch with changes for this issue, include "Fixes #12" in the PR description. The issue will auto-close when the PR merges.
 
-```bash
-gh pr create --title "[QA] Address review feedback for PROJ-12345" \
-  --body "Fixes #12" --milestone "PROJ-12345 — User Session Management"
-```
+    gh pr create --title "[QA] Address review feedback for PROJ-12345" \
+      --body "Fixes #12" --milestone "PROJ-12345 — User Session Management"
 
 ---
 

--- a/commands/github/gh-init.md
+++ b/commands/github/gh-init.md
@@ -14,57 +14,52 @@ Creates a GitHub milestone and ensures standard labels exist so all QA work
 
 ## WORKFLOW
 
-```
-/gh-init PROJ-12345
-    │
-    ├─► Step 1: Verify GitHub Access
-    │   - Run: gh auth status
-    │   - Run: gh repo view --json name,owner
-    │   - Confirm we are in a GitHub-backed repository
-    │
-    ├─► Step 2: Create Labels (idempotent)
-    │   - Create labels if they do not already exist:
-    │     • qa:plan       (color: #1d76db) — Test plan changes
-    │     • qa:case       (color: #0e8a16) — Test case changes
-    │     • qa:review     (color: #e4e669) — Review feedback
-    │     • qa:sync       (color: #d93f0b) — TestLink sync
-    │     • qa:execute    (color: #c5def5) — Test execution
-    │     • priority:high (color: #b60205) — High priority
-    │     • priority:med  (color: #fbca04) — Medium priority
-    │     • priority:low  (color: #0e8a16) — Low priority
-    │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
-    │
-    ├─► Step 3: Create Milestone
-    │   - Title: "PROJ-12345 — [Short Description from Jira ticket]"
-    │   - Description: "QA tracking for Jira ticket PROJ-12345. Requirement source: [Jira URL]"
-    │   - Use: gh api repos/{owner}/{repo}/milestones --method POST
-    │   - If milestone with same title exists, skip creation and use existing
-    │
-    └─► Step 4: Report
-        - Print milestone number and URL
-        - Print label summary
-        - Print next step: "Run /gh-track to create tracking issues"
-```
+    /gh-init PROJ-12345
+        │
+        ├─► Step 1: Verify GitHub Access
+        │   - Run: gh auth status
+        │   - Run: gh repo view --json name,owner
+        │   - Confirm we are in a GitHub-backed repository
+        │
+        ├─► Step 2: Create Labels (idempotent)
+        │   - Create labels if they do not already exist:
+        │     • qa:plan       (color: #1d76db) — Test plan changes
+        │     • qa:case       (color: #0e8a16) — Test case changes
+        │     • qa:review     (color: #e4e669) — Review feedback
+        │     • qa:sync       (color: #d93f0b) — TestLink sync
+        │     • qa:execute    (color: #c5def5) — Test execution
+        │     • priority:high (color: #b60205) — High priority
+        │     • priority:med  (color: #fbca04) — Medium priority
+        │     • priority:low  (color: #0e8a16) — Low priority
+        │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+        │
+        ├─► Step 3: Create Milestone
+        │   - Title: "PROJ-12345 — [Short Description from Jira ticket]"
+        │   - Description: "QA tracking for Jira ticket PROJ-12345. Requirement source: [Jira URL]"
+        │   - Use: gh api repos/{owner}/{repo}/milestones --method POST
+        │   - If milestone with same title exists, skip creation and use existing
+        │
+        └─► Step 4: Report
+            - Print milestone number and URL
+            - Print label summary
+            - Print next step: "Run /gh-track to create tracking issues"
 
 ---
 
 ## EXAMPLE
 
-```bash
-/gh-init PROJ-12345
-```
+    /gh-init PROJ-12345
 
 **Output:**
-```
-GitHub tracking initialized for PROJ-12345
 
-Milestone: #3 "PROJ-12345 — User Session Management"
-URL: https://github.com/owner/repo/milestone/3
+    GitHub tracking initialized for PROJ-12345
 
-Labels verified: qa:plan, qa:case, qa:review, qa:sync, qa:execute
+    Milestone: #3 "PROJ-12345 — User Session Management"
+    URL: https://github.com/owner/repo/milestone/3
 
-Next: Use /gh-track to create tracking issues under this milestone.
-```
+    Labels verified: qa:plan, qa:case, qa:review, qa:sync, qa:execute
+
+    Next: Use /gh-track to create tracking issues under this milestone.
 
 ---
 

--- a/commands/github/gh-status.md
+++ b/commands/github/gh-status.md
@@ -14,66 +14,60 @@ what remains. Gives the agent session-start context to resume work.
 
 ## WORKFLOW
 
-```
-/gh-status PROJ-12345
-    │
-    ├─► Step 1: Find Milestone
-    │   - Search milestones matching the ticket ID
-    │   - Use: gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title | contains("PROJ-12345"))'
-    │   - If not found: "No milestone found. Run /gh-init PROJ-12345 first."
-    │
-    ├─► Step 2: List Issues
-    │   - Fetch all issues (open + closed) under the milestone
-    │   - Use: gh issue list --milestone "<title>" --state all --json number,title,state,labels,body
-    │
-    ├─► Step 3: Parse Open Tasks
-    │   - For each open issue, count checked vs unchecked tasks in body
-    │   - Extract unchecked items (lines matching "- [ ]")
-    │
-    └─► Step 4: Report
-        - Print summary table
-        - Print open tasks list
-        - Suggest next action
-```
+    /gh-status PROJ-12345
+        │
+        ├─► Step 1: Find Milestone
+        │   - Search milestones matching the ticket ID
+        │   - Use: gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title | contains("PROJ-12345"))'
+        │   - If not found: "No milestone found. Run /gh-init PROJ-12345 first."
+        │
+        ├─► Step 2: List Issues
+        │   - Fetch all issues (open + closed) under the milestone
+        │   - Use: gh issue list --milestone "<title>" --state all --json number,title,state,labels,body
+        │
+        ├─► Step 3: Parse Open Tasks
+        │   - For each open issue, count checked vs unchecked tasks in body
+        │   - Extract unchecked items (lines matching "- [ ]")
+        │
+        └─► Step 4: Report
+            - Print summary table
+            - Print open tasks list
+            - Suggest next action
 
 ---
 
 ## OUTPUT FORMAT
 
-```
-## QA Tracking Status: PROJ-12345 — User Session Management
+    ## QA Tracking Status: PROJ-12345 — User Session Management
 
-### Summary
-| # | Title | Labels | Tasks | Status |
-|---|-------|--------|-------|--------|
-| #8 | Create test plan | qa:plan | 4/4 | ✅ Closed |
-| #10 | Design test cases | qa:case | 6/6 | ✅ Closed |
-| #12 | Review feedback: TS-02, TS-04 | qa:review | 2/4 | 🔴 Open |
-| #15 | Sync to TestLink | qa:sync | 0/4 | 🔴 Open |
+    ### Summary
+    | # | Title | Labels | Tasks | Status |
+    |---|-------|--------|-------|--------|
+    | #8 | Create test plan | qa:plan | 4/4 | ✅ Closed |
+    | #10 | Design test cases | qa:case | 6/6 | ✅ Closed |
+    | #12 | Review feedback: TS-02, TS-04 | qa:review | 2/4 | 🔴 Open |
+    | #15 | Sync to TestLink | qa:sync | 0/4 | 🔴 Open |
 
-### Open Tasks
+    ### Open Tasks
 
-**#12 — Review feedback: TS-02, TS-04** (2 remaining)
-- [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
-- [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
+    **#12 — Review feedback: TS-02, TS-04** (2 remaining)
+    - [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
+    - [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
 
-**#15 — Sync to TestLink** (4 remaining)
-- [ ] Create/update test suites
-- [ ] Sync test cases (diff: skip/update/create)
-- [ ] Create test plan and assign cases
-- [ ] Verify count matches local
+    **#15 — Sync to TestLink** (4 remaining)
+    - [ ] Create/update test suites
+    - [ ] Sync test cases (diff: skip/update/create)
+    - [ ] Create test plan and assign cases
+    - [ ] Verify count matches local
 
-### Suggested Next Action
-Pick up issue #12 — 2 tasks remaining from PM review feedback.
-```
+    ### Suggested Next Action
+    Pick up issue #12 — 2 tasks remaining from PM review feedback.
 
 ---
 
 ## EXAMPLE
 
-```bash
-/gh-status PROJ-12345
-```
+    /gh-status PROJ-12345
 
 ---
 
@@ -81,22 +75,20 @@ Pick up issue #12 — 2 tasks remaining from PM review feedback.
 
 ### Session Start
 Run at the beginning of a new session to see where you left off:
-```
-/gh-status PROJ-12345
-```
+
+    /gh-status PROJ-12345
+
 The agent reads open tasks and resumes work without asking the user.
 
 ### Progress Check
 Run mid-session to see how much work remains:
-```
-/gh-status PROJ-12345
-```
+
+    /gh-status PROJ-12345
 
 ### Milestone Completion
 When all issues are closed, the milestone can be closed:
-```
-gh api repos/{owner}/{repo}/milestones/{number} --method PATCH -f state=closed
-```
+
+    gh api repos/{owner}/{repo}/milestones/{number} --method PATCH -f state=closed
 
 ---
 

--- a/commands/github/gh-track.md
+++ b/commands/github/gh-track.md
@@ -15,70 +15,66 @@ Each issue captures what changed, why, and what tasks remain.
 
 ## WORKFLOW
 
-```
-/gh-track "Create test plan for PROJ-12345"
-    │
-    ├─► Step 1: Determine Context
-    │   - Identify the milestone (from project folder name or user input)
-    │   - Detect activity type from context:
-    │     • Creating/updating test plan → label: qa:plan
-    │     • Creating/updating test cases → label: qa:case
-    │     • Review feedback or change request → label: qa:review
-    │     • Syncing to TestLink → label: qa:sync
-    │     • Executing tests → label: qa:execute
-    │   - Detect priority (default: priority:med)
-    │
-    ├─► Step 2: Build Issue Body
-    │   - Source: where this work comes from (Jira ticket, review, PR, conversation)
-    │   - Rationale: why this change is needed
-    │   - Checklist: break work into checkable tasks
-    │   - References: link to related issues, Jira tickets, Confluence pages
-    │   - Use markdown template below
-    │
-    ├─► Step 3: Create Issue
-    │   - Use: gh issue create --title "<title>" --body "<body>"
-    │           --milestone "<milestone>" --label "<labels>"
-    │   - Title format: "[QA] <action> for <ticket>"
-    │     Examples:
-    │     • "[QA] Create test plan for PROJ-12345"
-    │     • "[QA] Review feedback: rewrite TS-02, add TS-04"
-    │     • "[QA] Sync test cases to TestLink"
-    │
-    └─► Step 4: Report
-        - Print issue number and URL
-        - Print checklist summary (N tasks)
-```
+    /gh-track "Create test plan for PROJ-12345"
+        │
+        ├─► Step 1: Determine Context
+        │   - Identify the milestone (from project folder name or user input)
+        │   - Detect activity type from context:
+        │     • Creating/updating test plan → label: qa:plan
+        │     • Creating/updating test cases → label: qa:case
+        │     • Review feedback or change request → label: qa:review
+        │     • Syncing to TestLink → label: qa:sync
+        │     • Executing tests → label: qa:execute
+        │   - Detect priority (default: priority:med)
+        │
+        ├─► Step 2: Build Issue Body
+        │   - Source: where this work comes from (Jira ticket, review, PR, conversation)
+        │   - Rationale: why this change is needed
+        │   - Checklist: break work into checkable tasks
+        │   - References: link to related issues, Jira tickets, Confluence pages
+        │   - Use markdown template below
+        │
+        ├─► Step 3: Create Issue
+        │   - Use: gh issue create --title "<title>" --body "<body>"
+        │           --milestone "<milestone>" --label "<labels>"
+        │   - Title format: "[QA] <action> for <ticket>"
+        │     Examples:
+        │     • "[QA] Create test plan for PROJ-12345"
+        │     • "[QA] Review feedback: rewrite TS-02, add TS-04"
+        │     • "[QA] Sync test cases to TestLink"
+        │
+        └─► Step 4: Report
+            - Print issue number and URL
+            - Print checklist summary (N tasks)
 
 ---
 
 ## ISSUE BODY TEMPLATE
 
-```markdown
-## Source
-<!-- Where this work comes from -->
-- **Jira ticket**: PROJ-12345
-- **Trigger**: [e.g., "Initial test planning" / "PM review feedback" / "Code change in PR #42"]
+    ## Source
+    <!-- Where this work comes from -->
+    - **Jira ticket**: PROJ-12345
+    - **Trigger**: [e.g., "Initial test planning" / "PM review feedback" / "Code change in PR #42"]
 
-## Rationale
-<!-- Why this change is needed -->
-[Brief explanation of why this work matters]
+    ## Rationale
+    <!-- Why this change is needed -->
+    [Brief explanation of why this work matters]
 
-## Tasks
-<!-- Break into checkable items -->
-- [ ] Task 1 description
-- [ ] Task 2 description
-- [ ] Task 3 description
+    ## Tasks
+    <!-- Break into checkable items -->
+    - [ ] Task 1 description
+    - [ ] Task 2 description
+    - [ ] Task 3 description
 
-## References
-<!-- Related issues, docs, links -->
-- Jira: [PROJ-12345](https://your-domain.atlassian.net/browse/PROJ-12345)
-- Related: #N (if applicable)
+    ## References
+    <!-- Related issues, docs, links -->
+    - Jira: [PROJ-12345](https://your-domain.atlassian.net/browse/PROJ-12345)
+    - Related: #N (if applicable)
 
-## Artifacts
-<!-- Files created or modified -->
-- `test_plan/sections/04_Test_Strategy.md`
-- `test_cases/TS-02_Session_Validation.md`
-```
+    ## Artifacts
+    <!-- Files created or modified -->
+    - `test_plan/sections/04_Test_Strategy.md`
+    - `test_cases/TS-02_Session_Validation.md`
 
 ---
 
@@ -86,59 +82,50 @@ Each issue captures what changed, why, and what tasks remain.
 
 ### Example 1: Track test plan creation
 
-```bash
-/gh-track "Create test plan for PROJ-12345"
-```
+    /gh-track "Create test plan for PROJ-12345"
 
 **Issue created:**
-```
-#8: [QA] Create test plan for PROJ-12345
-Labels: qa:plan, priority:high
-Milestone: PROJ-12345 — User Session Management
 
-Tasks:
-- [ ] Detect ticket type (feature/bugfix/enhance)
-- [ ] Write test plan sections 01-06
-- [ ] Review coverage matrix
-- [ ] Publish to Confluence
-```
+    #8: [QA] Create test plan for PROJ-12345
+    Labels: qa:plan, priority:high
+    Milestone: PROJ-12345 — User Session Management
+
+    Tasks:
+    - [ ] Detect ticket type (feature/bugfix/enhance)
+    - [ ] Write test plan sections 01-06
+    - [ ] Review coverage matrix
+    - [ ] Publish to Confluence
 
 ### Example 2: Track review feedback
 
-```bash
-/gh-track "PM review: rewrite TS-02, add TS-04, clarify TS-03 scope"
-```
+    /gh-track "PM review: rewrite TS-02, add TS-04, clarify TS-03 scope"
 
 **Issue created:**
-```
-#12: [QA] Review feedback: rewrite TS-02, add TS-04, clarify TS-03
-Labels: qa:review, priority:med
-Milestone: PROJ-12345 — User Session Management
 
-Tasks:
-- [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
-- [ ] Add TS-04 timeout edge case for session renewal
-- [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
-```
+    #12: [QA] Review feedback: rewrite TS-02, add TS-04, clarify TS-03
+    Labels: qa:review, priority:med
+    Milestone: PROJ-12345 — User Session Management
+
+    Tasks:
+    - [ ] Rewrite TS-02 steps 3-5 (API changed from XML to JSON)
+    - [ ] Add TS-04 timeout edge case for session renewal
+    - [ ] Clarify TS-03 scope — confirm with PM if bulk upload included
 
 ### Example 3: Track TestLink sync
 
-```bash
-/gh-track "Sync updated test cases to TestLink"
-```
+    /gh-track "Sync updated test cases to TestLink"
 
 **Issue created:**
-```
-#15: [QA] Sync test cases to TestLink for PROJ-12345
-Labels: qa:sync, priority:med
-Milestone: PROJ-12345 — User Session Management
 
-Tasks:
-- [ ] Create/update test suites
-- [ ] Sync test cases (diff: skip/update/create)
-- [ ] Create test plan and assign cases
-- [ ] Verify count matches local
-```
+    #15: [QA] Sync test cases to TestLink for PROJ-12345
+    Labels: qa:sync, priority:med
+    Milestone: PROJ-12345 — User Session Management
+
+    Tasks:
+    - [ ] Create/update test suites
+    - [ ] Sync test cases (diff: skip/update/create)
+    - [ ] Create test plan and assign cases
+    - [ ] Verify count matches local
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaced inner triple-backtick code blocks with 4-space indented code blocks in all 4 GitHub command files (`gh-init.md`, `gh-track.md`, `gh-status.md`, `gh-close.md`)
- Inner fences were causing the outer command fence to close prematurely, producing malformed markdown

Closes #21

## Test plan
- [ ] Verify each file has exactly one outer fence (opening `` ``` `` and closing `` ``` ``)
- [ ] Confirm indented blocks render correctly when installed via `make install`
- [ ] Run `/gh-init`, `/gh-track`, `/gh-status`, `/gh-close` to verify commands parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)