### PR TITLE
feat: rewrite README and add script review command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,14 +146,14 @@ Commands are installed by copying markdown files to `~/.claude/commands/`. Skill
 
 ```
 commands/
-├── confluence/    # Confluence page operations (6 commands, cf-*)
-├── dev-workflow/  # Dev lifecycle: story, plan, implement, PR, review, merge (6 commands, dw-*)
-├── github/        # GitHub tracking and traceability (4 commands, gh-*)
-├── jira/          # Jira ticket tracing and conversion (7 commands, jr-*)
-├── project/       # Project management commands (8 commands, pm-*)
-├── testlink/      # TestLink CRUD and execution (18 commands, tl-*)
-├── test-workflow/ # Test planning and case workflows (15 commands, tw-*)
-└── utility/       # Text rewriting, log analysis, self-improvement, cross-repo sync (8 commands)
+├── confluence/    # Confluence page operations (cf-*)
+├── dev-workflow/  # Dev lifecycle: story, plan, implement, PR, review, merge (dw-*)
+├── github/        # GitHub tracking and traceability (gh-*)
+├── jira/          # Jira ticket tracing and conversion (jr-*)
+├── project/       # Project management commands (pm-*)
+├── testlink/      # TestLink CRUD and execution (tl-*)
+├── test-workflow/ # Test planning and case workflows (tw-*)
+└── utility/       # Text rewriting, log analysis, self-improvement, cross-repo sync
 skills/
 ├── receiving-tickets/    # Fetch Jira ticket + set up project workspace
 ├── planning-tests/       # Create test plan from ticket, publish to Confluence

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ ai-qa-workflow/
 ### Adding New Commands
 
 1. Create markdown file in the appropriate `commands/` subfolder
-2. Follow the standard template (see existing commands for examples)
+2. Follow the [command format spec](docs/references/command-format.md) (or use existing commands as examples)
 3. Tell your AI agent to re-read `CLAUDE.md` and sync the new command
 4. Commit only the source file
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AI QA Workflow
 
-A complete QA automation toolkit that connects AI coding agents with test management systems through MCP (Model Context Protocol) integrations.
+A QA automation toolkit that connects AI coding agents with test management systems through MCP (Model Context Protocol). Slash commands and agent skills cover the full test lifecycle — from Jira ticket to TestLink execution.
 
 ## Project Goal
 
-Enable **end-to-end test automation** from a single source of truth. Instead of manually copying information between Jira, Confluence, TestLink, and test scripts, we use AI coding agents to:
+Enable **end-to-end test automation** from a single source of truth. Instead of manually copying information between Jira, Confluence, TestLink, and test scripts, AI coding agents:
 
 1. **Discover** requirements from Jira and Confluence via MCP
 2. **Plan** test strategies using intelligent checklists
@@ -13,7 +13,60 @@ Enable **end-to-end test automation** from a single source of truth. Instead of 
 5. **Automate** test execution with the dual-judge framework
 6. **Report** results back to source systems
 
-This eliminates duplication, maintains traceability, and accelerates the QA process.
+## Quick Start
+
+### Installation
+
+Installation is agent-driven — no installer script, no build step. Your AI agent reads `CLAUDE.md` and does the work.
+
+```
+git clone https://github.com/dogkeeper886/ai-qa-workflow
+```
+
+Then tell your AI agent:
+
+> "Read /path/to/ai-qa-workflow/CLAUDE.md and install the commands I need"
+
+The agent will:
+1. Detect your project context and configured MCP servers
+2. Recommend relevant modules (e.g., Jira commands if you use mcp-atlassian)
+3. Ask where to install — home folder or project folder (see [Two-Tier Architecture](#two-tier-architecture))
+4. Compare with any existing commands and sync only the differences
+
+### After Installation
+
+1. Restart your IDE to load new commands
+2. Skills available as slash commands (e.g., `/receiving-tickets`)
+3. All commands also available (e.g., `/jr-trace`)
+4. Configure MCP integrations (see [docs/integrations/](docs/integrations/))
+
+### Updating
+
+Same flow — tell your agent to re-read `CLAUDE.md`. It compares, detects changes, and syncs updates. Use `/compare` to preview drift before syncing.
+
+## Two-Tier Architecture
+
+Commands are organized in two tiers to reduce maintenance across multiple projects:
+
+| Tier | Location | Scope | What belongs here |
+|------|----------|-------|-------------------|
+| **Home** | `~/.claude/commands/` | Every project | Universal commands that work without modification anywhere |
+| **Project** | `.claude/commands/`, `.claude/skills/` | One project | Commands needing project-specific MCP servers or paths |
+
+**Home tier** — install once, use everywhere:
+- Utility: `rewrite-text`, `evolve`, `session-summary`, `compare`, `sync`, `command-review`, `review-install`, `robot-log-analyzer`
+- Dev Workflow: `dw-story`, `dw-plan`, `dw-implement`, `dw-create-pr`, `dw-review-pr`, `dw-merge`
+
+**Project tier** — install per project as needed:
+- Jira (`jr-*`), Confluence (`cf-*`), TestLink (`tl-*`), Test Workflow (`tw-*`), GitHub (`gh-*`), Project (`pm-*`), Skills
+
+### Maintenance Tools
+
+| Command | Purpose |
+|---------|---------|
+| `/review-install` | Audit your setup — catches duplicates, misplacements, and drift |
+| `/compare` | Detect what's out of sync between source repo and installed commands |
+| `/sync` | Push updates from source to target |
 
 ## Complete Test Lifecycle
 
@@ -53,64 +106,28 @@ This eliminates duplication, maintains traceability, and accelerates the QA proc
 
 See [docs/workflows/test-lifecycle.md](docs/workflows/test-lifecycle.md) for the complete workflow guide.
 
-## Notable Features
+## Agent Skills
 
-| Feature | Description |
-|---------|-------------|
-| **Single Source of Truth** | Requirements flow from Jira/Confluence through test design to execution |
-| **MCP Integrations** | Direct access to Atlassian, TestLink, and Playwright via Model Context Protocol |
-| **Agent Skills** | High-level skills route to slash commands, covering complete lifecycle phases |
-| **Slash Commands** | Granular commands for targeted, atomic operations |
-| **Dual-Judge Framework** | Test execution with both deterministic and semantic (LLM) verification |
-| **Layered Architecture** | Skills (routers) → Commands (operations) → MCP tools |
-| **Orchestration Pattern** | Skills and commands detect context and route to focused sub-tasks |
+Skills are the recommended high-level interface. Each skill is a thin router that covers a complete lifecycle phase with a built-in progress checklist, delegating to slash commands for each step.
 
-## Orchestration Pattern
+| Skill | Phase | Description |
+|---|---|---|
+| `/receiving-tickets` | Discover | Fetch Jira ticket, linked issues, Confluence pages; create project workspace |
+| `/planning-tests` | Plan | Detect ticket type, write test plan, publish to Confluence |
+| `/designing-cases` | Design | Write test cases from plan, publish to Confluence |
+| `/drafting-review-email` | Review | Draft stakeholder review email and meeting invite |
+| `/syncing-testlink` | Manage | Sync test cases into TestLink with suites, plans, and assignments |
+| `/executing-tests` | Execute | Execute test plan via browser automation, record pass/fail |
+| `/creating-demo` | — | Create demo PPTX with content outline and browser-verified screenshots |
+| `/analyzing-logs` | Report | Analyze Robot Framework logs, group failures, suggest fixes |
+| `/tracking-changes` | Track | Track QA artifact changes in GitHub with full provenance |
+| `/reviewing-commands` | — | Audit slash commands against quality dimensions and best practices |
 
-Commands use a **detect-and-route** pattern: a short entry-point command reads the project context, classifies it, and routes to the right specialist command. Each command ends with a "Next step" hint so the agent always knows what to do next.
-
-### Orchestration Styles
-
-| Style | Entry Point | How It Works |
-|-------|-------------|--------------|
-| **Sequential Pipeline** | `/jr-trace` | Chains through fetch → structure → docs in a fixed order |
-| **Fan-out Router** | `/tw-plan-init` | Detects type (feature/enhance/bugfix) and routes to one specialist |
-| **Smart Diff** | `/tl-sync` | Compares local files against TestLink, applies only the changes |
-
-### End-to-End Flow
-
-**Using skills (recommended):**
-```
-/receiving-tickets → /planning-tests → /designing-cases → /syncing-testlink → /executing-tests
-                                              │
-                                   /drafting-review-email
-```
-
-**Using commands (granular):**
-```
-/jr-trace → /tw-plan-init → /tw-plan-review → /tw-case-init → /tw-case-review → /tl-sync
-  │              │                                   │
-  ├─ fetch       ├─ feature                          ├─ feature
-  ├─ structure   ├─ enhance                          ├─ enhance
-  ├─ docs        └─ bugfix                           └─ bugfix
-  └─ verify
-```
+See [docs/workflows/skills.md](docs/workflows/skills.md) for invocation patterns, trigger phrases, and MCP requirements per skill.
 
 ## Issue-Driven Development with `dw-*`
 
 The dev workflow commands provide a structured development lifecycle where every change is driven by a GitHub issue.
-
-### Usage
-
-```
-/dw-plan Add cross-repo sync commands     # Break request into GitHub issues
-/dw-implement 27                           # Pick up issue, create branch, implement
-/dw-create-pr 27                           # Push branch, open PR linked to issue
-/dw-review-pr 30                           # Review PR against checklist
-/dw-merge 30                               # Merge PR, clean up branch and labels
-```
-
-### Flow
 
 ```
 /dw-plan → /dw-implement → /dw-create-pr → /dw-review-pr → /dw-merge
