### PR TITLE
Sync cross-repo and dev workflow commands from ollama37

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,30 @@ AI QA Workflow is a QA automation toolkit that connects AI coding agents with te
 
 ## Git Workflow
 
-- Create feature branches for all changes: `git checkout -b feature/description`
 - Never commit directly to main
 - Open PR for review before merging
 - PRs require review approval before merging
 - Delete the feature branch after merging
+
+### Branch Naming
+
+- General work: `feature/<description>` (e.g. `feature/add-sync-commands`)
+- Issue-based work: `issue-<N>-<slug>` (e.g. `issue-27-release-notes`)
+
+### PR Conventions
+
+- Title: short, imperative, under 70 characters
+- Body: include `Fixes #N` or `Closes #N` to auto-close the linked issue
+- Body: include `## Summary` (1-3 bullet points) and `## Test plan` sections
+
+### Dev Workflow Commands
+
+For structured issue-driven development, use the `dw-*` commands:
+1. `/dw-plan` — Break request into GitHub issues with labels
+2. `/dw-implement` — Pick up issue, create branch, implement
+3. `/dw-create-pr` — Push and open PR with issue linkage
+4. `/dw-review-pr` — Review PR against checklist
+5. `/dw-merge` — Merge PR and clean up
 
 ## Information Leak Check
 
@@ -57,12 +76,13 @@ Commands are installed by copying markdown files to `~/.claude/commands/`. Skill
 ```
 commands/
 ├── confluence/    # Confluence page operations (6 commands, cf-*)
+├── dev-workflow/  # Dev lifecycle: plan, implement, PR, review, merge (5 commands, dw-*)
 ├── github/        # GitHub tracking and traceability (4 commands, gh-*)
 ├── jira/          # Jira ticket tracing and conversion (7 commands, jr-*)
 ├── project/       # Project management commands (8 commands, pm-*)
 ├── testlink/      # TestLink CRUD and execution (18 commands, tl-*)
 ├── test-workflow/ # Test planning and case workflows (13 commands, tw-*)
-└── utility/       # Text rewriting, log analysis, self-improvement (4 commands)
+└── utility/       # Text rewriting, log analysis, self-improvement, cross-repo sync (6 commands)
 skills/
 ├── receiving-tickets/    # Fetch Jira ticket + set up project workspace
 ├── planning-tests/       # Create test plan from ticket, publish to Confluence
@@ -75,6 +95,7 @@ skills/
 └── tracking-changes/     # Track QA artifact changes in GitHub
 docs/
 ├── integrations/  # MCP server setup guides
+├── references/    # Claude Code command and skill format specs
 ├── workflows/     # End-to-end test lifecycle guide
 └── design/        # Design principles
 ```

