### PR TITLE
Add dw-tasks and make dev-workflow story-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,12 @@ Everything else (code changes, new commands/skills, refactors) requires a featur
 For structured issue-driven development, use the `dw-*` commands:
 1. `/dw-story` — Create structured user story from requirements
 2. `/dw-plan` — Break request into GitHub issues with labels
-3. `/dw-implement` — Pick up issue, create branch, implement
-4. `/dw-test-design` — Design tests for the implementation (detects project test infra)
-5. `/dw-create-pr` — Push and open PR with issue linkage
-6. `/dw-review-pr` — Review PR against checklist (adapts to CI presence)
-7. `/dw-merge` — Merge PR and clean up
+3. `/dw-tasks` — Break an existing story file into GitHub issues
+4. `/dw-implement` — Pick up issue, create branch, implement (story-aware)
+5. `/dw-test-design` — Design tests for the implementation (detects project test infra)
+6. `/dw-create-pr` — Push and open PR with issue linkage (story-aware)
+7. `/dw-review-pr` — Review PR against checklist (adapts to CI and project type)
+8. `/dw-merge` — Merge PR and clean up (story-aware)
 
 ## Information Leak Check
 

--- a/commands/dev-workflow/dw-create-pr.md
+++ b/commands/dev-workflow/dw-create-pr.md
@@ -21,6 +21,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │   - Run: git status — check for uncommitted changes
         │   - Run: git log --oneline main..HEAD — review commits
         │   - If no argument given, infer issue number from branch name
+        │   - Run: gh issue view <N> — check if title contains [STORY-XXX]
         │
         ├─► Step 2: Push Branch
         │   - Run: git push -u origin $(git branch --show-current)
@@ -35,6 +36,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │       <1-3 bullet points>
         │
         │       Fixes #<issue-number>
+        │       (if linked to story: "Part of STORY-XXX")
         │
         │       ## Test plan
         │       - [ ] ...
@@ -49,7 +51,12 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │   - Comment on issue:
         │     gh issue comment <N> --body "PR #<PR> created. Summary: <what changed>"
         │
-        └─► Step 5: Report
+        ├─► Step 5: Update Story File (if linked)
+        │   - If the issue title contains [STORY-XXX]:
+        │     update docs/stories/STORY-XXX.md status to reflect PR is open
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        └─► Step 6: Report
             - Show the PR URL to the user
             - Suggest next step: /dw-review-pr <PR>
 

--- a/commands/dev-workflow/dw-implement.md
+++ b/commands/dev-workflow/dw-implement.md
@@ -22,6 +22,8 @@ and prepares for PR creation when done.
         │   - Read acceptance criteria, technical notes, dependencies
         │   - Check labels — type and priority should already be set
         │   - Check for linked/blocking issues
+        │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for full context (user story, broader acceptance criteria, related tasks)
         │   - If anything is unclear, ask the user before starting
         │
         ├─► Step 2: Create Branch
@@ -42,6 +44,8 @@ and prepares for PR creation when done.
         ├─► Step 4a: On Success
         │   - Comment on issue:
         │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
+        │   - If linked to STORY-XXX, update docs/stories/STORY-XXX.md:
+        │     check off completed acceptance criteria for this task
         │   - Proceed to /dw-create-pr
         │
         ├─► Step 4b: On Failure

--- a/commands/dev-workflow/dw-merge.md
+++ b/commands/dev-workflow/dw-merge.md
@@ -22,9 +22,10 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: gh pr checks <PR>
         │   - CI checks must pass (if applicable)
         │
-        ├─► Step 2: Identify Linked Issue
+        ├─► Step 2: Identify Linked Issue and Story
         │   - Read PR body for "Fixes #N" or "Closes #N"
         │   - Note the issue number for label cleanup
+        │   - Check if PR body or issue title contains [STORY-XXX] or "Part of STORY-XXX"
         │
         ├─► Step 3: Merge
         │   - Run: gh pr merge <PR> --merge --delete-branch
@@ -35,13 +36,21 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: gh issue edit <N> --remove-label "status:needs-review"
         │   - Issue auto-closes via "Fixes #N" — no manual close needed
         │