@@ -121,100 +138,30 @@ The dev workflow commands provide a structured development lifecycle where every
  labels      branch          & test plan                      clean up
 ```
 
-Each step uses the GitHub issue as the single source of truth. Issues get status labels (`status:in-progress`, `status:needs-review`) and progress comments automatically. The PR's `Fixes #N` auto-closes the issue on merge.
+```
+/dw-plan Add cross-repo sync commands     # Break request into GitHub issues
+/dw-implement 27                           # Pick up issue, create branch, implement
+/dw-create-pr 27                           # Push branch, open PR linked to issue
+/dw-review-pr 30                           # Review PR against checklist
+/dw-merge 30                               # Merge PR, clean up branch and labels
+```
 
-### Branch Naming
-
-Branches follow `issue-<N>-<short-slug>` convention (e.g., `issue-27-release-notes`), keeping the issue linkage visible in git history.
+Branches follow `issue-<N>-<short-slug>` convention (e.g., `issue-27-release-notes`). Issues get status labels and progress comments automatically. The PR's `Fixes #N` auto-closes the issue on merge.
 
 ## Self-Improvement with `/evolve`
 
-The `/evolve` command is an evidence-based self-improvement loop that analyzes project history and proposes actionable improvements to CLAUDE.md, commands, and skills.
-
-### Usage
+The `/evolve` command analyzes project history and proposes improvements to CLAUDE.md, commands, and skills.
 
 ```
 /evolve                     # Full analysis (issues + commits, last 90 days)
 /evolve issues              # Analyze GitHub issues only
 /evolve commits             # Analyze git commits only
 /evolve --since 30d         # Override time range
-/evolve commits --since 30d # Combine arguments
 ```
 