--- a/commands/dev-workflow/dw-create-pr.md
+++ b/commands/dev-workflow/dw-create-pr.md
@@ -1,0 +1,84 @@
+# Create a Pull Request
+
+```
+Push branch and open a pull request with issue linkage.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Creates a pull request for the current branch, linking it to the GitHub Issue
+via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
+
+---
+
+## WORKFLOW
+
+    /dw-create-pr 27
+        │
+        ├─► Step 1: Verify Readiness
+        │   - Confirm you're on the correct branch (issue-<N>-<slug>)
+        │   - Run: git status — check for uncommitted changes
+        │   - Run: git log --oneline main..HEAD — review commits
+        │   - If no argument given, infer issue number from branch name
+        │
+        ├─► Step 2: Push Branch
+        │   - Run: git push -u origin $(git branch --show-current)
+        │
+        ├─► Step 3: Create PR
+        │   - Title: short, imperative, under 70 characters
+        │   - Body must include "Fixes #N" or "Closes #N"
+        │   - Use this template:
+        │
+        │       gh pr create --title "<title>" --body "$(cat <<'EOF'
+        │       ## Summary
+        │       <1-3 bullet points>
+        │
+        │       Fixes #<issue-number>
+        │
+        │       ## Test plan
+        │       - [ ] ...
+        │
+        │       Generated with [Claude Code](https://claude.com/claude-code)
+        │       EOF
+        │       )"
+        │
+        ├─► Step 4: Update Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:in-progress" \
+        │          --add-label "status:needs-review"
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "PR #<PR> created. Summary: <what changed>"
+        │
+        └─► Step 5: Report
+            - Show the PR URL to the user
+            - Suggest next step: /dw-review-pr <PR>
+
+---
+
+## EXAMPLE
+
+    /dw-create-pr 27
+
+**Agent verifies, pushes, creates PR:**
+
+    $ git status
+    $ git log --oneline main..HEAD
+    $ git push -u origin issue-27-release-notes
+    $ gh pr create --title "Add release notes generator command" --body "..."
+    $ gh issue edit 27 --remove-label "status:in-progress" --add-label "status:needs-review"
+    $ gh issue comment 27 --body "PR #30 created."
+
+**Output:**
+
+    PR #30 created: https://github.com/owner/repo/pull/30
+    Next: /dw-review-pr 30
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `Fixes #N` in PR body auto-closes the issue when PR is merged
+- Copy relevant labels from the issue to the PR if needed
+- If branch is already pushed, the push step is a no-op
+```

--- a/commands/dev-workflow/dw-implement.md
+++ b/commands/dev-workflow/dw-implement.md
@@ -1,0 +1,108 @@
+# Implement a GitHub Issue
+
+```
+Start work on a GitHub Issue — create branch, implement, and track progress.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Picks up a GitHub Issue and drives it through implementation. Creates a feature
+branch, tracks status via labels and comments, handles failures transparently,
+and prepares for PR creation when done.
+
+---
+
+## WORKFLOW
+
+    /dw-implement 27
+        │
+        ├─► Step 1: Understand the Issue
+        │   - Run: gh issue view <N>
+        │   - Read acceptance criteria, technical notes, dependencies
+        │   - Check labels — type and priority should already be set
+        │   - Check for linked/blocking issues
+        │   - If anything is unclear, ask the user before starting
+        │
+        ├─► Step 2: Create Branch
+        │   - Branch name: issue-<N>-<short-slug>
+        │     Example: issue-27-release-notes
+        │   - Run: git checkout -b issue-<N>-<slug> main
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"
+        │   - Add status label:
+        │     gh issue edit <N> --add-label "status:in-progress"
+        │
+        ├─► Step 3: Implement
+        │   - Make the changes based on acceptance criteria
+        │   - Build and test using the project's standard tooling
+        │     (Makefile, test framework, CI pipeline — whatever the project uses)
+        │   - Commit incrementally with clear messages
+        │
+        ├─► Step 4a: On Success
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
+        │   - Proceed to /dw-create-pr
+        │
+        ├─► Step 4b: On Failure
+        │   - Do NOT silently retry — update the issue:
+        │     gh issue comment <N> --body "Build/test failure: <what failed, error, root cause>"
+        │   - If blocked, add label:
+        │     gh issue edit <N> --add-label "status:blocked"
+        │   - Investigate, fix, update issue:
+        │     gh issue comment <N> --body "Applied fix: <what changed>. Retesting."
+        │   - Remove blocked label after unblocking:
+        │     gh issue edit <N> --remove-label "status:blocked"
+        │   - If stuck after 2-3 attempts, comment blockers and ask the user
+        │
+        └─► Step 4c: On Partial Fix
+            - Comment: what was fixed, what remains, blockers
+            - Proceed to /dw-create-pr if the partial fix is independently useful
+            - Create follow-up issues for remaining work
+
+---
+
+## ISSUE CROSS-REFERENCES
+
+Use these patterns in issue comments and PR bodies:
+- **Parent/child**: "Part of #N" or "Parent: #N"
+- **Dependencies**: "Depends on #N", "Blocked by #N"
+- **Related**: "Related to #N"
+
+GitHub auto-creates backlinks when issues reference each other.
+
+---
+
+## EXAMPLE
+
+    /dw-implement 27
+
+**Agent reads issue #27, creates branch, implements:**
+
+    $ gh issue view 27
+    $ git checkout -b issue-27-release-notes main
+    $ gh issue comment 27 --body "Starting work on branch `issue-27-release-notes`"
+    $ gh issue edit 27 --add-label "status:in-progress"
+
+    ... (implementation work) ...
+
+    $ gh issue comment 27 --body "Implementation complete, tests passing. Ready for PR."
+
+**Next step:** /dw-create-pr 27
+
+---
+
+## KEY PRINCIPLE
+
+The issue is the single source of truth. Anyone reading it should see the full
+history — start, failures, fixes, and resolution.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Branch naming convention: `issue-<number>-<short-slug>`
+- Always comment on the issue before and after implementation
+- Label management: `status:in-progress` while working, `status:blocked` if stuck
+```

--- a/commands/dev-workflow/dw-merge.md
+++ b/commands/dev-workflow/dw-merge.md
@@ -1,0 +1,76 @@
+# Merge a Pull Request
+
+```
+Merge an approved pull request and clean up.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Merges an approved PR, deletes the remote branch, cleans up local branches
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+
+---
+
+## WORKFLOW
+
+    /dw-merge 30
+        │
+        ├─► Step 1: Verify PR is Ready
+        │   - Run: gh pr view <PR> --json reviewDecision,mergeStateStatus,headRefName
+        │   - Must be approved and mergeable
+        │   - Run: gh pr checks <PR>
+        │   - CI checks must pass (if applicable)
+        │
+        ├─► Step 2: Identify Linked Issue
+        │   - Read PR body for "Fixes #N" or "Closes #N"
+        │   - Note the issue number for label cleanup
+        │
+        ├─► Step 3: Merge
+        │   - Run: gh pr merge <PR> --merge --delete-branch
+        │   - Uses --merge (not squash/rebase) to preserve commit history
+        │   - --delete-branch cleans up the remote branch
+        │
+        ├─► Step 4: Clean Up Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:needs-review"
+        │   - Issue auto-closes via "Fixes #N" — no manual close needed
+        │
+        ├─► Step 5: Clean Up Local Branch
+        │   - Run: git checkout main && git pull
+        │   - Run: git branch -d <branch-name>
+        │
+        └─► Step 6: Report
+            - Confirm merge to the user
+            - Show the merged PR URL
+            - Mention any follow-up issues if applicable
+
+---
+
+## EXAMPLE
+
+    /dw-merge 30
+
+**Agent verifies, merges, cleans up:**
+
+    $ gh pr view 30 --json reviewDecision,mergeStateStatus,headRefName
+    $ gh pr checks 30
+    $ gh pr merge 30 --merge --delete-branch
+    $ gh issue edit 27 --remove-label "status:needs-review"
+    $ git checkout main && git pull
+    $ git branch -d issue-27-release-notes
+
+**Output:**
+
+    PR #30 merged: https://github.com/owner/repo/pull/30
+    Issue #27 auto-closed.
+    Branch issue-27-release-notes deleted (local + remote).
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
+- `--delete-branch` removes the remote branch; `git branch -d` removes the local one
+- If PR is not approved or CI fails, report the blocker instead of merging
+```

--- a/commands/dev-workflow/dw-plan.md
+++ b/commands/dev-workflow/dw-plan.md
@@ -1,0 +1,129 @@
+# Plan Development Work into GitHub Issues
+
+```
+Break down a user request into GitHub Issues with labels and priorities.
+
+Request: {{input}}
+
+## PURPOSE
+
+Analyzes a feature request, enhancement, or bug report and creates well-structured
+GitHub Issues with proper labels and priorities. Checks for duplicates, breaks down
+multi-part requests, and waits for user approval before implementation begins.
+
+---
+
+## WORKFLOW
+
+    /dw-plan Add cross-repo sync commands
+        │
+        ├─► Step 1: Check Existing Issues
+        │   - Run: gh issue list --state all --limit 50
+        │   - Scan for duplicates or related issues
+        │   - If duplicate found, report and ask user how to proceed
+        │
+        ├─► Step 2: Classify the Request
+        │   - Determine type: feature / enhancement / bug / docs
+        │   - Determine priority: high / medium / low
+        │   - Break down into individual issues if request covers multiple items
+        │
+        ├─► Step 3: Create Labels (idempotent)
+        │   - Ensure type labels exist:
+        │     • feature        (color: #0e8a16) — New capability
+        │     • enhancement    (color: #1d76db) — Improve existing
+        │     • bug            (color: #d93f0b) — Bug report
+        │     • docs           (color: #c5def5) — Documentation
+        │   - Ensure priority labels exist:
+        │     • priority:high   (color: #b60205) — Important, fix soon
+        │     • priority:medium (color: #fbca04) — Normal priority
+        │     • priority:low    (color: #0e8a16) — Nice to have
+        │   - Ensure status labels exist:
+        │     • status:in-progress  (color: #1d76db) — Work started
+        │     • status:needs-review (color: #e4e669) — PR open, awaiting review
+        │     • status:blocked      (color: #d93f0b) — Blocked by dependency
+        │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+        │
+        ├─► Step 4: Create Issues
+        │   - One issue per distinct work item
+        │   - Use the appropriate body template (see below)
+        │   - Apply type + priority labels
+        │   - Link related issues: "Depends on #N", "Related to #N"
+        │
+        ├─► Step 5: Summarize
+        │   - Output a table of created issues:
+        │     | Issue | Title | Type | Priority | URL |
+        │   - Wait for user approval before proceeding
+        │
+        └─► Step 6: User Approval Gate
+            - Ask: "Want me to start on #N?"
+            - Do NOT proceed to /dw-implement until user explicitly approves
+
+---
+
+## ISSUE BODY TEMPLATES
+
+### Feature / Enhancement
+
+    ## User Story
+    As a [role], I want [capability], so that [benefit].
+
+    ## Acceptance Criteria
+    1. ...
+
+    ## Technical Notes
+    - ...
+
+    ## Dependencies
+    - None | Depends on #N
+
+### Bug
+
+    ## Description
+    ...
+
+    ## Expected Behavior
+    ...
+
+    ## Steps to Reproduce
+    1. ...
+
+---
+
+## EXAMPLE
+
+    /dw-plan Add command to generate release notes from git history
+
+**Agent creates:**
+
+    gh issue create \
+      --label "feature" --label "priority:medium" \
+      --title "Add release notes generator command" \
+      --body "## User Story
+    As a developer, I want to generate release notes from git history,
+    so that I can quickly summarize changes for each release.
+
+    ## Acceptance Criteria
+    1. Command reads git log between two tags
+    2. Groups commits by type (feature, fix, docs)
+    3. Outputs formatted markdown
+
+    ## Dependencies
+    - None"
+
+**Output:**
+
+    | Issue | Title                              | Type    | Priority | URL                    |
+    |-------|------------------------------------|---------|----------|------------------------|
+    | #27   | Add release notes generator command | feature | medium   | https://github.com/... |
+
+    Want me to start on #27?
+
+---
+
+## API Notes
+
+- Uses `gh` CLI — must be authenticated (`gh auth status`)
+- Labels use `--force` flag so existing labels are updated, not duplicated
+- Always check for duplicates before creating new issues
+- The issue body is the single source of truth for the work item
+```

--- a/commands/dev-workflow/dw-review-pr.md
+++ b/commands/dev-workflow/dw-review-pr.md
@@ -1,0 +1,92 @@
+# Review a Pull Request
+
+```
+Review a pull request using a structured checklist.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Reviews a pull request against a structured checklist covering issue linkage,
+code quality, test coverage, and documentation. Approves or requests changes.
+
+---
+
+## WORKFLOW
+
+    /dw-review-pr 30
+        │
+        ├─► Step 1: Read the PR
+        │   - Run: gh pr view <PR>
+        │   - Run: gh pr diff <PR>
+        │   - Run: gh pr checks <PR>
+        │
+        ├─► Step 2: Review Checklist
+        │
+        │   Issue Linkage:
+        │   - [ ] PR body contains "Fixes #N" or "Closes #N"
+        │   - [ ] PR title is clear and under 70 characters
+        │   - [ ] Labels match the linked issue
+        │
+        │   Code Quality:
+        │   - [ ] Changes match the issue's acceptance criteria
+        │   - [ ] No unnecessary changes beyond what was requested
+        │   - [ ] No security vulnerabilities (injection, hardcoded secrets)
+        │   - [ ] No debug/temporary code left in
+        │
+        │   Test Coverage:
+        │   - [ ] Relevant tests added or updated (if applicable)
+        │   - [ ] CI checks pass (if applicable)
+        │
+        │   Documentation:
+        │   - [ ] Comments added where logic isn't self-evident
+        │   - [ ] No unnecessary comments or docstrings
+        │
+        ├─► Step 3: Decision
+        │   - Approve: all checks pass → proceed to /dw-merge
+        │   - Request changes: specific feedback → back to /dw-implement
+        │
+        └─► Step 4: Submit Review
+            - Check if you are the PR author (GitHub blocks self-approval)
+            - If NOT the author:
+              gh pr review <PR> --approve --body "LGTM"
+            - If you ARE the author (self-review):
+              gh pr comment <PR> --body "Self-review complete. Checklist passes. Ready to merge."
+            - To request changes:
+              gh pr review <PR> --request-changes --body "<specific feedback>"
+
+---
+
+## EXAMPLE
+
+    /dw-review-pr 30
+
+**Agent reads PR, runs checklist:**
+
+    $ gh pr view 30
+    $ gh pr diff 30
+    $ gh pr checks 30
+
+**Checklist result:**
+
+    ✓ Issue linkage — Fixes #27 present
+    ✓ Title — "Add release notes generator command" (42 chars)
+    ✓ Code quality — Changes match acceptance criteria
+    ✓ No security issues
+    ✓ Tests — N/A (markdown-only change)
+
+    $ gh pr review 30 --approve --body "LGTM"
+
+**Output:**
+
+    PR #30 approved. Next: /dw-merge 30
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR operations
+- GitHub blocks self-approval — use comment instead if you authored the PR
+- If CI checks are failing, investigate before approving
+- Always read the full diff, not just the PR description
+```

--- a/commands/utility/compare.md
+++ b/commands/utility/compare.md
@@ -1,0 +1,128 @@
+# Compare — Cross-Repo Drift Detection
+
+```
+Compare shared components between the current repo and a remote repo to detect drift and propose backport issues.
+
+Arguments: {{input}}
+  - <remote-repo-path>                Full analysis of all shared components
+  - <remote-repo-path> --issue        Also create GitHub issues in the remote repo for backport items
+
+Examples:
+  /compare /home/jack/src/ollama37
+  /compare /home/jack/src/test-framework-template --issue
+
+## Important Rules
+
+1. This command relies on YOUR judgment as an AI agent — there is no manifest file
+2. Read both repos' structure and CLAUDE.md to understand what each repo does
+3. Determine shared components by understanding PURPOSE, not just matching file names
+4. Two files that serve the same purpose but have different paths, names, or adaptations ARE the same component
+5. Show diffs, never auto-apply changes — this command is read-only
+6. When creating issues (--issue), create one issue per actionable backport item
+7. Respect that each repo adapts shared components to its own context — divergence is expected and healthy
+8. Focus on meaningful differences (new features, bug fixes, structural improvements) not cosmetic ones (wording, formatting, project-specific values)
+
+## Phase 1: Explore Both Repos
+
+Explore both the current repo and the remote repo to build understanding:
+
+### For each repo, gather:
+1. **CLAUDE.md** — Read it to understand the project's purpose, workflow, and conventions
+2. **Skills** — List all skill files (check `.claude/skills/`, `skills/`, or similar locations)
+3. **Commands** — List all command files (check `.claude/commands/`, `commands/`, or similar locations)
+4. **References** — List any shared reference docs (`.claude/references/`, `docs/`)
+5. **Test framework** — Check for test framework code (`cicd/tests/`, `tests/`, or similar)
+6. **Workflow docs** — Check `docs/workflows/` or similar
+7. **GitHub remote** — Run `git remote -v` to get the GitHub owner/repo for issue creation
+
+### Build a mental model of each repo:
+- What is this repo for?
+- What patterns does it use? (skill/command architecture, test framework, CI, etc.)
+- What was likely ported FROM this repo vs ported TO it?
+
+## Phase 2: Identify Shared Components
+
+Using your understanding of both repos, identify components that serve the SAME PURPOSE across repos. Match by intent, not by filename.
+
+Examples of smart matching:
+- `commands/utility/evolve.md` (ai-qa-workflow) ↔ `.claude/commands/evolve.md` (ollama37) — same command, different path
+- `cicd/tests/src/judge/llm-judge.ts` in both repos — same framework file
+- A skill in one repo that doesn't exist in the other — candidate for backporting
+
+### Classification
+For each identified component, classify it:
+- **identical** — Same purpose AND same content (no action needed)
+- **diverged** — Same purpose but content differs (inspect further)
+- **local-only** — Exists here but not in remote (candidate for backporting)
+- **remote-only** — Exists in remote but not here (candidate for syncing)
+
+### For diverged components, determine:
+1. Which side was modified more recently: `git log -1 --format="%ci" -- <file>` in both repos
+2. What the meaningful differences are (ignore project-specific adaptations like repo names, labels, IDs)
+3. Whether the local or remote version has improvements worth propagating
+
+## Phase 3: Analyze Differences
+
+For each **diverged** component, use your judgment to assess:
+
+1. **What changed and why** — Read the diffs, understand the intent
+2. **Is this a meaningful improvement or just project-specific adaptation?**
+   - Bug fix in LLM judge → meaningful, should backport
+   - Different label names in /plan skill → project-specific, ignore
+   - New phase added to /evolve → meaningful, should backport
+   - Different example commands in a skill → cosmetic, ignore
+3. **Direction** — Which repo should receive the change?
+   - **backport** (local → remote) — Local has an improvement the remote should get
+   - **sync** (remote → local) — Remote has an improvement we should pull
+   - **diverged-ok** — Both sides adapted independently, no action needed
+
+## Phase 4: Generate Report
+
+Present the comparison report:
+
+    ## Cross-Repo Comparison Report
+
+    **Local repo:** [name] ([path])
+    **Remote repo:** [name] ([path])
+    **Date:** [YYYY-MM-DD]
+
+    ### Summary
+    - Components compared: [count]
+    - Identical: [count]
+    - Diverged: [count] (backport: N, sync: N, diverged-ok: N)
+    - Local-only: [count]
+    - Remote-only: [count]
+
+    ### Actionable Items
+
+    For each item that needs action:
+    - Component name and type
+    - Where it lives in each repo
+    - What changed (brief, focused on the improvement)
+    - Recommended direction: backport / sync
+    - Priority: high (bug fix, missing feature) / low (enhancement, convenience)
+
+    ### No Action Needed
+
+    For each identical or diverged-ok component:
+    - Component name
+    - Status: identical / diverged-ok (with brief note on why divergence is fine)
+
+## Phase 5: Create Backport Issues (only if --issue flag)
+
+For each component that should be backported to the remote repo:
+
+1. Determine the remote repo's GitHub owner/repo from `git remote -v` in the remote repo
+2. Create a focused GitHub issue describing:
+   - What improvement exists in the source repo
+   - Why it's worth backporting
+   - What file(s) to look at
+   - Suggested approach (copy, adapt, or merge)
+
+3. Report the created issue URLs
+
+## Phase 6: Save Report (optional)
+
+Ask the user if they want to save the report:
+- Save to `docs/compare/[YYYY-MM-DD]_[remote-name]_compare.md`
+```

--- a/commands/utility/sync.md
+++ b/commands/utility/sync.md
@@ -1,0 +1,105 @@
+# Sync — Cross-Repo Component Sync
+
+```
+Pull shared components from a remote repo into the current repo, adapting them to fit.
+
+Arguments: {{input}}
+  - <remote-repo-path>                  Sync improvements from remote
+  - <remote-repo-path> --dry-run        Show what would be synced without applying
+
+Examples:
+  /sync /home/jack/src/ollama37
+  /sync /home/jack/src/test-framework-template --dry-run
+
+## Important Rules
+
+1. This command relies on YOUR judgment as an AI agent — there is no manifest file
+2. NEVER blindly copy files — understand both repos and ADAPT the content to fit the destination
+3. NEVER auto-apply changes — show what you plan to do and ask for confirmation
+4. Prefer editing existing files over overwriting — preserve local adaptations
+5. Project-specific values (repo names, labels, IDs, paths) must be adapted, not copied verbatim
+6. After syncing, update CLAUDE.md if new skills/commands were added
+7. If a component needs significant rewriting to fit this repo, tell the user and propose the adaptation
+
+## Phase 1: Explore and Compare
+
+1. Read CLAUDE.md, skills, commands, and key files in BOTH repos to understand their structure
+2. Run the same analysis as `/compare` — identify shared components and which ones have improvements to sync
+3. Focus only on components where the remote has something worth pulling:
+   - Remote has a component we don't have (new)
+   - Remote has a newer/better version of something we have (update)
+
+## Phase 2: Plan Sync
+
+Present the sync plan:
+
+    ## Sync Plan
+
+    **From:** [remote-name] ([path])
+    **To:** [current-repo-name] ([path])
+
+    | # | Component | Action | What Changes |
+    |---|-----------|--------|--------------|
+    | 1 | evolve    | update | New phase 4 evaluation logic from remote |
+    | 2 | session-summary | create | New command, needs adaptation for dev workflow |
+
+    **Actions:**
+    - **update** — File exists locally, will merge improvements from remote
+    - **create** — New component, will adapt from remote and create locally
+    - **adapt** — Significant rewriting needed to fit this repo's context
+
+For each item, briefly explain:
+- What the remote has that we want
+- How it needs to be adapted for this repo
+- Where it will go in this repo's structure
+
+Ask the user: "Proceed with sync? (all / 1,3 / none)"
+
+## Phase 3: Apply Sync (per-component)
+
+For each approved component:
+
+### For updates (file exists locally):
+1. Read both the local and remote versions
+2. Identify the specific improvements from the remote version
+3. Apply those improvements to the LOCAL file, preserving local adaptations
+4. Use the Edit tool to make surgical changes, not wholesale replacement
+5. Show the user what changed
+
+### For new components:
+1. Read the remote file
+2. Adapt it for this repo:
+   - Replace project-specific references (repo name, labels, paths, tools)
+   - Adjust workflow patterns to match this repo's conventions
+   - Follow this repo's file format (check existing skills/commands for style)
+3. Determine the correct local path based on this repo's structure
+4. Create the file
+5. Show the user the adapted version
+
+### For adaptations (heavy rewriting):
+1. Explain what the remote component does
+2. Propose how it should work in this repo
+3. Write the adapted version
+4. Show the user for approval
+
+## Phase 4: Post-Sync Updates
+
+After syncing, handle integration:
+
+1. **Update CLAUDE.md** if new skills or commands were added:
+   - Add to the directory structure listing
+   - Add to relevant command lists
+2. **Show a summary** of what was synced:
+
+        ## Sync Complete
+
+        ### Applied
+        | # | Component | Action | Files Changed |
+        |---|-----------|--------|---------------|
+
+        ### Skipped
+        | # | Component | Reason |
+        |---|-----------|--------|
+
+3. **Remind the user** to review the changes and test
+```

--- a/docs/references/command-format.md
+++ b/docs/references/command-format.md
@@ -1,0 +1,126 @@
+# Claude Code Custom Slash Command Format
+
+## File Location
+
+```
+.claude/commands/<name>.md        ← project scope
+~/.claude/commands/<name>.md      ← global scope
+```
+
+Filename (without `.md`) becomes the command name.
+e.g. `refactor.md` → `/refactor`
+
+---
+
+## Basic (no frontmatter)
+
+```markdown
+Refactor the selected code to improve readability and maintainability.
+Focus on clean code principles and best practices.
+```
+
+---
+
+## With Frontmatter
+
+```markdown
+---
+allowed-tools: Read, Grep, Glob
+description: Run security vulnerability scan
+model: claude-opus-4-6
+argument-hint: [issue-number] [priority]
+---
+
+Fix issue #$1 with priority $2.
+Analyze the codebase for security vulnerabilities.
+```
+
+---
+
+## Frontmatter Fields
+
+| Field | Description |
+|---|---|
+| `description` | Shown in autocomplete; helps Claude decide when to auto-load |
+| `allowed-tools` | Restrict tools e.g. `Read, Grep, Bash(git diff:*)` |
+| `model` | Override model for this command |
+| `argument-hint` | Label for expected arguments |
+| `context` | Set to `fork` to run in a sub-agent |
+| `agent` | Specify sub-agent type e.g. `Explore`, `Plan` |
+
+---
+
+## Arguments
+
+- `$1`, `$2` — positional arguments
+- `$ARGUMENTS` — all arguments as a single string
+
+### Example
+
+```markdown
+---
+argument-hint: [issue-number] [priority]
+description: Fix a GitHub issue
+---
+
+Fix issue #$1 with priority $2.
+Check the issue description and implement the necessary changes.
+```
+
+Invoked as: `/fix-issue 123 high`
+
+---
+
+## Dynamic Context
+
+```markdown
+- Current diff: !`git diff HEAD`
+- Git status: !`git status`
+- Config file: @package.json
+```
+
+| Syntax | Description |
+|---|---|
+| `` !`<cmd>` `` | Execute bash command and inject output |
+| `@filename` | Inject file content |
+
+### Full Example with Dynamic Context
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+## Context
+
+- Current status: !`git status`
+- Current diff: !`git diff HEAD`
+
+## Task
+
+Create a git commit with appropriate message based on the changes.
+```
+
+---
+
+## Subdirectory Namespacing
+
+```
+.claude/commands/
+├── backend/
+│   └── api-test.md     → /api-test
+├── frontend/
+│   └── component.md    → /component
+└── review.md           → /review
+```
+
+Subdirectory name appears in description but does **not** affect the command name.
+
+---
+
+## Notes
+
+- Files in `.claude/commands/` still work with the same frontmatter
+- Skills (`.claude/skills/`) are now recommended as they support additional features like supporting files
+- Built-in commands like `/compact` and `/clear` are not affected

--- a/docs/references/skill-format.md
+++ b/docs/references/skill-format.md
@@ -1,0 +1,180 @@
+# Creating Custom Skills
+
+> Learn how to create, structure, and test your own custom skills
+
+Custom skills extend Claude with specialized knowledge and workflows. This guide explains how to create, structure, and test your own skills.
+
+Skills can range from simple instruction sets to multi-file packages with executable code. Effective skills:
+
+* Solve a specific, repeatable task
+* Have clear instructions Claude can follow
+* Include examples when helpful
+* Define when they should be used
+* Focus on one workflow rather than trying to do everything
+
+## Directory Structure
+
+A skill is a directory containing at minimum a `SKILL.md` file:
+
+```
+brand-guidelines/
+├── SKILL.md
+├── scripts/        # Optional: executable code
+├── references/     # Optional: additional documentation
+└── assets/         # Optional: templates, images, data files
+```
+
+The directory name must match the `name` field in your `SKILL.md`.
+
+## Creating a SKILL.md File
+
+The `SKILL.md` file must start with YAML frontmatter containing required metadata, followed by markdown instructions.
+
+### Required Fields
+
+```markdown
+---
+name: brand-guidelines
+description: Apply Acme Corp brand guidelines to presentations and documents, including official colors, fonts, and logo usage.
+---
+```
+
+**name**: Lowercase letters, numbers, and hyphens only. Maximum 64 characters. Must match the directory name.
+
+**description**: Explains what the skill does and when to use it. Claude uses this to determine when to invoke your skill.
+
+> Claude.ai limits descriptions to **200 characters**. The Agent Skills specification allows up to 1024 characters, but skills uploaded to Claude.ai must use the shorter limit.
+
+### Markdown Body
+
+After the frontmatter, write markdown instructions for Claude. Include:
+
+* Step-by-step procedures
+* Examples of inputs and outputs
+* Templates or formatting requirements
+* Edge cases to handle
+
+Keep your main `SKILL.md` under 500 lines. Move detailed reference material to separate files.
+
+### Complete Example
+
+```markdown
+---
+name: brand-guidelines
+description: Apply Acme Corp brand guidelines to presentations and documents, including official colors, fonts, and logo usage.
+---
+
+# Brand Guidelines
+
+Apply these standards when creating presentations, documents, or marketing materials for Acme Corp.
+
+## Brand colors
+
+- Primary: #FF6B35 (Coral)
+- Secondary: #004E89 (Navy Blue)
+- Accent: #F7B801 (Gold)
+- Neutral: #2E2E2E (Charcoal)
+
+## Typography
+
+- Headers: Montserrat Bold
+- Body text: Open Sans Regular
+- Size guidelines: H1 32pt, H2 24pt, Body 11pt
+
+## Logo usage
+
+Use the full-color logo on light backgrounds, white logo on dark backgrounds. Maintain minimum spacing of 0.5 inches around the logo.
+
+## When to apply
+
+Apply these guidelines when creating:
+- PowerPoint presentations
+- Word documents for external sharing
+- Marketing materials
+- Reports for clients
+
+See the [assets/](assets/) folder for logo files and font downloads.
+```
+
+## Adding Resources
+
+For content too detailed for `SKILL.md`, add files to your skill directory:
+
+* **`references/`**: Additional documentation Claude can read when needed
+* **`assets/`**: Templates, images, lookup tables, schemas
+* **`scripts/`**: Executable code (see below)
+
+Reference these files in `SKILL.md` so Claude knows when to load them. Keep files focused — smaller files mean less context usage.
+
+## Adding Scripts
+
+Skills can include executable code in Python, JavaScript/Node.js, or Bash. Place scripts in the `scripts/` directory.
+
+Claude can install packages from standard repositories (PyPI, npm) when loading skills. Declare dependencies in your frontmatter:
+
+```markdown
+---
+name: data-analysis
+description: Analyze CSV files and generate visualizations.
+dependencies: python>=3.8, pandas>=1.5.0, matplotlib
+---
+```
+
+## Packaging Your Skill
+
+To upload a skill to Claude:
+
+1. Ensure the directory name matches your skill's `name` field
+2. Create a ZIP file containing the skill directory
+
+**Correct structure:**
+
+```
+my-skill.zip
+└── my-skill/
+    ├── SKILL.md
+    └── scripts/
+```
+
+**Incorrect structure:**
+
+```
+my-skill.zip
+├── SKILL.md  # files directly in ZIP root
+└── scripts/
+```
+
+## Testing Your Skill
+
+### Before Uploading
+
+1. Review `SKILL.md` for clarity
+2. Verify the description accurately reflects when Claude should use the skill
+3. Check that all referenced files exist
+
+### After Uploading
+
+1. Enable the skill in **Settings > Capabilities**
+2. Try prompts that should trigger it
+3. Review Claude's thinking to confirm it's loading the skill
+4. Iterate on the description if Claude isn't using it when expected
+
+## Best Practices
+
+**Keep it focused**: Create separate skills for different workflows. Multiple focused skills compose better than one large skill.
+
+**Write clear descriptions**: Be specific about when the skill applies. Include keywords that help Claude identify relevant tasks.
+
+**Start simple**: Begin with markdown instructions before adding scripts.
+
+**Use examples**: Include example inputs and outputs to help Claude understand what success looks like.
+
+**Test incrementally**: Test after each significant change.
+
+**Leverage composability**: Claude can use multiple skills together automatically.
+
+## Security Considerations
+
+* Don't hardcode sensitive information (API keys, passwords)
+* Review any downloaded skills before enabling them
+* Use MCP connections for external service access


### PR DESCRIPTION
## Summary
- Add `/compare` and `/sync` commands for cross-repo drift detection and component sync
- Add 5 dev workflow commands (`/dw-plan`, `/dw-implement`, `/dw-create-pr`, `/dw-review-pr`, `/dw-merge`) for structured issue-driven development
- Add `docs/references/` with command-format and skill-format specs for contributors
- Expand CLAUDE.md git workflow with branch naming, PR conventions, and dw-* command reference

Closes #26

## Test plan
- [ ] `make install` picks up all new commands
- [ ] All 7 new commands appear as slash commands after IDE restart
- [ ] No ollama37-specific references (dogkeeper886, K80, CUDA, component:*) in any new file
- [ ] Examples use generic placeholders (PROJ-NNNNN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)