-        ├─► Step 5: Clean Up Local Branch
+        ├─► Step 5: Update Story File (if linked)
+        │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
+        │     • Check off completed acceptance criteria for this task
+        │     • If all story tasks are closed, mark story status as Completed
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        ├─► Step 6: Clean Up Local Branch
         │   - Run: git checkout main && git pull
         │   - Run: git branch -d <branch-name>
         │
-        └─► Step 6: Report
+        └─► Step 7: Report
             - Confirm merge to the user
             - Show the merged PR URL
+            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
+            - If story is complete, mention it
             - Mention any follow-up issues if applicable
 
 ---

--- a/commands/dev-workflow/dw-review-pr.md
+++ b/commands/dev-workflow/dw-review-pr.md
@@ -52,6 +52,12 @@ code quality, test coverage, and documentation. Approves or requests changes.
         │   IF Containerized:
         │   - [ ] Dockerfile follows best practices (multi-stage, non-root)
         │   - [ ] No secrets in image layers
+        │   IF Python:
+        │   - [ ] Type hints on public functions
+        │   - [ ] No bare except clauses
+        │   IF Go:
+        │   - [ ] Errors are checked, not discarded
+        │   - [ ] No goroutine leaks (context cancellation handled)
         │   (Skip this section silently if no project type detected)
         │
         │   Test Coverage (adaptive — detect what the project uses):

--- a/commands/dev-workflow/dw-review-pr.md
+++ b/commands/dev-workflow/dw-review-pr.md
@@ -34,6 +34,26 @@ code quality, test coverage, and documentation. Approves or requests changes.
         │   - [ ] No security vulnerabilities (injection, hardcoded secrets)
         │   - [ ] No debug/temporary code left in
         │
+        │   Project-Type Checks (detect and apply relevant items):
+        │   - Detect project type by scanning for markers:
+        │     • src/mcpServer.ts or @modelcontextprotocol/sdk → MCP server
+        │     • package.json with react/next → Frontend
+        │     • Dockerfile or docker-compose.yml → Containerized
+        │     • pyproject.toml or setup.py → Python
+        │     • go.mod → Go
+        │
+        │   IF MCP server:
+        │   - [ ] Service function follows existing patterns in services/
+        │   - [ ] Tool registered with clear description (REQUIRED/PREREQUISITE refs)
+        │   - [ ] Async operations use standard retry/polling pattern
+        │   IF Frontend:
+        │   - [ ] No console.log left in production code
+        │   - [ ] Components follow existing patterns
+        │   IF Containerized:
+        │   - [ ] Dockerfile follows best practices (multi-stage, non-root)
+        │   - [ ] No secrets in image layers
+        │   (Skip this section silently if no project type detected)
+        │
         │   Test Coverage (adaptive — detect what the project uses):
         │   - Detect CI: .github/workflows/, .gitlab-ci.yml, Jenkinsfile, .circleci/
         │   - Detect test infra: cicd/tests/, tests/, __tests__/, *_test.go, *.robot

--- a/commands/dev-workflow/dw-tasks.md
+++ b/commands/dev-workflow/dw-tasks.md
@@ -70,7 +70,6 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
         │     - Created: [original date]
         │     - Tasks: #1, #2, #3
         │     - Tests: none
-        │   - Commit the story file update
         │
         └─► Step 7: Report
             - Show table of created issues:

--- a/commands/dev-workflow/dw-tasks.md
+++ b/commands/dev-workflow/dw-tasks.md
@@ -1,0 +1,123 @@
+# Break Story into GitHub Issues
+
+```
+Read a user story file and create GitHub issues for each task.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Reads an existing story file from `docs/stories/STORY-XXX.md` and breaks it into
+implementable GitHub issues. Each issue is linked back to the story via title prefix.
+Updates the story file with created issue numbers.
+
+Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue):
+
+    dw-story → dw-tasks → dw-implement → dw-create-pr → dw-review-pr → dw-merge
+
+---
+
+## WORKFLOW
+
+    /dw-tasks STORY-003
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - Extract: title, acceptance criteria, technical notes
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Break into Tasks
+        │   - Analyze the story and break it into tasks
+        │   - Each task should be:
+        │     • Small — completable in one session
+        │     • Independent — minimal dependencies between tasks
+        │     • Testable — has a clear done condition
+        │   - Detect project type to suggest task breakdown:
+        │     • Check project structure, CLAUDE.md, and existing code patterns
+        │     • Use these to inform sensible task boundaries
+        │   - Present the proposed task list to the user for approval
+        │
+        ├─► Step 3: Check for Duplicates
+        │   - Run: gh issue list --search "[STORY-XXX]" --state all
+        │   - If matching issues exist, report and ask user how to proceed
+        │
+        ├─► Step 4: Create Labels (idempotent)
+        │   - Ensure labels exist (same as /dw-plan):
+        │     • type labels: feature, enhancement, bug, docs
+        │     • priority labels: priority:high, priority:medium, priority:low
+        │     • status labels: status:in-progress, status:needs-review, status:blocked
+        │   - Use: gh label create "<name>" --color "<hex>" --force
+        │
+        ├─► Step 5: Create GitHub Issues
+        │   - One issue per task
+        │   - Title: [STORY-XXX] Task description
+        │   - Body:
+        │       ## Context
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md)
+        │
+        │       ## Acceptance Criteria
+        │       - [ ] [criterion from task breakdown]
+        │
+        │       ## Technical Notes
+        │       [relevant notes from the story]
+        │   - Labels: type + priority (infer from story content)
+        │   - Link related issues: "Part of STORY-XXX"
+        │
+        ├─► Step 6: Update Story File
+        │   - Update the Status section in docs/stories/STORY-XXX.md:
+        │     ## Status
+        │     - Created: [original date]
+        │     - Tasks: #1, #2, #3
+        │     - Tests: none
+        │   - Commit the story file update
+        │
+        └─► Step 7: Report
+            - Show table of created issues:
+              | Issue | Title | Type | Priority |
+            - Suggest implementation order based on dependencies
+            - Suggest: /dw-implement <N> to start on the first task
+
+---
+
+## EXAMPLE
+
+    /dw-tasks STORY-003
+
+**Agent reads story, breaks into tasks, creates issues:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --search "[STORY-003]" --state all
+    $ gh issue create --title "[STORY-003] Add input validation" \
+        --label "enhancement" --label "priority:high" \
+        --body "## Context\nPart of STORY-003\n\n## Acceptance Criteria\n..."
+    $ gh issue create --title "[STORY-003] Add error response formatting" \
+        --label "enhancement" --label "priority:medium" \
+        --body "..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Tasks: #15, #16
+    - Tests: none
+
+**Output:**
+
+    | Issue | Title                              | Type        | Priority |
+    |-------|------------------------------------|-------------|----------|
+    | #15   | [STORY-003] Add input validation   | enhancement | high     |
+    | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Suggested order: #15 → #16
+    Start: /dw-implement 15
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
+- Issue titles use `[STORY-XXX]` prefix for traceability
+- The story file is the persistent record linking requirements → tasks → tests
+```


### PR DESCRIPTION
## Summary

- Add `dw-tasks` command: reads `docs/stories/STORY-XXX.md` and breaks it into GitHub issues with `[STORY-XXX]` prefixed titles
- Make `dw-implement`, `dw-create-pr`, `dw-merge` story-aware: detect `[STORY-XXX]` in issue titles, read story for context, update story status as work progresses
- Make `dw-review-pr` extensible: detect project type (MCP server, frontend, containerized, Python, Go) and add type-specific checklist items

Backported from ruckus1-mcp project-level adaptations, generalized for any project. Story tracking is opportunistic — skips silently when no story link exists.

Fixes #50, Fixes #51, Fixes #52

## Test plan

- [ ] Verify dw-tasks creates issues with [STORY-XXX] prefix from a story file
- [ ] Verify dw-implement reads story context when issue has [STORY-XXX] in title
- [ ] Verify dw-create-pr includes story reference in PR body
- [ ] Verify dw-merge updates story status and suggests next task
- [ ] Verify dw-review-pr detects MCP server projects and adds relevant checks
- [ ] Verify all commands still work normally for issues without story links

🤖 Generated with [Claude Code](https://claude.com/claude-code)