-### 7-Phase Workflow
+**How it works:** Collects GitHub issues, git commits, and session summaries → detects workflow gaps, friction points, usage patterns, and knowledge decay → scores each finding by confidence → proposes grouped actions → applies selected changes with confirmation.
 
-| Phase | Name | What It Does |
-|-------|------|--------------|
-| 0 | Read Prior Reports | Load previous evolve report to establish baseline |
-| 1 | Data Collection | Gather GitHub issues, git commits, file changes, and session summaries |
-| 2 | Pattern Detection | Detect workflow gaps, friction points, usage patterns, and knowledge decay |
-| 3 | Generate Insights | Score each pattern by confidence (Low / Medium / High) with cited evidence |
-| 4 | Evaluate Prior Actions | Check if previously applied actions were effective |
-| 5 | Propose Actions | Group suggestions into CLAUDE.md updates, new/updated commands, skill improvements |
-| 6–7 | Report & Apply | Output structured report, then apply selected actions with confirmation |
-
-### Detection Categories
-
-- **Workflow Gaps** — missing commands, manual steps that could be automated
-- **Friction Points** — recurring fixes, reverts, long issue threads
-- **Usage Patterns** — files always modified together, high-churn directories, unused commands
-- **Knowledge Decay** — CLAUDE.md contradicted by recent commits, stale references
-
-### Integration with `/session-summary`
-
-When session summaries exist at `docs/session_summaries/patterns.md`, `/evolve` incorporates recurring friction points (3+ occurrences become high-confidence insights) and improvement candidates into its analysis.
-
-### Reports
-
-Reports are saved to `docs/evolve/[YYYY-MM-DD]_evolve_report.md` and include an effectiveness scorecard tracking whether prior actions achieved their goals.
-
-## Quick Start
-
-### Installation
-
-Installation is agent-driven — your AI agent reads `CLAUDE.md` and guides you through it.
-
-**From a local clone:**
-```
-git clone https://github.com/dogkeeper886/ai-qa-workflow
-```
-Then tell your AI agent: "Read /path/to/ai-qa-workflow/CLAUDE.md and install the commands I need"
-
-The agent will:
-1. Detect your project context and what MCP servers you have
-2. Recommend relevant modules (e.g., Jira commands if you use mcp-atlassian)
-3. Ask where to install — project folder or home folder
-4. Compare with any existing commands and sync intelligently
-
-### After Installation
-
-1. Restart your IDE to load new commands
-2. Skills available as slash commands (e.g., `/receiving-tickets`)
-3. All commands also available (e.g., `/jr-trace`)
-4. Configure MCP integrations (see [docs/integrations/](docs/integrations/))
-
-### Updating
-
-Same flow — tell your agent to re-read `CLAUDE.md` and it will compare, detect changes, and sync updates.
-
-## Agent Skills
-
-Skills are the recommended high-level interface. Each skill is a thin router that covers a complete lifecycle phase with a built-in progress checklist, routing to slash commands for each step.
-
-| Skill | Invoke as | Phase | Description |
-|---|---|---|---|
-| `receiving-tickets` | `/receiving-tickets` | Discover | Fetch Jira ticket, linked issues, and Confluence pages; create project workspace |
-| `planning-tests` | `/planning-tests` | Plan | Detect ticket type, write test plan, publish to Confluence |
-| `designing-cases` | `/designing-cases` | Design | Write detailed test cases from plan, publish to Confluence |
-| `drafting-review-email` | `/drafting-review-email` | Review | Draft stakeholder review email and meeting invite |
-| `syncing-testlink` | `/syncing-testlink` | Manage | Sync test cases into TestLink with suites, cases, and test plan |
-| `executing-tests` | `/executing-tests` | Execute | Execute test plan via browser automation, record pass/fail results |
-| `creating-demo` | `/creating-demo` | — | Create demo PPTX with content outline and browser-verified screenshots |
-| `analyzing-logs` | `/analyzing-logs` | Report | Analyze Robot Framework logs, group failures, suggest fixes |
-| `tracking-changes` | `/tracking-changes` | Track | Track QA artifact changes in GitHub with full provenance |
-| `reviewing-commands` | `/reviewing-commands` | — | Audit slash commands against quality dimensions and best practices |
-
-See [docs/workflows/skills.md](docs/workflows/skills.md) for invocation patterns, trigger phrases, and MCP requirements per skill.
+**Integration with `/session-summary`:** When session summaries exist, `/evolve` incorporates recurring friction points (3+ occurrences become high-confidence insights) into its analysis. Reports are saved to `docs/evolve/`.
 
 ## Available Commands
 
@@ -249,14 +196,27 @@ Issue-driven development lifecycle: plan issues, implement on branches, open PRs
 `dw-story` · `dw-plan` · `dw-implement` · `dw-create-pr` · `dw-review-pr` · `dw-merge`
 
 ### [Project Commands (pm-*)](commands/project/)
-Cross-cutting project management: bug reports, scrum tasks, meeting invites, and demo materials.
+Cross-cutting project management: bug reports, scrum tasks, meeting invites, demo materials, and script review.
 
-`pm-init` · `pm-bug-report` · `pm-scrum-task` · `pm-meeting-invite` · `pm-demo-content` · `pm-demo-review` · `pm-demo-ppt` · `pm-demo-email`
+`pm-init` · `pm-bug-report` · `pm-scrum-task` · `pm-meeting-invite` · `pm-demo-content` · `pm-demo-review` · `pm-demo-ppt` · `pm-demo-email` · `pm-script-review`
 
 ### [Utility Commands](commands/utility/)
-Text rewriting, log analysis, self-improvement, cross-repo sync, and command quality auditing.
+Text rewriting, log analysis, self-improvement, cross-repo sync, installation auditing, and command quality review.
 
-`rewrite-text` · `robot-log-analyzer` · `evolve` · `session-summary` · `command-review` · `compare` · `sync`
+`rewrite-text` · `robot-log-analyzer` · `evolve` · `session-summary` · `command-review` · `compare` · `sync` · `review-install`
+
+## Notable Features
+
+| Feature | Description |
+|---------|-------------|
+| **Agent-Driven Installation** | No installer script — the AI agent reads CLAUDE.md, detects context, and syncs commands |
+| **Two-Tier Architecture** | Home tier (universal) + project tier (specific) eliminates duplication across projects |
+| **Single Source of Truth** | Requirements flow from Jira/Confluence through test design to execution |
+| **MCP Integrations** | Direct access to Atlassian, TestLink, and Playwright via Model Context Protocol |
+| **Detect-and-Route** | Entry commands classify context (feature/enhance/bugfix) and route to specialist commands |
+| **Agent Skills** | Thin routers covering complete lifecycle phases with progress checklists |
+| **Dual-Judge Framework** | Test execution with both deterministic and semantic (LLM) verification |
+| **Self-Improvement** | `/evolve` analyzes project history and proposes actionable improvements |
 
 ## Documentation
 
@@ -265,6 +225,8 @@ Text rewriting, log analysis, self-improvement, cross-repo sync, and command qua
 - [MCP Atlassian](docs/integrations/mcp-atlassian.md) - Jira and Confluence access
 - [MCP TestLink](docs/integrations/mcp-testlink.md) - Test management
 - [MCP Playwright](docs/integrations/mcp-playwright.md) - Browser automation
+- [MCP WPA](docs/integrations/mcp-wpa.md) - WPA supplicant control
+- [MCP RADIUS SQL](docs/integrations/mcp-radius-sql.md) - RADIUS database queries
 - [Test Framework Template](docs/integrations/test-framework-template.md) - Dual-judge execution
 
 ### Workflows
@@ -276,6 +238,12 @@ Text rewriting, log analysis, self-improvement, cross-repo sync, and command qua
 ### Design
 
 - [Principles](docs/design/principles.md) - Core design guidelines
+- [Orchestration Pattern](docs/design/orchestration.md) - Detect-and-route pattern with sequential, fan-out, and smart-diff styles
+
+### References
+
+- [Command Format](docs/references/command-format.md) - Slash command format specification
+- [Skill Format](docs/references/skill-format.md) - Skill directory and SKILL.md format
 
 ## Related Projects
 
@@ -299,64 +267,46 @@ ai-qa-workflow/
 │   ├── test-workflow/  # Test planning and case workflows (tw-*)
 │   └── utility/        # Utility commands
 ├── skills/
-│   ├── analyzing-logs/        # Phase 6: Robot Framework log analysis
+│   ├── analyzing-logs/        # Robot Framework log analysis
 │   ├── creating-demo/         # Demo PPTX generation
-│   ├── designing-cases/       # Phase 3: Write test cases
-│   ├── drafting-review-email/ # Phase 3: Stakeholder review email
-│   ├── executing-tests/       # Phase 4/6: Browser test execution
-│   ├── planning-tests/        # Phase 2: Create test plan
-│   ├── receiving-tickets/     # Phase 1: Fetch ticket, create workspace
+│   ├── designing-cases/       # Write test cases
+│   ├── drafting-review-email/ # Stakeholder review email
+│   ├── executing-tests/       # Browser test execution
+│   ├── planning-tests/        # Create test plan
+│   ├── receiving-tickets/     # Fetch ticket, create workspace
 │   ├── reviewing-commands/    # Command quality auditing
-│   ├── syncing-testlink/      # Phase 4: Import cases to TestLink
-│   └── tracking-changes/     # GitHub artifact tracking
+│   ├── syncing-testlink/      # Import cases to TestLink
+│   └── tracking-changes/      # GitHub artifact tracking
 ├── templates/          # Project templates
 ├── docs/
-│   ├── design/         # Design principles
+│   ├── design/         # Design principles and patterns
 │   ├── examples/       # Sample command outputs
 │   ├── integrations/   # MCP integration guides
+│   ├── references/     # Command and skill format specs
 │   └── workflows/      # End-to-end workflows
-├── Makefile            # Legacy installation (deprecated — use agent-driven install via CLAUDE.md)
+├── Makefile            # Legacy installation (deprecated)
 └── README.md
 ```
 
 ## For Developers
 
+### Adding New Commands
+
+1. Create markdown file in the appropriate `commands/` subfolder
+2. Follow the standard template (see existing commands for examples)
+3. Tell your AI agent to re-read `CLAUDE.md` and sync the new command
+4. Commit only the source file
+
 ### Adding New Skills
 
-1. Create `skills/<gerund-name>/SKILL.md` with YAML frontmatter (`name`, `description`, `disable-model-invocation`, `tools`)
+1. Create `skills/<gerund-name>/SKILL.md` with YAML frontmatter (`name`, `description`)
 2. Route each step to an existing slash command — skills should not duplicate command logic
 3. Tell your AI agent to re-read `CLAUDE.md` and sync the new skill
 4. Commit only the source file under `skills/`
 
-### Adding New Commands
-
-1. Create markdown file in appropriate `commands/` subfolder
-2. Follow the standard template (see existing commands)
-3. Tell your AI agent to re-read `CLAUDE.md` and sync the new command
-4. Commit only the source file
-
-### Command Template
-
-```markdown
-# Command Name
-
-## Purpose
-One-sentence description
-
-## Input
-- parameter_name (type): Description
-
-## Process
-1. Step one
-2. Step two
-
-## Output
-What gets created
-```
-
 ### Updating Commands
 
-Pull the latest changes, then tell your AI agent to re-read `CLAUDE.md` — it will compare and sync updates automatically.
+Pull the latest changes, then tell your AI agent to re-read `CLAUDE.md` — it will compare and sync updates automatically. Use `/review-install` to audit across projects.
 
 ## License
 

--- a/commands/project/pm-demo-content.md
+++ b/commands/project/pm-demo-content.md
@@ -276,7 +276,7 @@ Based on PROJ-54321:
    - Keep sections flowing naturally
    - Include navigation steps in Slide 4 only when the demo has a single slide; otherwise use a brief transition sentence
 
-6. **Review scripts for overlap** before saving:
+6. **Review scripts for overlap** before saving (for a full narration and flow audit, run `/pm-script-review` after saving):
    - Read all slide scripts in sequence
    - If a script pre-narrates content covered verbatim or near-verbatim on a later slide, trim the earlier occurrence to a transition phrase
    - Slide 4 is the most common offender: if individual demo slides each narrate their own UI element, Slide 4's script should only bridge into the demo — not retell it

--- a/commands/project/pm-script-review.md
+++ b/commands/project/pm-script-review.md
@@ -1,0 +1,178 @@
+# Script Review — Narration & Flow Audit
+
+Review any script (video, demo, presentation) for smooth transitions, simple language, and content value per section. Produces a structured audit with specific rewrites.
+
+**Usage:** `/pm-script-review [SCRIPT_PATH]`
+
+**Arguments:**
+- `$ARGUMENTS` - Path to the script file to review
+
+---
+
+## What This Command Reviews
+
+| Dimension | Question | Goal |
+|-----------|----------|------|
+| **Transitions** | Does each section flow into the next? | Viewer never wonders "why did we jump here?" |
+| **Language** | Can every sentence be spoken aloud naturally? | No jargon walls, no passive voice, no stacked nouns |
+| **Content value** | Does each section earn its time? | Every section teaches, shows, or moves the story forward |
+| **Structure** | Does the overall arc make sense? | Clear beginning → middle → end with rising interest |
+
+---
+
+## Agent Instructions
+
+### Phase 1: Read and Map
+
+1. **Read** the script at `$ARGUMENTS`
+2. **Map the structure** — list each section with:
+   - Section name and time range (if given)
+   - One-sentence summary of what it covers
+   - Key claim or message
+
+### Phase 2: Transition Audit
+
+Check the **last sentence of each section** and the **first sentence of the next**:
+
+1. **Bridge exists?** — Does the section end with a sentence that leads into the next topic?
+2. **Bridge quality** — A good bridge:
+   - Closes the current topic ("That handles installation.")
+   - Opens the next with a question or promise ("But where do these commands actually live?")
+   - Feels like natural speech, not a chapter heading
+3. **Flag missing bridges** — If a section ends cold (no connection to what follows), flag it
+
+**Common bridge patterns:**
+- Question bridge: "That's the workflow. But how does the toolkit get better over time?"
+- Consequence bridge: "Once that's set up, the next thing you'll want is..."
+- Contrast bridge: "That works for one project. But what about ten?"
+
+### Phase 3: Sentence-Level Language Audit
+
+Read each sentence aloud (mentally). Flag sentences that:
+
+| Problem | Test | Example |
+|---------|------|---------|
+| **Jargon wall** | 3+ technical terms in one sentence | "MCP integrates RADIUS LDAP via proxy" |
+| **Noun stack** | 3+ nouns without a verb | "test management system configuration interface" |
+| **Passive voice** | Subject receives action | "installation is driven by the agent" → "the agent handles installation" |
+| **Filler opening** | Sentence starts with empty words | "Basically, what happens is..." → cut to the point |
+| **Acronym overload** | Undefined acronym on first use | Define on first use or drop it |
+| **Long sentence** | More than 25 words spoken aloud | Split into two sentences |
+| **Repeat within earshot** | Same word/phrase used within 2 sentences | Vary the phrasing |
+
+For each flagged sentence, provide:
+- **Original:** the sentence as written
+- **Problem:** which issue from the table above
+- **Rewrite:** a simpler version
+
+### Phase 4: Content Value Audit
+
+For each section, evaluate:
+
+1. **Does it earn its time?**
+   - A 90-second section should deliver at least one clear takeaway
+   - If you can't state the takeaway in one sentence, the section is unfocused
+
+2. **Is it the right level of detail?**
+   - Too much detail: listing every sub-feature when one example would do
+   - Too little detail: making a claim without showing evidence
+
+3. **Would the audience care?**
+   - Implementation details (architecture, internal naming) rarely matter to viewers
+   - Pain points and before/after comparisons always matter
+
+4. **Is anything repeated?**
+   - Same concept explained in two sections → consolidate into the stronger one
+   - Same tool mentioned in passing multiple times → give it one home
+
+Rate each section:
+
+| Rating | Meaning |
+|--------|---------|
+| **Strong** | Clear takeaway, right detail level, audience cares |
+| **Trim** | Good content but too long or too detailed — cut to essentials |
+| **Weak** | No clear takeaway or audience won't care — cut or merge |
+| **Move** | Content belongs in a different section |
+
+### Phase 5: Structure & Arc Check
+
+Evaluate the overall flow:
+
+1. **Hook** — Does the intro make the viewer want to stay? First 15 seconds decide.
+2. **Rising interest** — Do sections build on each other? Best order: problem → solution → proof → surprise.
+3. **Strongest section placement** — The most compelling content should be in the first half, not buried at the end.
+4. **Surprise moment** — Does the script include at least one unexpected result, discovery, or "I didn't expect that" moment? These keep viewers engaged.
+5. **Ending** — Does the outro close with a clear call to action, not a fade-out?
+
+If the structure needs reordering, propose a **revised section order** with rationale.
+
+---
+
+## Output Format
+
+### 1. Structure Map
+
+| # | Section | Time | Summary | Rating |
+|---|---------|------|---------|--------|
+| 1 | Intro | 0:00–0:45 | What the toolkit does | Strong |
+| 2 | ... | ... | ... | ... |
+
+### 2. Transition Report
+
+| Between | Status | Suggested Bridge |
+|---------|--------|-----------------|
+| Intro → S1 | Good | — |
+| S1 → S2 | Missing | "That handles installation. But where do these commands live?" |
+| ... | ... | ... |
+
+### 3. Language Fixes
+
+| Section | Original | Problem | Rewrite |
+|---------|----------|---------|---------|
+| Intro | "connects AI coding agents with test management systems through MCP" | Jargon wall | "connects AI agents to tools like Jira and TestLink" |
+| ... | ... | ... | ... |
+
+### 4. Content Value
+
+| Section | Rating | Recommendation |
+|---------|--------|---------------|
+| S5: Architecture | Weak | Cut — "thin routers" means nothing to new viewers. Fold one sentence into outro. |
+| ... | ... | ... |
+
+### 5. Recommended Structure (if changes needed)
+
+| # | Section | Duration | What changed |
+|---|---------|----------|-------------|
+| ... | ... | ... | ... |
+
+### 6. Revised Script (if requested)
+
+If the user asks for a revised script, apply all fixes and output the full updated script.
+
+---
+
+## Phrase Simplification Reference
+
+Common script jargon and their plain alternatives:
+
+| Technical | Plain |
+|-----------|-------|
+| "leverages" | "uses" |
+| "utilizes" | "uses" |
+| "facilitates" | "helps" or "lets you" |
+| "is driven by" | "the [subject] handles" |
+| "diffs and syncs" | "finds what changed and updates" |
+| "integrates with" | "works with" or "connects to" |
+| "comprehensive" | cut — add specifics instead |
+| "robust" | cut — show don't tell |
+| "seamlessly" | cut — if it's seamless, the viewer will see it |
+| "end-to-end" | "start to finish" or "the whole process" |
+
+---
+
+## When to Use
+
+- After writing a video script, demo script, or presentation script
+- Before recording — catch issues while editing is cheap
+- When a script "feels off" but you can't pinpoint why
+- As a second pass after `/pm-demo-content` generates presenter scripts

--- a/docs/design/orchestration.md
+++ b/docs/design/orchestration.md
@@ -1,0 +1,30 @@
+# Orchestration Pattern
+
+Commands use a **detect-and-route** pattern: a short entry-point command reads the project context, classifies it, and routes to the right specialist command. Each command ends with a "Next step" hint so the agent always knows what to do next.
+
+## Orchestration Styles
+
+| Style | Entry Point | How It Works |
+|-------|-------------|--------------|
+| **Sequential Pipeline** | `/jr-trace` | Chains through fetch → structure → docs in a fixed order |
+| **Fan-out Router** | `/tw-plan-init` | Detects type (feature/enhance/bugfix) and routes to one specialist |
+| **Smart Diff** | `/tl-sync` | Compares local files against TestLink, applies only the changes |
+
+## End-to-End Flow
+
+**Using skills (recommended):**
+```
+/receiving-tickets → /planning-tests → /designing-cases → /syncing-testlink → /executing-tests
+                                              │
+                                   /drafting-review-email
+```
+
+**Using commands (granular):**
+```
+/jr-trace → /tw-plan-init → /tw-plan-review → /tw-case-init → /tw-case-review → /tl-sync
+  │              │                                   │
+  ├─ fetch       ├─ feature                          ├─ feature
+  ├─ structure   ├─ enhance                          ├─ enhance
+  ├─ docs        └─ bugfix                           └─ bugfix
+  └─ verify
+```

--- a/docs/v3.0-video-script.md
+++ b/docs/v3.0-video-script.md
@@ -4,7 +4,7 @@
 **AI QA Workflow v3.0: From Makefile to Agent-Driven Installation**
 
 ## Estimated Duration
-8–10 minutes
+7–8 minutes
 
 ---
 
@@ -12,9 +12,9 @@
 
 **[Screen: GitHub repo landing page]**
 
-> AI QA Workflow is an open-source toolkit that connects AI coding agents with test management systems — Jira, Confluence, TestLink, Playwright — through MCP.
+> AI QA Workflow is an open-source toolkit that connects AI agents to tools like Jira, TestLink, and Playwright.
 >
-> v3.0 is a major update. The headline: **installation is now driven by the AI agent itself**. Let me show you what that means.
+> v3.0 is a major update. The headline: **the AI agent handles its own installation**. Let me show you what that means.
 
 ---
 
@@ -28,11 +28,13 @@
 
 **[Demo: show the agent reading CLAUDE.md]**
 
-> The agent reads CLAUDE.md, checks what MCP servers I have configured, sees what's already installed, and recommends the right modules. It asks where to install, compares with what I have, and syncs only the differences.
+> The agent reads CLAUDE.md, checks what tools I have configured, sees what's already installed, and recommends the right modules. It asks where to install, compares with what I have, and syncs only the differences.
 >
-> Updates work the same way. Pull the latest, tell the agent to re-read CLAUDE.md — it diffs and syncs. The agent IS the installer.
+> Updates work the same way. Pull the latest, tell the agent to re-read CLAUDE.md — it finds what changed and updates only those files. The agent IS the installer.
 
 **[Screen: show agent output with compare/sync results]**
+
+> That handles installation. But where do these commands actually live?
 
 ---
 
@@ -42,15 +44,15 @@
 
 > With 10+ projects, I had the same commands duplicated everywhere. Six copies of `/evolve`, six copies of `/dw-plan`. When I fixed a bug in one, the others stayed broken.
 >
-> v3.0 solves this with two tiers:
->
-> **Home tier** — `~/.claude/commands/`. Loads in every project. Universal commands like `/evolve`, `/compare`, `/sync`, and the dev workflow live here. Install once, use everywhere.
->
-> **Project tier** — `.claude/commands/` inside a repo. Project-specific commands that need specific MCP servers — Jira commands, TestLink commands.
+> v3.0 solves this with two tiers. Universal commands — like `/evolve` and the dev workflow — go in your home folder. Install once, use everywhere. Project-specific commands — Jira, TestLink — stay inside the repo.
 
 **[Demo: run `/review-install`]**
 
 > `/review-install` audits your setup. It catches duplicates, misplacements, and drift. I ran this across all my projects and found 15 duplicated commands I could delete.
+>
+> `/compare` detects what's out of sync between this source repo and your installed commands. `/sync` pushes the updates. One source of truth, many projects.
+
+> Let me show you what working with these commands looks like day to day.
 
 ---
 
@@ -58,19 +60,17 @@
 
 **[Screen: terminal demo of dw-* commands]**
 
-> Let me show you how I built this release using its own dev workflow commands.
+> I built this release using its own dev workflow commands.
 >
 > I started with `/dw-plan` — "add review-install command and tier design." It created GitHub issue #45 with labels.
 >
-> `/dw-implement 45` created branch `issue-45-review-install`, and the agent started coding.
->
-> `/dw-create-pr 45` pushed and opened a PR with `Fixes #45` in the body.
->
-> `/dw-review-pr 45` ran the review checklist. `/dw-merge 45` merged it, auto-closed the issue, and deleted the branch.
+> `/dw-implement 45` created the branch and the agent started coding. When it was ready, `/dw-create-pr` opened a PR linked to the issue.
 
 **[Demo: show GitHub issue #45 and its PR]**
 
-> Five commands, zero manual bookkeeping. The GitHub issue is the single source of truth throughout.
+> Five commands, start to finish. The GitHub issue is the single source of truth — from plan to merge.
+
+> That's the workflow. But how does the toolkit itself get better over time?
 
 ---
 
@@ -78,37 +78,23 @@
 
 **[Screen: terminal running /evolve]**
 
-> Here's my favorite. After working on this project for months, I ran `/evolve` to see what it would find.
+> Here's my favorite part. After working on this project for months, I ran `/evolve` to see what it would find.
 >
-> It scanned my GitHub issues and git history, and flagged that I had duplicated HTML formatting logic across 18 TestLink commands. That became issue #31 — the `/tl-format` consolidation.
+> It scanned my GitHub issues and git history, and flagged that I had duplicated HTML formatting logic across 18 TestLink commands. I'd been maintaining these commands for months and never noticed. The agent found it in 30 seconds. That became issue #31.
 >
-> It also noticed I kept fixing the same nested markdown fence bug in GitHub commands. That pattern led to issue #24.
+> It also spotted a pattern — I kept fixing the same nested markdown fence bug in GitHub commands. That led to issue #24.
 
 **[Screen: show evolve report output]**
 
-> `/evolve` feeds on `/session-summary` — which records what happened in each conversation, privacy-safe. The more you use the toolkit, the smarter `/evolve` gets at finding friction.
->
-> `/compare` and `/sync` close the loop. `/compare` detects drift between this source repo and your installed commands. `/sync` pushes updates. One source of truth, many projects.
+> `/evolve` builds on `/session-summary` — which records what happened in each conversation, no credentials, no private data, just what happened. The more you use the toolkit, the smarter `/evolve` gets at finding friction.
 
 ---
 
-## SECTION 5: Architecture Improvements (7:30 – 8:00)
-
-**[Screen: code diffs]**
-
-> Under the hood:
->
-> **Skills are now thin routers** — they list the steps, commands do the work. Easier to maintain, easier to understand.
->
-> **Test planning uses user-journey scenarios** — `tw-plan-feature` now walks through real user paths instead of just listing features to test.
-
----
-
-## OUTRO (8:00 – 8:30)
+## OUTRO (7:30 – 8:00)
 
 **[Screen: GitHub release page]**
 
-> That's v3.0. The agent installs, updates, audits, and improves the toolkit itself.
+> That's v3.0. The agent installs, updates, audits, and improves the toolkit itself. Under the hood, we also simplified how skills and test planning work — details in the release notes.
 >
 > Clone the repo, point your AI agent at CLAUDE.md, and let it set you up. Links in the description.
 
@@ -119,7 +105,7 @@
 - [ ] GitHub repo landing page
 - [ ] Terminal: agent reading CLAUDE.md and installing
 - [ ] Terminal: `/review-install` audit output
+- [ ] Terminal: `/compare` drift detection
 - [ ] GitHub: issue #45 and its linked PR (dev workflow story)
 - [ ] Terminal: `/evolve` report showing #31 and #24 discoveries
-- [ ] Terminal: `/compare` drift detection
 - [ ] GitHub: v3.0 release page

--- a/docs/v3.0-video-script.md
+++ b/docs/v3.0-video-script.md
@@ -12,9 +12,9 @@
 
 **[Screen: GitHub repo landing page]**
 
-> AI QA Workflow is an open-source toolkit that connects AI agents to tools like Jira, TestLink, and Playwright.
+> AI QA Workflow is a QA automation toolkit that connects AI coding agents with test management systems through MCP. Slash commands and agent skills cover the full test lifecycle — from Jira ticket to TestLink execution.
 >
-> v3.0 is a major update. The headline: **the AI agent handles its own installation**. Let me show you what that means.
+> v3.0 is a major update. The headline: **the AI agent handles its own installation** — no installer script, no build step. Let me show you what that means.
 
 ---
 
@@ -24,11 +24,11 @@
 
 > Here's the problem I had. I maintain over 10 projects. Every time I updated a command in ai-qa-workflow, I had to run `make install`, then go to each project and copy files manually. I kept forgetting which project had which version. It was a mess.
 >
-> Now, I just tell my AI agent: "Read CLAUDE.md and install the commands I need."
+> Now, I just tell my AI agent: "Read CLAUDE.md and install the commands I need." That's it — one sentence.
 
 **[Demo: show the agent reading CLAUDE.md]**
 
-> The agent reads CLAUDE.md, checks what tools I have configured, sees what's already installed, and recommends the right modules. It asks where to install, compares with what I have, and syncs only the differences.
+> The agent reads CLAUDE.md, detects my project context and configured MCP servers, sees what's already installed, and recommends the right modules. It asks where to install — home folder or project folder — compares with what I have, and syncs only the differences.
 >
 > Updates work the same way. Pull the latest, tell the agent to re-read CLAUDE.md — it finds what changed and updates only those files. The agent IS the installer.
 
@@ -44,13 +44,13 @@
 
 > With 10+ projects, I had the same commands duplicated everywhere. Six copies of `/evolve`, six copies of `/dw-plan`. When I fixed a bug in one, the others stayed broken.
 >
-> v3.0 solves this with two tiers. Universal commands — like `/evolve` and the dev workflow — go in your home folder. Install once, use everywhere. Project-specific commands — Jira, TestLink — stay inside the repo.
+> v3.0 solves this with two tiers. Universal commands — like `/evolve` and the dev workflow — go in your home folder at `~/.claude/commands/`. Install once, use everywhere. Project-specific commands that need specific MCP servers — Jira, TestLink — stay inside the repo.
 
 **[Demo: run `/review-install`]**
 
 > `/review-install` audits your setup. It catches duplicates, misplacements, and drift. I ran this across all my projects and found 15 duplicated commands I could delete.
 >
-> `/compare` detects what's out of sync between this source repo and your installed commands. `/sync` pushes the updates. One source of truth, many projects.
+> `/compare` previews drift between this source repo and your installed commands. `/sync` pushes the updates. One source of truth, many projects.
 
 > Let me show you what working with these commands looks like day to day.
 
@@ -94,9 +94,9 @@
 
 **[Screen: GitHub release page]**
 
-> That's v3.0. The agent installs, updates, audits, and improves the toolkit itself. Under the hood, we also simplified how skills and test planning work — details in the release notes.
+> That's v3.0. The agent installs, updates, audits, and improves the toolkit itself.
 >
-> Clone the repo, point your AI agent at CLAUDE.md, and let it set you up. Links in the description.
+> Clone the repo, tell your AI agent to read CLAUDE.md, and let it set you up. Links in the description.
 
 ---
 

--- a/docs/v3.0-video-script.md
+++ b/docs/v3.0-video-script.md
@@ -12,7 +12,7 @@
 
 **[Screen: GitHub repo landing page]**
 
-> AI QA Workflow is a QA automation toolkit that connects AI coding agents with test management systems through MCP. Slash commands and agent skills cover the full test lifecycle — from Jira ticket to TestLink execution.
+> AI QA Workflow is an open-source toolkit that lets AI agents automate your entire test lifecycle — from receiving a Jira ticket all the way to recording results in TestLink.
 >
 > v3.0 is a major update. The headline: **the AI agent handles its own installation** — no installer script, no build step. Let me show you what that means.
 


### PR DESCRIPTION
## Summary
- Rewrite README with install-first structure — Quick Start and Two-Tier Architecture moved near top, orchestration pattern moved to `docs/design/orchestration.md`
- Add `pm-script-review` command for reviewing video/demo/presentation scripts (transitions, language, content value, structure)
- Revise v3.0 video script — add section bridges, simplify language, cut weak section, tighten to 7–8 minutes
- Remove hardcoded command counts from README and CLAUDE.md to prevent staleness

## Test plan
- [ ] Verify all internal links in README resolve correctly
- [ ] Verify `docs/design/orchestration.md` content matches what was removed from README
- [ ] Run `/pm-script-review` against the revised video script to validate the new command works
- [ ] Check no command counts remain in directory structure sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)