### PR TITLE
Backport graph-path check, ISO 29119 format, and typography audit from r1-test-cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ skills/
 ├── receiving-tickets/    # Fetch Jira ticket + set up project workspace
 ├── planning-tests/       # Create test plan from ticket, publish to Confluence
 ├── designing-cases/      # Write test cases from plan, publish to Confluence
+├── reviewing-typography/ # Audit just-published Confluence pages for proximity / hierarchy issues
 ├── drafting-review-email/ # Draft stakeholder review email + meeting invite
 ├── syncing-testlink/     # Import test cases into TestLink, build test plan
 ├── executing-tests/      # Execute TestLink plan via browser automation
@@ -218,6 +219,7 @@ Skills are loaded on demand. The agent reads this table to decide which skill to
 | `receiving-tickets` | When given a Jira ticket ID to investigate or start a new QA project |
 | `planning-tests` | When requirements are gathered and a test plan is needed |
 | `designing-cases` | When a test plan exists and detailed test cases need to be written |
+| `reviewing-typography` | After `planning-tests` / `designing-cases` publish — audit the just-published Confluence pages for proximity + hierarchy problems on actual rendered content |
 | `drafting-review-email` | When test artifacts are ready for stakeholder review |
 | `syncing-testlink` | When test cases need to be imported into TestLink |
 | `executing-tests` | When a TestLink test plan is ready for browser-based execution |
@@ -232,11 +234,12 @@ Skills are thin routers — each SKILL.md contains the step sequence and progres
 
 The test lifecycle flows through 6 phases:
 1. **Discover** - Gather requirements via `/jr-trace`
-2. **Plan** - Create test strategy via `/tw-plan-init` (routes to feature/enhance/bugfix)
-3. **Design** - Write test cases via `/tw-case-init` (routes to feature/enhance/bugfix)
-4. **Manage** - Import to TestLink via `/tl-create-case`
-5. **Automate** - Create YAML tests with test-framework-template
-6. **Execute** - Run tests and record via `/tl-create-execution`
+2. **Baseline** - Capture live UI state via `/tw-baseline-trace` (recommended before planning)
+3. **Plan** - Create test strategy via `/tw-plan-init` (routes to feature/enhance/bugfix). Plans follow the ISO/IEC/IEEE 29119-3 layout: `test_plan/sections/` (lean strategy) + `test_plan/test_design/{scenarios/, traceability_matrix.md, risk_register.md}`. The Confluence publish runs `reviewing-typography` as its final gate.
+4. **Design** - Write test cases via `/tw-case-init` (routes to feature/enhance/bugfix); same typography gate after publish
+5. **Manage** - Import to TestLink via `/tl-create-case`
+6. **Automate** - Create YAML tests with test-framework-template
+7. **Execute** - Run tests and record via `/tl-create-execution`
 
 ## TestLink HTML Formatting
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Skills are the recommended high-level interface. Each skill is a thin router tha
 | Skill | Phase | Description |
 |---|---|---|
 | `/receiving-tickets` | Discover | Fetch Jira ticket, linked issues, Confluence pages; create project workspace |
-| `/planning-tests` | Plan | Detect ticket type, write test plan, publish to Confluence |
+| `/planning-tests` | Plan | Detect ticket type, write test plan, publish to Confluence (ISO 29119-3 layout) |
 | `/designing-cases` | Design | Write test cases from plan, publish to Confluence |
+| `/reviewing-typography` | Design | Audit just-published Confluence pages for typography (Gestalt proximity + visual hierarchy) — runs after `planning-tests` / `designing-cases` publish |
 | `/drafting-review-email` | Review | Draft stakeholder review email and meeting invite |
 | `/syncing-testlink` | Manage | Sync test cases into TestLink with suites, plans, and assignments |
 | `/executing-tests` | Execute | Execute test plan via browser automation, record pass/fail |
@@ -176,9 +177,9 @@ Summarize, convert, create, update, and review Confluence pages.
 `cf-page-summary` · `cf-to-markdown` · `cf-create-page` · `cf-update-page` · `cf-review-page` · `cf-format-guide`
 
 ### [Test Workflow Commands (tw-*)](commands/test-workflow/)
-Plan test strategies and design test cases, with fan-out routing by ticket type (feature/enhance/bugfix).
+Plan test strategies and design test cases, with fan-out routing by ticket type (feature/enhance/bugfix). Includes `tw-baseline-trace` to capture the live UI state via Playwright before scenarios are drafted (anchors the plan in observable reality, prevents over-specified test plans — see `skills/planning-tests/references/scenario-conventions.md`).
 
-`tw-plan-init` · `tw-plan-feature` · `tw-plan-enhance` · `tw-plan-bugfix` · `tw-plan-review` · `tw-case-init` · `tw-case-feature` · `tw-case-enhance` · `tw-case-bugfix` · `tw-case-review` · `tw-case-publish` · `tw-case-verify-refs` · `tw-diagrams` · `tw-script-review` · `tw-templates`
+`tw-baseline-trace` · `tw-plan-init` · `tw-plan-feature` · `tw-plan-enhance` · `tw-plan-bugfix` · `tw-plan-review` · `tw-case-init` · `tw-case-feature` · `tw-case-enhance` · `tw-case-bugfix` · `tw-case-review` · `tw-case-publish` · `tw-case-verify-refs` · `tw-diagrams` · `tw-script-review` · `tw-templates`
 
 ### [TestLink Commands (tl-*)](commands/testlink/)
 Manage test suites, cases, plans, and execution results in TestLink via MCP.
@@ -272,9 +273,10 @@ ai-qa-workflow/
 │   ├── designing-cases/       # Write test cases
 │   ├── drafting-review-email/ # Stakeholder review email
 │   ├── executing-tests/       # Browser test execution
-│   ├── planning-tests/        # Create test plan
+│   ├── planning-tests/        # Create test plan (ISO 29119-3 layout)
 │   ├── receiving-tickets/     # Fetch ticket, create workspace
 │   ├── reviewing-commands/    # Command quality auditing
+│   ├── reviewing-typography/  # Audit just-published Confluence pages
 │   ├── syncing-testlink/      # Import cases to TestLink
 │   └── tracking-changes/      # GitHub artifact tracking
 ├── templates/          # Project templates

--- a/commands/confluence/cf-create-page.md
+++ b/commands/confluence/cf-create-page.md
@@ -4,84 +4,107 @@ Create Confluence pages from a test plan folder under parent page {{parent_page_
 
 Source folder: $ARGUMENTS
 
+This command creates the **3-level tree** that mirrors the local `test_plan/` + `test_design/` layout. See `skills/planning-tests/SKILL.md` § Step 5 for the tree shape and parent-id chaining (load-bearing — getting the chain wrong puts level-3 pages flat under the user-provided parent).
+
 ## Instructions
 
-1. **Get parent page info** to find the space key from page ID {{parent_page_id}}
+1. **Get parent page info** to find the space ID from page ID {{parent_page_id}} (use `mcp-atlassian:confluence_get_page`).
 
 2. **Read the source folder structure**
-   - Look for `README.md` as the main page content
-   - Look for `sections/` folder containing numbered section files (01_*, 02_*, etc.)
+   - `test_plan/README.md` → entry-point page
+   - `test_plan/sections/` → numbered section files (01_*, 02_*, …)
+   - `test_design/scenarios/README.md` → scenarios index (with Mermaid flow diagrams)
+   - `test_design/scenarios/TS-XX_*.md` → one file per scenario
+   - `test_design/traceability_matrix.md` → RTM
+   - `test_design/risk_register.md` → risk register
 
-3. **Extract project ID from folder path**
-   - Parse folder path to find project ID (e.g., `PROJ-12345` from `PROJ-12345_Feature_Description`)
-   - Use this as prefix for all page titles
+3. **Extract project ID** from the folder path (e.g., `PROJ-12345` from `PROJ-12345_Feature_Description/`). Use as prefix for every page title.
 
-4. **Create parent page first**
-   - Title format: `[PROJECT_ID]: [Title from README.md]`
-   - Example: `PROJ-12345: Test Plan - Feature Description`
-   - Content: README.md content
-   - Parent: {{parent_page_id}}
+4. **Create pages in this order** — the order matters; each step depends on the previous returning a page ID. Pick `content_format: "markdown"` or `"storage"` per page based on the patterns it contains (see "Format Notes" below):
 
-5. **Create child pages for each section**
-   - Read each file in `sections/` folder in order (01, 02, 03...)
-   - Title format: `[PROJECT_ID]: [Section Number]. [Section Title]`
-   - Examples:
-     - `PROJ-12345: 1. Project & Business Context`
-     - `PROJ-12345: 2. Feature Definition`
-     - `PROJ-12345: 3. Scope & Boundaries`
-     - `PROJ-12345: 4. Test Strategy`
-     - `PROJ-12345: 5. References & Resources`
-     - `PROJ-12345: 6. Document Revision History`
-   - Parent: The newly created parent page (from step 4)
-   - Content: Section file content
+   1. **README** (level 1) — `parentId` = {{parent_page_id}}. Capture returned ID as `README_ID`.
+   2. **Sections in numeric order** (level 2) — `parentId` = `README_ID`.
+   3. **Test Scenarios index** `test_design/scenarios/README.md` (level 2) — `parentId` = `README_ID`. Capture returned ID as `SCENARIOS_ID`.
+   4. **TS-XX pages** in scenario-number order (level 3) — `parentId` = **`SCENARIOS_ID`** (NOT `README_ID`).
+   5. **Traceability Matrix** (level 2) — `parentId` = `README_ID`.
+   6. **Risk Register** (level 2) — `parentId` = `README_ID`.
 
-6. **Report created pages**
-   - List all created page IDs and titles
-   - Provide links to the pages
+5. **Record page IDs** to `test_plan/confluence_pages.md` so future updates target the right page rather than re-creating (which would break inbound links from Jira tickets, Slack, etc.). Capture: every page's ID, source-file path, level, and Confluence URL. Bold the load-bearing handles (`README_ID` and `SCENARIOS_ID`).
+
+6. **Report** the parent page URL and the count of pages created (should be `1 + N_sections + 1 + N_scenarios + 2`, e.g. `1 + 6 + 1 + 7 + 2 = 17` for a Type A feature with 7 scenarios).
 
 ## Page Naming Convention
 
 ### Feature (Type A)
 
-| Source File | Page Title Format |
-|-------------|-------------------|
-| `README.md` | `[PROJECT_ID]: Test Plan - [Feature Name]` |
-| `sections/01_Project_Business_Context.md` | `[PROJECT_ID]: 1. Project & Business Context` |
-| `sections/02_Feature_Definition.md` | `[PROJECT_ID]: 2. Feature Definition` |
-| `sections/03_Scope_Boundaries.md` | `[PROJECT_ID]: 3. Scope & Boundaries` |
-| `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` |
-| `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` |
-| `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` |
+| Source File | Page Title | Level |
+|---|---|:-:|
+| `test_plan/README.md` | `[PROJECT_ID]: Test Plan - [Feature Name]` | 1 |
+| `sections/01_Project_Business_Context.md` | `[PROJECT_ID]: 1. Project & Business Context` | 2 |
+| `sections/02_Feature_Definition.md` | `[PROJECT_ID]: 2. Feature Definition` | 2 |
+| `sections/03_Scope_Boundaries.md` | `[PROJECT_ID]: 3. Scope & Boundaries` | 2 |
+| `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` | 2 |
+| `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` | 2 |
+| `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` | 2 |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` | 2 |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` | 3 |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` | 2 |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` | 2 |
 
 ### Bug Fix (Type B)
 
-| Source File | Page Title Format |
-|-------------|-------------------|
-| `README.md` | `[PROJECT_ID]: Test Plan - [Bug Description]` |
-| `sections/01_Problem_Context.md` | `[PROJECT_ID]: 1. Problem Context` |
-| `sections/02_Test_Scope.md` | `[PROJECT_ID]: 2. Test Scope` |
-| `sections/03_Test_Strategy.md` | `[PROJECT_ID]: 3. Test Strategy` |
-| `sections/04_References_Resources.md` | `[PROJECT_ID]: 4. References & Resources` |
-| `sections/05_Revision_History.md` | `[PROJECT_ID]: 5. Document Revision History` |
+| Source File | Page Title | Level |
+|---|---|:-:|
+| `test_plan/README.md` | `[PROJECT_ID]: Test Plan - [Bug Description]` | 1 |
+| `sections/01_Problem_Context.md` | `[PROJECT_ID]: 1. Problem Context` | 2 |
+| `sections/02_Test_Scope.md` | `[PROJECT_ID]: 2. Test Scope` | 2 |
+| `sections/03_Test_Strategy.md` | `[PROJECT_ID]: 3. Test Strategy` | 2 |
+| `sections/04_References_Resources.md` | `[PROJECT_ID]: 4. References & Resources` | 2 |
+| `sections/05_Revision_History.md` | `[PROJECT_ID]: 5. Document Revision History` | 2 |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` | 2 |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` | 3 |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` | 2 |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` | 2 |
 
 ### Enhancement (Type C)
 
-| Source File | Page Title Format |
-|-------------|-------------------|
-| `README.md` | `[PROJECT_ID]: Test Plan - [Enhancement Name]` |
-| `sections/01_Enhancement_Context.md` | `[PROJECT_ID]: 1. Enhancement Context` |
-| `sections/02_Enhancement_Definition.md` | `[PROJECT_ID]: 2. Enhancement Definition` |
-| `sections/03_Test_Scope.md` | `[PROJECT_ID]: 3. Test Scope` |
-| `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` |
-| `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` |
-| `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` |
+| Source File | Page Title | Level |
+|---|---|:-:|
+| `test_plan/README.md` | `[PROJECT_ID]: Test Plan - [Enhancement Name]` | 1 |
+| `sections/01_Enhancement_Context.md` | `[PROJECT_ID]: 1. Enhancement Context` | 2 |
+| `sections/02_Enhancement_Definition.md` | `[PROJECT_ID]: 2. Enhancement Definition` | 2 |
+| `sections/03_Test_Scope.md` | `[PROJECT_ID]: 3. Test Scope` | 2 |
+| `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` | 2 |
+| `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` | 2 |
+| `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` | 2 |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` | 2 |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` | 3 |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` | 2 |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` | 2 |
+
+### Legacy projects without `test_design/`
+
+If the project pre-dates the ISO 29119 layout migration, only the `sections/` rows apply. Skip the level-2 scenarios index and level-3 TS-XX rows. The README + section pages still form a valid 2-level tree.
+
+## Format Notes (verified 2026-05-15)
+
+- `content_format: "markdown"` produces clean Confluence storage HTML for **flat, blank-line-separated** content. Tables, top-level lists, code blocks (including ` ```mermaid `), hyperlinks, bold/italic, em-dashes, and arrows all round-trip cleanly. The older `cf-format-guide.md` warning that markdown breaks tables applies to the legacy direct-REST path, NOT the MCP tool.
+- **Four markdown patterns DO NOT round-trip cleanly** (failures are silent, the API returns 200 OK):
+  1. Bold paragraph + immediately-following list with no blank line → list collapses into the paragraph with hyphens as text.
+  2. 2-space-indented nested lists → flattened to the same level as parent.
+  3. Metadata block (multiple `**Label:**` lines separated by single newlines) → all merge into one paragraph.
+  4. Task list `- [ ]` syntax → bullet items with literal `[ ]` text, NOT native `<ac:task-list>` checkboxes.
+- For these patterns, use `content_format: "storage"` for the affected page. Mixing markdown and storage pages within one publish is fine; both formats are accepted on `confluence_create_page` and `confluence_update_page`. See `cf-format-guide.md` § "Path A gotchas" + § 1.3 (nested) + § 1.4 (task lists) + Path C (mixed strategy) for the full decision rule and storage-format templates.
+- The schema enum lists only `markdown`, `wiki`, and `storage`; the description claims `html` is supported but the validator rejects it.
+
+## Pre-flight check (mandatory)
+
+After creating any batch of pages, immediately re-fetch each page with `convert_to_markdown: false` and inspect the storage HTML for the four red-flag patterns above before declaring the publish complete. The most efficient pattern is to run `/cf-review-page` against each created page ID, then update any page that failed to render correctly via `confluence_update_page` (re-using the same page ID — never delete-and-recreate). A typical first publish has multiple pages with at least one of the four issues; only catching this by re-fetching prevents shipping a broken page.
 
 ## Example Usage
 
 ```
-/cf-create-page /path/to/project/PROJ-12345_Feature_Description/test_plan
+/cf-create-page /path/to/active/PROJ-12345_Feature_Description/test_plan
 ```
 
-This creates:
-1. Parent page: `PROJ-12345: Test Plan - Feature Description`
-2. Child pages for each section under the parent
+Creates a 3-level tree: README → 6 sections + Test Scenarios index + RTM + Risk Register; Test Scenarios index → N TS-XX scenario pages.

--- a/commands/confluence/cf-format-guide.md
+++ b/commands/confluence/cf-format-guide.md
@@ -2,11 +2,81 @@
 
 ## Overview
 
-This document provides guidelines for creating properly formatted Confluence pages programmatically. These guidelines ensure consistent formatting and proper rendering of lists, tables, and other elements when using Confluence APIs.
+This document provides guidelines for creating properly formatted Confluence pages programmatically.
 
-## Key Principle
+## Path A — `mcp-atlassian:confluence_create_page` with `content_format: "markdown"` (RECOMMENDED for simple pages, verified 2026-05-15)
 
-**Use Confluence `storage` format (HTML-based) instead of `markdown` format** when creating pages programmatically. Markdown format often fails to convert lists and tables properly, resulting in plain text with markdown syntax instead of proper HTML elements.
+**Use markdown for flat, blank-line-separated content.** The Atlassian MCP server's markdown converter produces clean Confluence storage format for the majority of authoring needs. Verified across multiple multi-page test plan publishes.
+
+What round-trips cleanly:
+
+| Markdown input | Confluence output |
+|---|---|
+| `\| col \| col \|` table | `<table data-layout="default"><tbody>…<th><p>…` (proper Confluence table) |
+| `- item` bullet (top-level, preceded by blank line) | `<ul><li><p>…</p></li></ul>` |
+| `1. item` numbered (top-level, preceded by blank line) | `<ol start="1"><li><p>…</p></li></ol>` |
+| ` ```mermaid ` fenced | `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">mermaid</ac:parameter>` (renders as a diagram if Mermaid Cloud app is installed; otherwise as readable source) |
+| ` ```json ` etc. | `<ac:structured-macro ac:name="code">` with language parameter |
+| `[text](url)` | `<a href="url">text</a>` |
+| `**bold**` / `*italic*` | `<strong>…</strong>` / `<em>…</em>` |
+| ``` `code` ``` | `<code>…</code>` |
+| `---` | `<hr />` |
+| `&` | auto-escaped to `&amp;` |
+| `→` `↔` `↑` `↓` | preserved as Unicode (Confluence renders correctly) |
+
+**Schema gotcha:** the tool's parameter description lists `markdown`, `wiki`, and `storage` as the supported values. `html` and `adf` are rejected by the validator despite some older notes claiming otherwise. Use `markdown` for simple pages and `storage` for pages with the gotcha patterns below (see Path C).
+
+### Path A gotchas — patterns the markdown converter silently mangles
+
+Four common patterns DO NOT round-trip cleanly. Each failure mode is silent — the page returns 200 OK from create/update — so you only catch it by re-fetching with `convert_to_markdown: false` and inspecting the storage HTML.
+
+| Source pattern | What the converter produces | Fix |
+|---|---|---|
+| **Bold paragraph + immediately-following list with no blank line:**<br/>`**Heading:**`<br/>`- item A`<br/>`- item B` | Whole block collapses to one `<p>` paragraph with the hyphens preserved as plain text. **The list never renders.** | Insert a blank line between the bold paragraph and the first `-`. |
+| **Nested list (2-space-indented sub-bullets):**<br/>`- Parent`<br/>`  - Sub-item 1`<br/>`  - Sub-item 2` | Sub-bullets are **flattened** to the same level as the parent — "Parent" sits next to "Sub-item 1" instead of containing it. | Either restructure as sibling lists separated by a paragraph, or switch the page to `content_format: "storage"` and write `<ul><li><p>Parent</p><ul><li><p>Sub-item 1</p></li></ul></li></ul>` directly (see § 1.3). |
+| **Metadata block (multiple bold-prefixed lines, single newlines between):**<br/>`**Focus:** A`<br/>`**Estimated cases:** 3`<br/>`**Test plan reference:** ...` | All lines **merge** into one `<p>` paragraph with bold labels run together as one wall of inline text. | Insert blank lines (each line becomes its own `<p>`), or switch to storage format with `<p>...<br/>...<br/>...</p>` (the cleanest visual result). |
+| **Task list checkboxes (`- [ ]`)** in a paragraph context | Render as **bullet items with literal `[ ]` text**, not as native `<ac:task-list>` macros — even with a blank line before. The native task-list conversion is unreliable across contexts. | Use `content_format: "storage"` with explicit `<ac:task-list>` + `<ac:task>` macros (see § 1.4 below). |
+
+**Decision rule (apply before every publish):** scan the source markdown for the four patterns above.
+
+- **All four absent** → markdown is fine, use Path A as-is.
+- **Patterns 1 or 3 present** → either pre-process the markdown to insert blank lines / `<br/>`, or write the page in storage format.
+- **Patterns 2 or 4 present** → markdown cannot express the intent; write that page in storage format. Mixing is OK: most pages in a publish can be markdown while just the ones with nested lists or task lists are storage.
+
+**Pre-flight check (mandatory for batch publishes):** after creating pages, immediately re-fetch each with `convert_to_markdown: false` and grep the storage HTML for these red flags before declaring the publish complete:
+
+- `<p>…<strong>…:</strong>\s*-\s` (collapsed bold-then-list)
+- `<li><p>\[ \]` or `<li>\[ \]` (un-converted task-list markers)
+- `<p>…<strong>Focus:</strong>…<strong>Estimated test cases:</strong>` (collapsed metadata block)
+- `<li>…</li>\s*<li>` followed at the same depth by items that should have been nested (harder to detect mechanically — eyeball the `Checkpoints:` / `tenant already has:` style patterns)
+
+Run `/cf-review-page` against each page; it automates this scan.
+
+## Path C — Mixed markdown + storage (RECOMMENDED for multi-page publishes with mixed content)
+
+In practice, a typical test-plan publish has both simple pages (sections, README) and complex pages (TS-XX scenarios with nested Checkpoints, Test Strategy with task lists). Rather than picking one format for the whole publish, pick per page based on the patterns each page contains:
+
+| Page shape | Recommended format |
+|---|---|
+| Flat bullets + tables + code blocks + Mermaid | `markdown` |
+| Bold-paragraph-headed sub-lists (e.g. Scope `**Admin configuration:** + bullets`) | `markdown` with blank line before each list (works) |
+| Nested lists (e.g. TS-XX `Checkpoints:` with sub-bullets) | `storage` |
+| Task-list checkboxes (Entry/Exit Criteria) | `storage` with `<ac:task-list>` |
+| Metadata header block (`**Focus:** … **Estimated cases:** …`) | `storage` with `<br/>`, OR markdown with blank lines between each label line |
+
+Both `mcp-atlassian:confluence_create_page` and `mcp-atlassian:confluence_update_page` accept `content_format: "markdown"` or `"storage"`. Pages can be mixed within a single publish — no special handling needed at the API level.
+
+**Recovery pattern:** if a page was created in markdown and the review reveals one of the Path A gotchas, update the same page ID with `content_format: "storage"` rather than delete-and-recreate. This preserves the page URL (and any inbound links from Jira/Slack/demo decks).
+
+## Path B — Direct Confluence REST API call (legacy, manual conversion required)
+
+When NOT going through the MCP tool (direct `POST /wiki/rest/api/content` calls), the older guidance below applies: write Confluence storage format (HTML-based) by hand because the REST API's markdown intake was unreliable for tables and lists.
+
+This path is retained for completeness but should not be the default. The MCP tool covers all current authoring needs.
+
+### Legacy Key Principle
+
+**Use Confluence `storage` format (HTML-based) instead of `markdown` format** when creating pages programmatically through the legacy REST API. Markdown format often fails to convert lists and tables properly, resulting in plain text with markdown syntax instead of proper HTML elements.
 
 ---
 
@@ -89,6 +159,34 @@ This document provides guidelines for creating properly formatted Confluence pag
 **Key Points:**
 - Nested list goes inside the parent `<li>` element, after the `<p>` tag
 - Can mix `<ul>` and `<ol>` for nested lists
+- **Markdown cannot express nesting reliably** — the MCP converter flattens 2-space-indented sub-bullets (see Path A gotchas above). For any page with nested lists, use `content_format: "storage"` with the structure above.
+
+### 1.4 Task Lists (Native Confluence Checkboxes)
+
+When the page needs **interactive checkboxes** (Entry/Exit criteria, sign-off checklists, definition-of-done lists), use Confluence's native task-list macro. The markdown `- [ ]` shortcut converts unreliably (see Path A gotchas) — write storage format directly.
+
+**Correct Format (Storage):**
+```html
+<ac:task-list>
+  <ac:task>
+    <ac:task-id>1</ac:task-id>
+    <ac:task-status>incomplete</ac:task-status>
+    <ac:task-body>First criterion to verify</ac:task-body>
+  </ac:task>
+  <ac:task>
+    <ac:task-id>2</ac:task-id>
+    <ac:task-status>incomplete</ac:task-status>
+    <ac:task-body>Second criterion — inline <code>code</code> and <strong>bold</strong> are fine inside <code>ac:task-body</code></ac:task-body>
+  </ac:task>
+</ac:task-list>
+```
+
+**Key Points:**
+- Each task needs a unique `<ac:task-id>` (any integer; just keep them unique within the page).
+- `<ac:task-status>` is `incomplete` or `complete`.
+- `<ac:task-body>` accepts inline HTML (`<code>`, `<strong>`, `<a>`, etc.) but not block-level elements.
+- The rendered output is a checkbox the reader can tick directly in Confluence — much better than a bullet list with `[ ]` placeholder text.
+- Reference example: a Test Strategy page § 4.5 with 16 task-list items split across Entry Criteria (9) and Exit Criteria (7).
 
 ---
 

--- a/commands/test-workflow/tw-baseline-trace.md
+++ b/commands/test-workflow/tw-baseline-trace.md
@@ -1,0 +1,230 @@
+# tw-baseline-trace
+
+Capture a UI baseline of the live web application **before** drafting test scenarios.
+
+## Purpose
+
+Test scenarios drafted purely from design spec + wireframes systematically over-specify — they generate cases for pre-existing behaviors (sort, search, navigation tabs) and miss UI realities the wireframes don't show (feature flags hiding controls; "tabs" that are actually separate routes over different domain objects).
+
+A short UI baseline trace, captured **before** scenarios are drafted, anchors the scenario author in observable reality:
+
+- Which columns / controls / filters are visible today
+- Which controls are pre-existing behavior (NOT modified by this feature)
+- Where the live UI differs from wireframes — and which version to trust
+- Whether feature-flagged controls are gated as the spec claims
+- Whether elements the spec calls "tabs" are real tabs (shared state) or separate routes (no shared state)
+
+The authoring rule the baseline enforces:
+
+> **Do not write a case for a behavior that's already visible in the baseline and isn't modified by the feature.** That's regression of the existing suite, not new coverage for this feature.
+
+## When to use
+
+- **After** `/jr-trace [TICKET]` (project folder exists; design spec downloaded)
+- **Before** `/tw-plan-feature` / `/tw-plan-enhance` / `/tw-plan-bugfix`
+- Recommended for any feature or enhancement that touches an existing UI page
+- Optional for bug fixes; useful when the repro page is non-obvious
+
+This step is **strongly recommended** — a recent project's self-review found that roughly half the drafted cases turned out to be either pre-existing-behavior regression or based on UI misreadings, both visible at trace time and neither caught at draft time. Skipping the trace works only when the feature genuinely lands on a page that doesn't exist yet.
+
+## Prerequisites
+
+- Project folder exists at `active/<TICKET>/` with design spec + feature-definition files (`/jr-trace` ran)
+- Playwright MCP available in the session
+- Test environment credentials available — typically in `config/env-<tenant>.txt`; any non-production tenant where the feature flag can be controlled works
+- Feature flag should be **OFF** on the tenant for the cleanest baseline (captures the pre-feature world; the post-feature world is what the test plan describes)
+
+## Inputs
+
+- `<TICKET>` — Jira ticket ID (folder slug under `active/`, e.g., `PROJ-12345_Feature_Name`)
+- Optional `<env>` — environment profile name (default: current profile)
+
+## Tools
+
+Allowed: Playwright MCP (browser_navigate, browser_snapshot, browser_take_screenshot, browser_click, browser_type, browser_fill_form, browser_wait_for, browser_resize, browser_press_key), Read, Write, Bash, Glob, Grep, TodoWrite
+
+## Workflow
+
+### Step 1: Identify pages to trace
+
+```
+1. Read active/<TICKET>/confluence/HLD_*.md (or design-spec equivalent)
+   - Find every section that references a UI page — Wireframes, Use Case
+     Flows, Components, Admin GUI / End-User Portal sections
+   - Extract a candidate page list: page name + spec-claimed route + paired
+     wireframe image path (hld_images/*.png)
+2. Read active/<TICKET>/00_Main_Task_<TICKET>.md and any 01_*Feature_Request*.md
+   - Cross-check the candidate list with the ticket's affected-areas section
+3. Present the candidate page list to the user:
+   "Will trace these N pages — confirm or edit"
+4. User confirms or edits; proceed with the agreed list
+```
+
+The page list typically includes 2–5 entries: one or two admin-facing pages (where the feature is configured), one or two end-user-facing pages (where the feature is observed), and the downstream admin observation page (where the result of the end-user action appears).
+
+### Step 2: Prepare output folders
+
+```bash
+DATE=$(date +%Y-%m-%d)
+mkdir -p active/<TICKET>/ui_baseline/$DATE/{screenshots,snapshots}
+```
+
+Convention: each capture goes in a dated folder so subsequent traces (after a build update, after flag flip) don't overwrite earlier captures.
+
+### Step 3: Verify Playwright session and tenant state
+
+```
+1. If Playwright is not yet logged into the target tenant, prompt the user
+   to log in manually first (do NOT pass credentials inline; the user logs
+   in once and the command drives the rest)
+2. Confirm the tenant currently has the feature flag OFF (or the state
+   matches what the trace is meant to document) — record the state in
+   the baseline metadata
+3. Resize the viewport to a stable size (e.g., 1440x900 or whatever the
+   target app's minimum width comfortably supports)
+```
+
+### Step 4: Drive Playwright through each page
+
+For each page on the agreed list:
+
+```
+1. browser_navigate to the page (or navigate via the side menu — match
+   what a real admin would do, since route accessibility itself is part
+   of what the baseline captures)
+2. browser_wait_for time:3 to let the page settle (list pages re-render
+   on filter init)
+3. browser_snapshot — save raw accessibility YAML to:
+     active/<TICKET>/ui_baseline/<DATE>/snapshots/<page_slug>.yml
+4. browser_take_screenshot type=png — save PNG to:
+     active/<TICKET>/ui_baseline/<DATE>/screenshots/<page_slug>.png
+5. Extract structural info from the snapshot:
+   - Page title + breadcrumbs
+   - Tabs in the tablist (and verify: do they change the URL on click?
+     If yes → they're routes, not tabs)
+   - Toolbar: search bar placeholder text, filters (combobox/dropdown
+     names), buttons
+   - Table columns (if present): each columnheader name + sort affordance
+   - Bulk-action controls — note that the bulk bar usually appears only
+     after row selection (test by selecting a row)
+   - Wizard steps (if present): step list + current step
+   - Form fields (if present): each field name + type + required marker
+6. Note any spec-described control that is NOT in the live snapshot —
+   typical reason: feature-flag gated
+7. Note any control IN the live snapshot that's NOT in the wireframe —
+   typical reason: pre-existing behavior the wireframe didn't draw
+```
+
+### Step 5: Cross-check "tab" semantics
+
+For each "tab" element found:
+
+```
+1. Click the next tab in the tablist
+2. Observe whether the URL changes
+3. If URL changes → it's a route, not a tab. Selection / filter / scroll
+   state will NOT survive switching, and shouldn't be tested as if they
+   would. Document this in the baseline.
+4. If URL stays the same → it's a true tab with shared state. Cases that
+   assert state preservation across tabs are valid.
+```
+
+This check explicitly catches the common misread where two related routes (e.g., a "Users" tab next to a "Roles" tab) look like tabs but each click switches the URL — they share no selection / filter / scroll state, and asserting that they would is testing for behavior the design doesn't claim.
+
+### Step 6: Generate baseline.md
+
+Write `active/<TICKET>/ui_baseline/<DATE>/baseline.md` using this template:
+
+```markdown
+# UI Baseline — <TICKET>
+
+**Captured:** <YYYY-MM-DD>
+**Tenant:** <tenant capability description> / <env URL>
+**Feature flag state:** <ON / OFF — usually OFF for pre-feature baselines>
+**Captured by:** <author>
+**Captured via:** /tw-baseline-trace + Playwright MCP
+
+## Pages traced
+
+### <Page name, e.g., "Settings → Profiles → Add → Form → Step 2">
+
+- **Route:** `<URL path>`
+- **Navigate via:** <menu path>
+- **Screenshot:** [`screenshots/<page_slug>.png`](screenshots/<page_slug>.png)
+- **Raw snapshot:** [`snapshots/<page_slug>.yml`](snapshots/<page_slug>.yml)
+
+**Live structure (flag <state>):**
+- <bullet list of observed columns / controls / tabs / wizard steps / fields>
+
+**Tab vs route semantics:** <if any tab-like elements were found, note whether they change the URL on click (route) or not (true tab)>
+
+**Wireframe diff (`<wireframe.png>`):**
+- Spec adds (not visible today): <list — conclusion: "feature-flag gated" / "spec aspirational">
+- Live has (not in spec): <list — conclusion: "pre-existing behavior" / "spec didn't draw it">
+
+**Authoring guidance for scenarios:**
+- Pre-existing behaviors NOT to test for this feature: <list>
+- Feature-flag-gated controls to verify under flag ON (likely in the flag-gating scenario): <list>
+- Other UI realities the spec doesn't show: <list>
+
+---
+
+### <Next page...>
+```
+
+### Step 7: Validate + handoff
+
+```
+1. Report:
+   - Number of pages traced
+   - Number of spec-vs-live diffs found
+   - List of pre-existing behaviors flagged as "not to retest"
+2. Confirm baseline.md is readable + screenshots/snapshots all saved
+3. Print next-step prompt:
+   "Run /tw-plan-feature (or tw-plan-enhance / tw-plan-bugfix) — it will
+    read the baseline alongside the design spec."
+```
+
+## What `/tw-plan-*` does with the baseline
+
+The plan-drafting commands check for `active/<TICKET>/ui_baseline/*/baseline.md` on entry. If found, they:
+
+- Load the baseline alongside the design spec
+- When proposing each scenario / case, cross-check against the baseline's "Pre-existing behaviors" and "Feature-flag-gated controls" lists
+- Skip cases for pre-existing behaviors unmodified by this feature
+- Route feature-flag-gated assertions to the flag-gating scenario
+
+If no baseline is found, the plan-drafting commands warn:
+
+> No UI baseline found at `ui_baseline/`. Drafting from design spec only — recommend running `/tw-baseline-trace` first to ground scenarios in observable UI reality. Proceed without baseline? (yes/no)
+
+A "yes" answer is fine for bug fixes or pages that don't exist yet; a "no" answer rewinds to `/tw-baseline-trace`.
+
+## Output layout
+
+```
+active/<TICKET>/
+└── ui_baseline/
+    └── <YYYY-MM-DD>/
+        ├── baseline.md          # the narrative + structural notes
+        ├── screenshots/
+        │   ├── <page_slug>.png
+        │   └── ...
+        └── snapshots/
+            ├── <page_slug>.yml
+            └── ...
+```
+
+Multiple dated folders coexist when traces are repeated (e.g., before flag flip, after flag flip, after build update). The most recent is canonical for current planning.
+
+## NEXT STEP
+
+After the baseline is captured, run `/tw-plan-feature`, `/tw-plan-enhance`, or `/tw-plan-bugfix` per the feature type. Those commands will load `ui_baseline/<latest-date>/baseline.md` alongside the design spec and apply the "don't author regression of pre-existing behavior" rule from `skills/planning-tests/references/scenario-conventions.md`.
+
+---
+
+## Related
+
+- `skills/planning-tests/SKILL.md` — describes where this command sits in the broader test-planning lifecycle
+- `skills/planning-tests/references/scenario-conventions.md` — the authoring rule the baseline enforces
+- `skills/planning-tests/references/file-layout.md` — documents `ui_baseline/` as part of the per-project tree

--- a/commands/test-workflow/tw-case-bugfix.md
+++ b/commands/test-workflow/tw-case-bugfix.md
@@ -22,12 +22,24 @@ AUDIENCE: QA Engineers, Test Execution Team, TestLink Users
 
 ## INFORMATION SOURCES
 
-**PRIMARY SOURCE (Required):**
-1. **test_plan/sections/03_Test_Strategy.md § 3.2** - Test scenarios (bug fix plans use section 3)
-2. **test_plan/sections/01_Problem_Context.md § 1.2** - Reproduction steps (critical for defect verification)
-3. **test_plan/sections/02_Test_Scope.md § 2.1-2.3** - Test scope
+**PRIMARY SOURCE (Required) — detect layout first:**
 
-> **Fallback:** If `test_plan/sections/` does not exist, read `test_plan/README.md` directly.
+Check whether the project uses the **new layout** (`test_plan/test_design/scenarios/`) or the **legacy layout** (scenarios inlined in `sections/03_Test_Strategy.md § 3.2`).
+
+```
+IF test_plan/test_design/scenarios/ exists (new layout):
+  - Scenarios: read each test_plan/test_design/scenarios/TS-XX_*.md directly
+  - Each file's `**Estimated test cases:** N` header gives the case count
+  - Body is the source of truth for activities (no § 3.2 table to consult)
+IF only test_plan/sections/ exists (legacy layout):
+  - Scenarios: test_plan/sections/03_Test_Strategy.md § 3.2 (inline table)
+```
+
+Other required sources (independent of layout):
+1. **test_plan/sections/01_Problem_Context.md § 1.2** — Reproduction steps (critical for defect verification)
+2. **test_plan/sections/02_Test_Scope.md § 2.1-2.3** — Test scope
+
+> **Fallback:** If `test_plan/sections/` does not exist at all, read `test_plan/README.md` directly.
 
 **SECONDARY SOURCES (Reference):**
 4. **Bug Ticket** (`00_Main_Task_*.md`) - Original reproduction steps
@@ -54,8 +66,19 @@ test_cases/
 1. Read test_plan/sections/01_Problem_Context.md § 1.2 - Extract reproduction steps
    - These become the basis for TS-01 (Defect Verification)
 
-2. Read test_plan/sections/03_Test_Strategy.md § 3.2 - Test scenarios
-   - Typically 2-4 scenarios:
+2. Read scenarios — layout-aware:
+   IF test_plan/test_design/scenarios/ exists:
+     - Read each TS-XX_*.md file under that directory
+     - Use the metadata header (Focus / Est. test cases), the optional
+       `## Scenario Preconditions` block, and each `### Case N:` block
+       (Objective + Checkpoints + optional Preconditions + optional Notes)
+       verbatim
+     - Steps are NOT in the scenario file — derive them in the test case
+       from each case's Objective + Checkpoints + Notes
+   ELSE (legacy layout):
+     - Read test_plan/sections/03_Test_Strategy.md § 3.2 inline table
+
+   Typical bug-fix scenarios:
      • TS-01: Defect Verification
      • TS-02: Regression Testing
      • TS-03: Edge Cases
@@ -72,12 +95,15 @@ test_cases/
 ```markdown
 # TS-01: Defect Verification
 
-**Objective:** Verify the original bug no longer occurs
 **Focus:** Defect verification
+
 **Test Cases:** 2-3
+
 **Test Plan Reference:** test_plan/sections/01_Problem_Context.md § 1.2
 
 ---
+
+**Objective:** Verify the original bug no longer occurs
 
 ## TC-01: Reproduce Original Bug
 
@@ -132,12 +158,15 @@ test_cases/
 ```markdown
 # TS-02: Regression Testing
 
-**Objective:** Verify fix didn't break related functionality
 **Focus:** Regression
+
 **Test Cases:** 2-3
+
 **Test Plan Reference:** test_plan/sections/02_Test_Scope.md § 2.2
 
 ---
+
+**Objective:** Verify fix didn't break related functionality
 
 ## TC-01: Related Operation 1
 
@@ -175,12 +204,15 @@ test_cases/
 ```markdown
 # TS-03: Edge Cases & Prevention
 
-**Objective:** Prevent similar bugs through edge case coverage
 **Focus:** Edge Cases
+
 **Test Cases:** 2-4
+
 **Test Plan Reference:** test_plan/sections/02_Test_Scope.md § 2.3
 
 ---
+
+**Objective:** Prevent similar bugs through edge case coverage
 
 ## TC-01: Boundary Condition
 
@@ -269,16 +301,30 @@ Before completing each test case, verify:
 ### Test Independence
 
 Each test case MUST run standalone:
-- All required setup is in preconditions (not "state from previous test")
+- All required data state and capabilities are in preconditions (not "state from previous test")
 - No reliance on execution order
 - No shared mutable state between test cases
+- Preconditions are system state, not UI state — see the split rule below
 
-### Navigation Step Strategy
+### Preconditions vs. Test Steps — the split rule
 
-Apply these navigation step rules:
-- [ ] Setup navigation moved to preconditions when 3+ TCs share the same path
-- [ ] Navigation condensed to 1-2 steps max (no intermediate page verifications)
-- [ ] No URLs/routes in test steps — use page names instead
+**Preconditions describe system state, not UI state.** Never write a precondition like "Admin on X page" or "X panel open" — navigation belongs in the first test step.
+
+| Belongs in **Preconditions** | Belongs in **Test Steps** (typically Step 1) |
+|---|---|
+| Data state (existing entities, defect-reproducing config) | UI state (open a page, click Edit, open a panel) |
+| Permission / role | Page navigation (menu paths) |
+| Build / version that has the fix applied | Opening dialogs, panels, sub-modals |
+| Device / tooling availability | Anything the executor does in the UI during this TC |
+
+Step pattern: combine the navigation and the initial action — "Go to **X → Y**, click **Z**" → expected: "form opens" or equivalent.
+
+### Navigation Step Rules (within Test Steps)
+
+- [ ] Combine navigation + the initial action into one step where natural
+- [ ] No intermediate page verifications
+- [ ] Use page names, not URLs or routes
+- [ ] Repeat the navigation step at the top of each TC when paths overlap — independence over DRY
 
 > **Note:** Test data adequacy, boundary value analysis, and
 > cleanup/postconditions are **skipped** for Bug Fix (Focused profile).

--- a/commands/test-workflow/tw-case-enhance.md
+++ b/commands/test-workflow/tw-case-enhance.md
@@ -23,12 +23,27 @@ AUDIENCE: QA Engineers, Test Execution Team, TestLink Users
 
 ## INFORMATION SOURCES
 
-**PRIMARY SOURCE (Required):**
-1. **test_plan/sections/04_Test_Strategy.md § 4.2** - Test scenarios
-2. **test_plan/sections/02_Enhancement_Definition.md § 2.1** - New/changed functionality
-3. **test_plan/sections/03_Test_Scope.md § 3.1-3.3** - Test scope
+**PRIMARY SOURCE (Required) — detect layout first:**
 
-> **Fallback:** If `test_plan/sections/` does not exist, read `test_plan/README.md` directly.
+Check whether the project uses the **new layout** (`test_plan/test_design/scenarios/`) or the **legacy layout** (scenarios inlined in `sections/04_Test_Strategy.md § 4.2`).
+
+```
+IF test_plan/test_design/scenarios/ exists (new layout):
+  - Scenarios: read each test_plan/test_design/scenarios/TS-XX_*.md directly
+  - Each file's metadata header (Focus / Estimated test cases), optional
+    `## Scenario Preconditions` block, and `### Case N:` blocks (Objective +
+    Checkpoints + optional Preconditions + optional Notes) are the source of truth
+  - Steps are NOT in the scenario file — derive them in the test case from
+    each case's Objective + Checkpoints + Notes (this command's job)
+IF only test_plan/sections/ exists (legacy layout):
+  - Scenarios: test_plan/sections/04_Test_Strategy.md § 4.2 (inline table)
+```
+
+Other required sources (independent of layout):
+1. **test_plan/sections/02_Enhancement_Definition.md § 2.1** — New/changed functionality
+2. **test_plan/sections/03_Test_Scope.md § 3.1-3.3** — Test scope
+
+> **Fallback:** If `test_plan/sections/` does not exist at all, read `test_plan/README.md` directly.
 
 **SECONDARY SOURCES (Reference):**
 4. **Enhancement Ticket** (`00_Main_Task_*.md`)
@@ -71,8 +86,13 @@ Enhancements require BOTH:
    - List what's new
    - List what's changed
 
-2. Read test_plan/sections/04_Test_Strategy.md § 4.2 - Test scenarios
-   - Usually 4-6 scenarios
+2. Read scenarios — layout-aware:
+   IF test_plan/test_design/scenarios/ exists:
+     - List all TS-XX_*.md files; read each file's header + body
+   ELSE (legacy):
+     - Read test_plan/sections/04_Test_Strategy.md § 4.2 inline table
+
+   Usually 4-6 scenarios.
 
 3. Split scenarios into groups:
    - Enhancement scenarios → Type A approach
@@ -84,12 +104,15 @@ Enhancements require BOTH:
 ```markdown
 # TS-01: Enhancement Verification
 
-**Objective:** Verify new/changed functionality works as specified
 **Focus:** Enhancement
+
 **Test Cases:** 4-6
+
 **Test Plan Reference:** test_plan/sections/02_Enhancement_Definition.md § 2.1
 
 ---
+
+**Objective:** Verify new/changed functionality works as specified
 
 ## TC-01: New Behavior - Basic
 
@@ -132,12 +155,15 @@ Enhancements require BOTH:
 ```markdown
 # TS-02: Configuration Changes
 
-**Objective:** Verify new/changed configuration options work correctly
 **Focus:** Configuration
+
 **Test Cases:** 2-4
+
 **Test Plan Reference:** test_plan/sections/02_Enhancement_Definition.md § 2.2
 
 ---
+
+**Objective:** Verify new/changed configuration options work correctly
 
 ## TC-01: New Configuration Option
 
@@ -164,12 +190,15 @@ Enhancements require BOTH:
 ```markdown
 # TS-03: Integration Impact
 
-**Objective:** Verify enhancement doesn't break component interactions
 **Focus:** Integration
+
 **Test Cases:** 2-4
+
 **Test Plan Reference:** test_plan/sections/03_Test_Scope.md § 3.2
 
 ---
+
+**Objective:** Verify enhancement doesn't break component interactions
 
 ## TC-01: Component A Integration
 
@@ -196,12 +225,15 @@ Enhancements require BOTH:
 ```markdown
 # TS-04: Backward Compatibility
 
-**Objective:** Verify existing functionality still works unchanged
 **Focus:** Backward Compatibility
+
 **Test Cases:** 2-3
+
 **Test Plan Reference:** test_plan/sections/03_Test_Scope.md § 3.3
 
 ---
+
+**Objective:** Verify existing functionality still works unchanged
 
 ## TC-01: Existing Workflow - Unchanged
 
@@ -252,16 +284,31 @@ Before completing each test case, verify:
 ### Test Independence
 
 Each test case MUST run standalone:
-- All required setup is in preconditions (not "state from previous test")
+- All required data state and capabilities are in preconditions (not "state from previous test")
 - No reliance on execution order
 - No shared mutable state between test cases
+- Preconditions are system state, not UI state — see the split rule below
 
-### Navigation Step Strategy
+### Preconditions vs. Test Steps — the split rule
 
-Apply these navigation step rules:
-- [ ] Setup navigation moved to preconditions when 3+ TCs share the same path
-- [ ] Navigation condensed to 1-2 steps max (no intermediate page verifications)
-- [ ] No URLs/routes in test steps — use page names instead
+**Preconditions describe system state, not UI state.** Never write a precondition like "Admin on X page" or "X panel open" — navigation belongs in the first test step.
+
+| Belongs in **Preconditions** | Belongs in **Test Steps** (typically Step 1) |
+|---|---|
+| Data state (existing entities, configured matrix, populated records) | UI state (open a page, click Edit, open a panel) |
+| Permission / role (admin with permission to manage X) | Page navigation (menu paths) |
+| Feature flag state | Opening dialogs, panels, sub-modals |
+| Device / tooling availability | Wizard advancement, button clicks, form input |
+| External gates (tickets resolved, build deployed) | Anything the executor does in the UI during this TC |
+
+Step pattern: combine the navigation and the initial action — "Go to **X → Y**, click **Z**" → expected: "form opens" or equivalent.
+
+### Navigation Step Rules (within Test Steps)
+
+- [ ] Combine navigation + the initial action into one step where natural ("Go to X, click Y")
+- [ ] No intermediate page verifications (no "Step 2: Verify the portal list loaded" — the expected-result column of the navigation step covers that)
+- [ ] Use page names, not URLs or routes
+- [ ] When multiple TCs share the same navigation path, repeat the navigation step at the top of each — independence over DRY
 
 ### Test Data Adequacy (Lite)
 

--- a/commands/test-workflow/tw-case-feature.md
+++ b/commands/test-workflow/tw-case-feature.md
@@ -22,12 +22,29 @@ AUDIENCE: QA Engineers, Test Execution Team, TestLink Users
 
 ## INFORMATION SOURCES
 
-**PRIMARY SOURCE (Required):**
-1. **test_plan/sections/04_Test_Strategy.md § 4.4** - Test scenarios to expand into test cases
-2. **test_plan/sections/04_Test_Strategy.md § 4.3** - Priority operations (example test operations)
-3. **test_plan/sections/03_Scope_Boundaries.md § 3.1** - In-scope testing categories
+**PRIMARY SOURCE (Required) — detect layout first:**
 
-> **Fallback:** If `test_plan/sections/` does not exist, read `test_plan/README.md` directly.
+Check whether the project uses the **new layout** (`test_plan/test_design/scenarios/`) or the **legacy layout** (scenarios inlined in `sections/04_Test_Strategy.md § 4.4`).
+
+```
+IF test_plan/test_design/scenarios/ exists (new layout):
+  - Scenarios: read each test_plan/test_design/scenarios/TS-XX_*.md directly
+  - Each file's `**Estimated test cases:** N`, optional `## Scenario Preconditions`
+    block, and `### Case N:` blocks (Objective + Checkpoints mandatory;
+    Preconditions + Notes optional) are the source of truth
+  - Steps are NOT in the scenario file — derive them in the test case from
+    each case's Objective + Checkpoints + Notes (this command's job)
+  - Strategy file (sections/04_Test_Strategy.md) is lean — read § 4.3 (Approach)
+    and § 4.4 (Test Data) for cross-cutting context, but NOT for scenarios
+IF only test_plan/sections/ exists (legacy layout):
+  - Scenarios: test_plan/sections/04_Test_Strategy.md § 4.4 (inline table)
+  - Approach: test_plan/sections/04_Test_Strategy.md § 4.3
+```
+
+Other required sources (independent of layout):
+1. **test_plan/sections/03_Scope_Boundaries.md § 3.1** — In-scope testing categories
+
+> **Fallback:** If `test_plan/sections/` does not exist at all, read `test_plan/README.md` directly.
 
 **SECONDARY SOURCES (Reference):**
 4. **Confluence HLD** (`confluence/HLD_*.md`) - For detailed acceptance criteria
@@ -52,15 +69,29 @@ test_cases/
 
 ### Step 1: Parse Test Plan Sections
 ```
-1. Read test_plan/sections/04_Test_Strategy.md § 4.4 (Test Scenarios table)
+1. Read scenarios — layout-aware:
+   IF test_plan/test_design/scenarios/ exists:
+     - List all TS-XX_*.md files in that directory (in numeric order)
+     - For each file, extract the metadata header (Focus / Estimated test
+       cases), the intro paragraph, the optional `## Scenario Preconditions`
+       block, and each `### Case N:` block (Objective + Checkpoints + optional
+       Preconditions + optional Notes)
+   ELSE (legacy):
+     - Read test_plan/sections/04_Test_Strategy.md § 4.4 (Test Scenarios table)
+
 2. Count test scenarios (TS-01, TS-02, etc.)
+
 3. For each scenario, extract:
    - Scenario ID (TS-XX)
    - Scenario name
-   - Focus area
+   - Focus
    - Estimated test case count
-   - Test activities (bullet points)
-4. Note priority operations from § 4.3 (use as examples)
+   - Scenario-level preconditions (if present)
+   - Per-case Objective + Checkpoints (+ case-level Preconditions and Notes if present)
+
+4. Note approach context from sections/04_Test_Strategy.md § 4.3 (use as
+   cross-cutting context — verification perspective, environment requirement,
+   visual baseline references)
 ```
 
 ### Step 2: Create Directory and README.md
@@ -85,20 +116,26 @@ test_cases/
 
 ### Step 3: Create Separate File for Each Test Scenario
 
-**FOR EACH test scenario in test_plan/sections/04_Test_Strategy.md § 4.4:**
+**FOR EACH test scenario** (source: `test_plan/test_design/scenarios/TS-XX_*.md` on the new layout, or `test_plan/sections/04_Test_Strategy.md § 4.4` on the legacy layout):
 
 1. **Create new file:** `test_cases/TS-XX_[Scenario_Name].md`
    - Replace spaces with underscores in filename
    - Example: `TS-01_Basic_Configuration.md`
 
-2. **Add file header:**
+2. **Add file header** — `Test Plan Reference` is layout-aware. Each metadata label gets its own paragraph (blank line between) to avoid the A1 "merged metadata block" anti-pattern; the Objective sits below the divider as its own paragraph so it doesn't collide visually with the short metadata labels.
    ```markdown
    # TS-XX: [Scenario Name]
 
-   **Objective:** [Copy from test plan]
-   **Focus:** [From "Focus" column]
+   **Focus:** [From "Focus" column / scenario file]
+
    **Test Cases:** [Count]
-   **Test Plan Reference:** test_plan/sections/04_Test_Strategy.md § 4.4, TS-XX
+
+   **Test Plan Reference:** <new layout> test_plan/test_design/scenarios/TS-XX_<Slug>.md
+                            <legacy layout> test_plan/sections/04_Test_Strategy.md § 4.4, TS-XX
+
+   ---
+
+   **Objective:** [Copy from test plan — keep as its own paragraph after the divider; maps to TestLink Suite Details on sync]
    ```
 
 3. **FOR EACH test activity, create test case variations:**
@@ -199,16 +236,45 @@ Before completing each test case, verify:
 ### Test Independence
 
 Each test case MUST run standalone:
-- All required setup is in preconditions (not "state from previous test")
+- All required data state and capabilities are in preconditions (not "state from previous test")
 - No reliance on execution order
 - No shared mutable state between test cases
+- Preconditions are system state, not UI state — see the split rule below
 
-### Navigation Step Strategy
+### Preconditions vs. Test Steps — the split rule
 
-Apply these navigation step rules:
-- [ ] Setup navigation moved to preconditions when 3+ TCs share the same path
-- [ ] Navigation condensed to 1-2 steps max (no intermediate page verifications)
-- [ ] No URLs/routes in test steps — use page names instead
+**Preconditions describe system state, not UI state.** This is a hard rule.
+
+| Belongs in **Preconditions** | Belongs in **Test Steps** (typically Step 1) |
+|---|---|
+| Data state (`tc-fixture-A` exists with X matrix) | UI state (open the portal list, click Edit) |
+| Permission / role (admin signed in with permission to manage profiles) | Page navigation (Settings → Resources → Profiles) |
+| Feature flag state (flag is ON / OFF on the tenant) | Opening dialogs, panels, sub-modals |
+| Device / tooling availability (real client device, device-driver MCP available) | Wizard advancement, button clicks, form input |
+| External gates (TKT-01 resolved, build deployed, fixture from another TC exists) | Anything the executor does in the UI during this TC |
+
+Never write a precondition like:
+- ❌ "Admin on Settings → Resources → Profiles page"
+- ❌ "Admin in the Edit view of the portal with the Sub-section panel open"
+- ❌ "On the submission form, ready to submit"
+
+Rewrite those as Step 1:
+- ✅ Step 1: Navigate to **Settings → Resources → Profiles**. Click **Add Profile**. → Add Profile form opens.
+- ✅ Step 1: Navigate to **Settings → Resources → Profiles**. Click the existing fixture `tc-fixture-A` and click **Edit**. Open the **Sub-section** panel. → Edit view shows the Sub-section panel.
+
+**Why this matters:**
+- Test independence — each TC runs standalone from a known data state; the executor never has to remember "what page should I already be on?"
+- Automation — the script does the navigation itself; it can't assume a page is open
+- Reproducibility — navigation IS part of the test; skipping it can mask a real navigation bug
+
+### Navigation Step Rules (within Test Steps)
+
+Once navigation is in the steps (not preconditions), keep the navigation itself tight:
+
+- [ ] Combine navigation + the initial action into one step where natural ("Go to X, click Y")
+- [ ] No intermediate page verifications (no "Step 2: Verify the portal list loaded" — the navigation's expected-result column covers that)
+- [ ] Use page names, not URLs or routes (e.g., "Users — Guests" not `/admin/users/guests`)
+- [ ] When multiple TCs share the same navigation path, repeat the navigation step at the top of each — independence over DRY
 
 ### Test Data Adequacy
 

--- a/commands/test-workflow/tw-case-init.md
+++ b/commands/test-workflow/tw-case-init.md
@@ -23,9 +23,9 @@ Analyze the test plan to:
 Before starting, verify these files exist:
 - [ ] `test_plan/README.md` must exist (index file created by /tw-plan-* commands)
 - [ ] `test_plan/sections/` should contain section files
-- [ ] Test scenarios in Test Strategy section file:
-  - Feature/Enhancement: `sections/04_Test_Strategy.md § 4.4 / § 4.2`
-  - Bug Fix: `sections/03_Test_Strategy.md § 3.2`
+- [ ] Test scenarios — layout-aware:
+  - **New layout** (`test_plan/test_design/scenarios/` exists): list all `TS-XX_*.md` files in that directory
+  - **Legacy layout**: scenario table inline in `sections/04_Test_Strategy.md § 4.4 / § 4.2` (Feature/Enhancement) or `sections/03_Test_Strategy.md § 3.2` (Bug Fix)
 - [ ] Optional: `/tw-plan-review` output with coverage matrix
 
 > **Fallback:** If `test_plan/sections/` does not exist, read `test_plan/README.md` directly.
@@ -66,20 +66,26 @@ IF "Enhancement Validation":
 
 ### Step 2: Extract Test Scenarios
 
-Count and list all test scenarios from the test plan:
+Count and list all test scenarios from the test plan, layout-aware:
 
 ```
-READ test_plan/sections/04_Test_Strategy.md § 4.4 (features)
-  or test_plan/sections/04_Test_Strategy.md § 4.2 (enhancements)
-  or test_plan/sections/03_Test_Strategy.md § 3.2 (bug fixes)
-EXTRACT test scenario table
+IF test_plan/test_design/scenarios/ exists (NEW LAYOUT):
+  LIST every TS-XX_*.md file under that directory (numeric order)
+  FOR EACH scenario file, READ:
+    - Scenario ID (from filename / H1)
+    - Scenario name (from H1)
+    - Focus (from **Focus:** field)
+    - Estimated test case count (from **Estimated test cases:** field)
+    - Scenario preconditions (from optional ## Scenario Preconditions block)
+    - Per-case Objective + Checkpoints (+ case-level Preconditions / Notes if present),
+      one ### Case N: block per case. Steps are NOT in the scenario — derive
+      them later in the test case body from Objective + Checkpoints + Notes
 
-FOR EACH scenario:
-  - Scenario ID (TS-XX)
-  - Scenario name
-  - Focus area
-  - Estimated test case count
-  - Test activities listed
+ELSE (LEGACY LAYOUT):
+  READ test_plan/sections/04_Test_Strategy.md § 4.4 (features)
+    or test_plan/sections/04_Test_Strategy.md § 4.2 (enhancements)
+    or test_plan/sections/03_Test_Strategy.md § 3.2 (bug fixes)
+  EXTRACT test scenario table (one row per TS-XX)
 ```
 
 ---

--- a/commands/test-workflow/tw-case-review.md
+++ b/commands/test-workflow/tw-case-review.md
@@ -54,10 +54,14 @@ Read the test plan for comparison baseline and determine review profile:
 
 ```
 1. Read test_plan/README.md for type and quick reference counts
-2. Read the Test Strategy section file for scenario details:
-   - Feature: test_plan/sections/04_Test_Strategy.md § 4.4
-   - Bug Fix: test_plan/sections/03_Test_Strategy.md § 3.2
-   - Enhancement: test_plan/sections/04_Test_Strategy.md § 4.2
+2. Read scenarios — layout-aware:
+   IF test_plan/test_design/scenarios/ exists (NEW LAYOUT):
+     - Read each test_plan/test_design/scenarios/TS-XX_*.md file
+     - Each file's `**Estimated test cases:** N`, optional `## Scenario Preconditions` block, and `### Case N:` blocks (Objective + Checkpoints + optional Preconditions + optional Notes) are the source of truth
+   ELSE (LEGACY LAYOUT):
+     - Feature: test_plan/sections/04_Test_Strategy.md § 4.4
+     - Bug Fix: test_plan/sections/03_Test_Strategy.md § 3.2
+     - Enhancement: test_plan/sections/04_Test_Strategy.md § 4.2
 3. Reference coverage matrix from /tw-plan-review (if available)
 4. Detect review profile from test plan type:
    - "New Feature Validation" → Full profile (expect 20-40 test cases)
@@ -126,13 +130,26 @@ For each test case, verify the following quality criteria:
 
 #### 3.6 Test Independence
 - [ ] Test can run standalone without prior tests
-- [ ] All setup is in preconditions
+- [ ] All required data state and capabilities are in preconditions
 - [ ] No reliance on state from other test cases
 
-#### 3.7 Navigation Step Strategy
-- [ ] Setup navigation is in preconditions when 3+ TCs share the same path
-- [ ] Navigation condensed to 1-2 steps (no intermediate page verifications)
-- [ ] No URLs/routes in test steps — page names only
+#### 3.7 Preconditions vs. Test Steps — split rule
+
+Preconditions describe **system state**; test steps describe **UI state** and actions. Flag any precondition that asserts UI state.
+
+- [ ] No precondition mentions a specific page, dialog, panel, or wizard step the executor must already be in (e.g., "Admin on X page", "Sub-section panel open")
+- [ ] Page navigation appears as Step 1 (or wherever it logically lands in the flow), not in preconditions
+- [ ] Combine navigation + the initial action into one step where natural ("Go to X, click Y")
+- [ ] No intermediate page verifications (no "Step 2: Verify the portal list loaded" — the expected-result column of the navigation step covers that)
+- [ ] Use page names in steps, not URLs or routes
+- [ ] When multiple TCs share the same navigation path, the navigation is repeated at the top of each — independence over DRY
+
+Common violations to flag during review:
+- ❌ "Admin on Settings → Resources → Profiles page" (precondition)
+- ❌ "Admin in the Edit view of the portal with the Sub-section panel open" (precondition)
+- ❌ "On the submission form, ready to submit" (precondition)
+- ✅ "There is an existing portal `tc-fixture-A` with the X matrix configured" (precondition — system state)
+- ✅ "Step 1: Navigate to Settings → Resources → Profiles. Click `tc-fixture-A` and click Configure. Open the Sub-section panel." (step — UI state + action)
 
 #### 3.8 No Internal Labels
 - [ ] Phase headers do not contain test plan mapping labels (e.g., `D1`, `D2`, `S2`)
@@ -436,7 +453,7 @@ Agent:
    ### Vague Expected Results
    | File | TC | Step | Issue | Suggested Fix |
    |------|-----|------|-------|---------------|
-   | TS-03 | TC-02 | 5 | "Network activates correctly" | "SSID 'Test-5GHz' visible in Wi-Fi scan within 60 seconds" |
+   | TS-03 | TC-02 | 5 | "Resource activates correctly" | "Resource 'Test-Resource-A' visible in the listing API response within 60 seconds" |
 
    ## Priority Recommendation
    | File | TC | Name | Recommended Priority | Reason |

--- a/commands/test-workflow/tw-case-verify-refs.md
+++ b/commands/test-workflow/tw-case-verify-refs.md
@@ -74,9 +74,14 @@ Look for:
 - **Total coverage line** like `**Total Test Coverage:** 7 Test Suites, 49 Test Cases`
 - Any per-scenario counts
 
-#### 2c. `test_plan/sections/04_Test_Strategy.md`
+#### 2c. Test plan scenario counts — layout-aware
 
-Look for:
+**New layout** (`test_plan/test_design/scenarios/` exists):
+- Per-scenario count: read each `TS-XX_*.md` file's `**Estimated test cases:** N` header
+- Total: `test_plan/test_design/scenarios/README.md` `**Total:** N estimated test cases.`
+- Cross-check: `test_plan/sections/04_Test_Strategy.md` § 4.7 Companion Artifacts trailer line `**Total Test Coverage:** ... N estimated test cases ...`
+
+**Legacy layout** (only `sections/` exists):
 - **§ 4.4 Test Scenarios table** — has `Test Cases` column with per-scenario counts
 - **Total summary** like `**49 Test Cases**`
 

--- a/commands/test-workflow/tw-plan-bugfix.md
+++ b/commands/test-workflow/tw-plan-bugfix.md
@@ -152,15 +152,23 @@ For bug fixes, focus on THREE areas:
 
 ### Step 5: Create Test Scenarios (Bug Fix)
 
-For bug fixes, typically create 2-4 focused scenarios:
+For bug fixes, typically create 2-4 focused scenarios. Each scenario gets its own file under `test_design/scenarios/`.
 
-```markdown
-| ID | Test Scenario | Focus | Est. Cases | Test Activities |
-|----|---------------|-------|------------|-----------------|
-| **TS-01** | Defect Verification | Verify fix | 2-3 | • Exact reproduction steps<br>• Variations of reported scenario<br>• Confirm expected behavior |
-| **TS-02** | Regression Testing | Prevent breaks | 2-3 | • Related functionality<br>• Adjacent features |
-| **TS-03** | Edge Cases & Prevention | Prevent recurrence | 2-4 | • Boundary values<br>• Large/small volumes<br>• Error conditions |
+**Output location:**
+- One file per scenario: `test_design/scenarios/TS-XX_<Slug>.md`
+- Index file: `test_design/scenarios/README.md`
+
+Typical scenario shape for a bug fix:
+
 ```
+| ID | Scenario | Focus | Est. Cases |
+|---|---|---|---|
+| TS-01 | Defect Verification | Verify fix | 2-3 |
+| TS-02 | Regression Testing | Prevent breaks | 2-3 |
+| TS-03 | Edge Cases & Prevention | Prevent recurrence | 2-4 |
+```
+
+Every TS-XX file follows the uniform metadata header, an optional Scenario Preconditions block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in test cases, not scenarios. See `skills/planning-tests/references/scenario-conventions.md`.
 
 **Note:** Bug fix test plans are typically SHORTER than feature test plans. Focus on quality over quantity.
 
@@ -204,38 +212,49 @@ IF no fix approach documented:
 
 ## BEST PRACTICE SECTIONS (Focused Profile)
 
-Bug fix test plans use the Focused review profile, which requires fewer
-best-practice sections. After finalizing test scenarios (Step 5), add:
+Bug fix test plans use the Focused review profile, which requires fewer best-practice sections. The legacy "Coverage Matrix" subsection is **dropped** — derive on-demand from the traceability matrix only if a reviewer asks. See `skills/planning-tests/references/file-layout.md`.
 
-### Step 6: Coverage Matrix
+After finalizing test scenarios (Step 5), produce:
 
-For each test scenario, identify which coverage aspects it addresses.
-Bug fixes typically cover only a few aspects:
+### Step 6: Requirements Traceability (lite)
 
-| Coverage Aspect | Typical for Bug Fixes |
-|-----------------|----------------------|
-| Error Handling | Almost always relevant |
-| Edge Cases | Often relevant |
-| Backward Compatibility | If fix changes existing behavior |
-| UI Configuration | If bug is UI-related |
+Even for bug fixes, write a minimal `test_design/traceability_matrix.md` mapping the bug's reproduction steps and any AC items to the scenarios that cover them. Keep it short — a few rows is fine.
 
-Output an ASCII coverage matrix in `03_Test_Strategy.md` after the
-scenarios table:
+```markdown
+# Requirements Traceability — [PROJECT_ID]
 
-```
-┌────────────────────────┬───────┬───────┬───────┐
-│ Test Aspect            │ TS-01 │ TS-02 │ TS-03 │
-├────────────────────────┼───────┼───────┼───────┤
-│ Error Handling         │   ✓   │       │   ✓   │
-│ Edge Cases             │       │       │   ✓   │
-│ Backward Compatibility │       │   ✓   │       │
-└────────────────────────┴───────┴───────┴───────┘
+| Requirement | Source | Covered By |
+|-------------|--------|------------|
+| Reproduction step 1 (defect repro) | Bug ticket § Steps to Reproduce | [TS-01](scenarios/TS-01_<Slug>.md) |
+| Adjacent area X (regression) | Bug ticket § Comments | [TS-02](scenarios/TS-02_<Slug>.md) |
 ```
 
-> **Note:** Entry/exit criteria, risk assessment, requirements traceability,
-> and diagrams are **skipped** for bug fix plans (Focused profile). Bug fix
-> testing has implicit criteria — the defect is verified fixed and regression
-> passes.
+### Step 7: Risk Register (lite)
+
+Optional but recommended for bug fixes that touch shared code paths or have customer-visible impact. Output as `test_design/risk_register.md`:
+
+```markdown
+# Risk Register — [PROJECT_ID]
+
+| Scenario | Risk Level | Notes |
+|----------|-----------|-------|
+| [TS-XX](scenarios/TS-XX_<Slug>.md) | High/Medium/Low | [Why] |
+```
+
+If the bug is purely cosmetic or contained to a small surface, omit the risk register entirely — note that in `03_Test_Strategy.md` § 3.5 Companion Artifacts.
+
+### Step 8: Overlap Sweep
+
+Even for 2-4 scenarios, run the overlap-review prompt — bugs often re-test paths that adjacent scenarios already cover. See `skills/planning-tests/references/overlap-review.md`.
+
+### Step 9: Environment Rules Check
+
+Confirm `03_Test_Strategy.md` describes environment **capability**, not specific instances. Specifics belong in `config/`. See `skills/planning-tests/references/environment-rules.md`.
+
+> **Skipped for bug fix plans (Focused profile):**
+> - Entry/exit criteria — implicit (defect verified + regression passes)
+> - Diagrams — bug fixes rarely need them; add only if the fix touches a multi-step flow
+> - Hybrid depth strategy — bug fixes don't have variants in the feature sense
 
 ---
 
@@ -246,13 +265,22 @@ scenarios table:
 ```
 test_plan/
 ├── README.md                          # Index with metadata + linked TOC
-└── sections/
-    ├── 01_Problem_Context.md          # § 1.1-1.3
-    ├── 02_Test_Scope.md               # § 2.1-2.3
-    ├── 03_Test_Strategy.md            # § 3.1-3.2 (includes scenarios table)
-    ├── 04_References_Resources.md     # § 4
-    └── 05_Revision_History.md         # § 5
+├── sections/
+│   ├── 01_Problem_Context.md          # § 1.1-1.3
+│   ├── 02_Test_Scope.md               # § 2.1-2.3
+│   ├── 03_Test_Strategy.md            # § 3.1-3.5 (lean: approach, data, depth (rare), entry/exit (implicit), companion-artifacts pointer)
+│   ├── 04_References_Resources.md     # § 4
+│   └── 05_Revision_History.md         # § 5
+└── test_design/
+    ├── scenarios/
+    │   ├── README.md                  # Scenario index (Mermaid optional for bugfix)
+    │   ├── TS-01_<Slug>.md            # One file per scenario
+    │   └── ...
+    ├── traceability_matrix.md         # Lite — see Step 6
+    └── risk_register.md               # Optional — see Step 7
 ```
+
+`test_design/` is a sibling of `sections/` under `test_plan/`. See `skills/planning-tests/references/file-layout.md`.
 
 ### test_plan/README.md
 
@@ -337,34 +365,40 @@ test_plan/
 [Tests to prevent similar issues]
 ```
 
-### test_plan/sections/03_Test_Strategy.md
+### test_plan/sections/03_Test_Strategy.md (lean)
 
 ```markdown
 ## 3. Test Strategy
 
 ### 3.1 Test Approach
-**Test Environment:** [QA/Staging environment details]
-**Test Focus:** Defect verification, regression, edge cases
+- **Test Environment:** [environment requirement; specific tenant in `config/`]
+- **Test Focus:** Defect verification, regression, edge cases
 
-### 3.2 Test Scenarios
+### 3.2 Test Data Setup (if non-trivial; otherwise omit)
+| Item | Value |
+|------|-------|
+| Tenant | [capability requirement; specifics in `config/`] |
 
-| ID | Test Scenario | Focus | Est. Cases | Test Activities |
-|----|---------------|-------|------------|-----------------|
-| **TS-01** | Defect Verification | Verify fix | 2-3 | • [Activities] |
-| **TS-02** | Regression Testing | Prevent breaks | 2-3 | • [Activities] |
-| **TS-03** | Edge Cases | Prevention | 2-4 | • [Activities] |
+### 3.3 Hybrid Depth Strategy (rare for bugfixes — omit unless variants exist)
 
-**Total:** [N] test scenarios, ~[N] test cases
+### 3.4 Entry/Exit Criteria (implicit — defect verified + regression passes)
 
-### 3.3 Coverage Matrix
+### 3.5 Companion Artifacts
 
-┌────────────────────────┬───────┬───────┬───────┐
-│ Test Aspect            │ TS-01 │ TS-02 │ TS-03 │
-├────────────────────────┼───────┼───────┼───────┤
-│ [Relevant aspect 1]   │   ✓   │       │   ✓   │
-│ [Relevant aspect 2]   │       │   ✓   │       │
-└────────────────────────┴───────┴───────┴───────┘
+Per ISO/IEC/IEEE 29119-3, the following live as separate artifacts in `test_design/`:
+
+| Artifact | Location | Contents |
+|---|---|---|
+| Scenario specifications | [`test_design/scenarios/`](../test_design/scenarios/) | One file per TS-XX |
+| Requirements Traceability Matrix (lite) | [`test_design/traceability_matrix.md`](../test_design/traceability_matrix.md) | Repro steps + AC items → scenarios |
+| Risk Register (optional) | [`test_design/risk_register.md`](../test_design/risk_register.md) | Only if the bug has customer-visible impact or shared-code-path risk |
+
+**Total Test Coverage:** [N] Test Scenarios — [N] estimated test cases.
 ```
+
+### test_design/scenarios/README.md, TS-XX_<Slug>.md, traceability_matrix.md, risk_register.md
+
+These files follow the same templates as Type A (Feature). See `/tw-plan-feature` Steps 6-9 and the `skills/planning-tests/references/` directory for full templates and conventions. Bug-fix scenarios usually have a Reproduction Steps preamble; embed it as the optional preamble line per the scenario header convention.
 
 ### test_plan/sections/04_References_Resources.md
 

--- a/commands/test-workflow/tw-plan-enhance.md
+++ b/commands/test-workflow/tw-plan-enhance.md
@@ -132,21 +132,26 @@ IF neither available:
 
 ### Step 5: Create Test Scenarios
 
-For enhancements, typically create 4-6 scenarios:
+For enhancements, typically create 4-6 scenarios. Each scenario gets its own file under `test_design/scenarios/`.
 
-```markdown
-| ID | Test Scenario | Focus | Est. Cases | Test Activities |
-|----|---------------|-------|------------|-----------------|
-| **TS-01** | Enhancement Verification | New behavior | 4-6 | • New functionality<br>• Changed behavior |
-| **TS-02** | Configuration Changes | Settings | 2-4 | • New options<br>• Migration |
-| **TS-03** | Integration Impact | Component interactions | 2-4 | • API changes<br>• Dependencies |
-| **TS-04** | Backward Compatibility | Existing behavior | 2-3 | • Old workflows<br>• Data migration |
+**Output location:**
+- One file per scenario: `test_design/scenarios/TS-XX_<Slug>.md`
+- Index file: `test_design/scenarios/README.md` (lists all TS-XX, includes Mermaid flow diagrams from Step 10)
+
+Typical scenario shape for an enhancement:
+
+```
+| ID | Scenario | Focus | Est. Cases |
+|---|---|---|---|
+| TS-01 | Enhancement Verification | New behavior | 4-6 |
+| TS-02 | Configuration Changes | Settings | 2-4 |
+| TS-03 | Integration Impact | Component interactions | 2-4 |
+| TS-04 | Backward Compatibility | Existing behavior | 2-3 |
 ```
 
-**Scenario organization note:** When the enhancement is substantial
-(adding new user workflows), apply the user-journey methodology from
-`/tw-plan-feature` Step 5 to organize scenarios around user journeys
-rather than technical components.
+Every TS-XX file follows the uniform metadata header, an optional Scenario Preconditions block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in test cases, not scenarios. See `skills/planning-tests/references/scenario-conventions.md`.
+
+**Scenario organization note:** When the enhancement is substantial (adding new user workflows), apply the user-journey methodology from `/tw-plan-feature` Step 5 to organize scenarios around user journeys rather than technical components.
 
 ---
 
@@ -177,41 +182,21 @@ IF enhancement scope is ambiguous:
 
 ## BEST PRACTICE SECTIONS (Standard Profile)
 
-After finalizing test scenarios (Step 5), add the following sections. These
-align with what `/tw-plan-review` checks at the Standard profile level.
+After finalizing test scenarios (Step 5), produce the following companion artifacts. These align with what `/tw-plan-review` checks at the Standard profile level.
 
-### Step 6: Coverage Matrix
+The legacy "Coverage Matrix" section is **dropped** — it's a derivative of the traceability matrix and adds no information beyond it. See `skills/planning-tests/references/file-layout.md`.
 
-For each test scenario, identify which coverage aspects it addresses.
-Include only aspects relevant to the enhancement — omit aspects that do
-not apply.
-
-| Coverage Aspect | Description |
-|-----------------|-------------|
-| UI Configuration | Tests that configure via user interface |
-| API Configuration | Tests that configure via API |
-| Data Flow | How data moves through the system |
-| Error Handling | Invalid inputs, edge cases, failures |
-| Backward Compatibility | Existing functionality still works |
-| Client/End-user Validation | End-to-end user scenarios |
-| Edge Cases | Boundary conditions, empty/max states |
-
-Output an ASCII coverage matrix in `04_Test_Strategy.md` after the
-scenarios table.
-
-### Step 7: Hybrid Depth Strategy
+### Step 6: Hybrid Depth Strategy
 
 If the enhancement has variants:
 
-1. **Identify the representative case** — the scenario covering the most
-   coverage aspects. This gets deep testing.
-2. **Identify variants** — scenarios differing by only 1-2 parameters.
-   These get lightweight validation only.
-3. Document which scenarios are "deep" vs "wide" in `04_Test_Strategy.md`.
+1. **Identify the representative case** — the scenario covering the broadest set of behaviors. This gets deep testing.
+2. **Identify variants** — scenarios differing by only 1-2 parameters. These get lightweight validation only.
+3. Document which scenarios are "deep" vs "wide" in `04_Test_Strategy.md` § 4.5.
 
-### Step 8: Requirements Traceability
+### Step 7: Requirements Traceability
 
-Map each requirement/acceptance criterion to test scenarios:
+Map each requirement/acceptance criterion to test scenarios. Output as a **standalone artifact** at `test_design/traceability_matrix.md` — not inlined in the strategy file.
 
 ```
 1. List requirements from:
@@ -220,26 +205,33 @@ Map each requirement/acceptance criterion to test scenarios:
    - Enhancement ticket acceptance criteria
 2. For each requirement, note which scenario(s) cover it
 3. Flag uncovered requirements
+4. Add a "Coverage Gaps" subsection for items the source documents don't specify
 ```
 
-Add a traceability table to `04_Test_Strategy.md`:
+`test_design/traceability_matrix.md` template:
 
 ```markdown
-### Requirements Traceability
+# Requirements Traceability Matrix — [PROJECT_ID]
+
+## Coverage
 
 | Requirement | Source | Covered By |
 |-------------|--------|------------|
-| [Requirement 1] | Enhancement ticket AC #1 | TS-01 |
-| [Requirement 2] | § 2.1 New Functionality | TS-01, TS-02 |
-| [Requirement 3] | § 3.3 Backward Compat | TS-04 |
+| [Req 1] | Enhancement ticket AC #1 | [TS-01](scenarios/TS-01_<Slug>.md) |
+| [Req 2] | § 2.1 New Functionality | [TS-01](scenarios/TS-01_<Slug>.md), [TS-02](scenarios/TS-02_<Slug>.md) |
+| [Req 3] | § 3.3 Backward Compat | [TS-04](scenarios/TS-04_<Slug>.md) |
+
+## Coverage Gaps
+
+- [Items the source documents don't specify but QA observed in the live build]
 ```
 
-### Step 9: Entry/Exit Criteria
+### Step 8: Entry/Exit Criteria
 
-Add to `04_Test_Strategy.md`:
+Add to `04_Test_Strategy.md` § 4.6:
 
 ```markdown
-### Entry/Exit Criteria
+### 4.6 Entry/Exit Criteria
 
 **Entry Criteria:**
 - [ ] Enhancement deployed to test environment
@@ -252,27 +244,40 @@ Add to `04_Test_Strategy.md`:
 - [ ] No regression in existing functionality
 ```
 
-### Step 10: Risk Assessment (Lite)
+### Step 9: Risk Assessment
 
-Flag only high-risk scenarios. For enhancements, pay special attention to:
+For enhancements, pay special attention to:
 - Backward compatibility risks
 - Integration breakage risks
 - Data migration risks
 
-Add a brief risk note to `04_Test_Strategy.md`:
+Output as a **standalone artifact** at `test_design/risk_register.md` — not inlined in the strategy file.
+
+`test_design/risk_register.md` template:
 
 ```markdown
-### Risk Assessment
+# Risk Register — [PROJECT_ID]
 
-| Scenario | Risk Level | Notes |
-|----------|-----------|-------|
-| TS-XX | High | [Why this is high risk] |
+| Scenario | Risk Level | Likelihood | Impact | Mitigation |
+|----------|-----------|------------|--------|------------|
+| [TS-XX](scenarios/TS-XX_<Slug>.md) | High | [Likelihood] | [Why high impact] | [Mitigation] |
 ```
 
-### Step 11: Diagrams (5+ Scenarios)
+### Step 10: Diagrams (5+ Scenarios)
 
-If the test plan has 5 or more scenarios, run `/tw-diagrams` to generate
-Configuration Flow, Data Flow, and Modular Test Design diagrams.
+If the test plan has 5 or more scenarios, run `/tw-diagrams` to generate Mermaid flow diagrams. Place them at the top of `test_design/scenarios/README.md` (the scenario index), labeled with the TS-XX each node belongs to.
+
+### Step 11: Overlap Sweep
+
+After scenarios + traceability + risk register are written, run an overlap review against every scenario. The prompt:
+
+> *List any case in this scenario whose object-under-test or assertion overlaps another scenario's case. Note as: layered (justified) or duplicate (fix).*
+
+See `skills/planning-tests/references/overlap-review.md`.
+
+### Step 12: Environment Rules Check
+
+Confirm `04_Test_Strategy.md` § 4.3 and § 4.4 describe environment **capability**, not specific instances. Specific tenant names, credentials, and hardware serials belong in `config/`. See `skills/planning-tests/references/environment-rules.md`.
 
 ---
 
@@ -283,14 +288,24 @@ Configuration Flow, Data Flow, and Modular Test Design diagrams.
 ```
 test_plan/
 ├── README.md                              # Index with metadata + linked TOC
-└── sections/
-    ├── 01_Enhancement_Context.md          # § 1.1-1.2
-    ├── 02_Enhancement_Definition.md       # § 2.1-2.2
-    ├── 03_Test_Scope.md                   # § 3.1-3.3
-    ├── 04_Test_Strategy.md                # § 4.1-4.6 (includes scenarios, coverage matrix, traceability, entry/exit, risk)
-    ├── 05_References_Resources.md         # § 5
-    └── 06_Revision_History.md             # § 6
+├── sections/
+│   ├── 01_Enhancement_Context.md          # § 1.1-1.2
+│   ├── 02_Enhancement_Definition.md       # § 2.1-2.2
+│   ├── 03_Test_Scope.md                   # § 3.1-3.3
+│   ├── 04_Test_Strategy.md                # § 4.1-4.7 (lean: levels/types if non-trivial, approach, data, depth, entry/exit, companion-artifacts pointer)
+│   ├── 05_References_Resources.md         # § 5
+│   └── 06_Revision_History.md             # § 6
+└── test_design/
+    ├── scenarios/
+    │   ├── README.md                      # Scenario index + Mermaid flow diagrams
+    │   ├── TS-01_<Slug>.md                # One file per scenario
+    │   ├── TS-02_<Slug>.md
+    │   └── ...
+    ├── traceability_matrix.md             # Requirements → scenarios mapping
+    └── risk_register.md                   # Per-scenario risk
 ```
+
+`test_design/` is a sibling of `sections/` under `test_plan/`. See `skills/planning-tests/references/file-layout.md`.
 
 ### test_plan/README.md
 
@@ -378,48 +393,33 @@ test_plan/
 [Tests for existing functionality]
 ```
 
-### test_plan/sections/04_Test_Strategy.md
+### test_plan/sections/04_Test_Strategy.md (lean)
 
 ```markdown
 ## 4. Test Strategy
 
-### 4.1 Test Approach
-**Focus:** Validate enhancement works as specified + no regression
+### 4.1 Test Levels (if non-trivial; otherwise omit for enhancements)
 
-### 4.2 Test Scenarios
+### 4.2 Test Types (if non-trivial; otherwise omit)
 
-| ID | Test Scenario | Focus | Est. Cases | Test Activities |
-|----|---------------|-------|------------|-----------------|
-| **TS-01** | Enhancement Verification | New/changed behavior | 4-6 | • [Activities] |
-| **TS-02** | Configuration Changes | Settings | 2-4 | • [Activities] |
-| **TS-03** | Integration Impact | Component interactions | 2-4 | • [Activities] |
-| **TS-04** | Backward Compatibility | Existing behavior | 2-3 | • [Activities] |
+### 4.3 Test Approach
+- **Focus:** Validate enhancement works as specified + no regression
+- **Test Environment:** [environment requirement; specific tenant in `config/`]
+- **Visual Baseline:** [path to wireframes / live captures]
 
-**Total:** [N] test scenarios, ~[N] test cases
+### 4.4 Test Data Setup
+| Item | Value |
+|------|-------|
+| Tenant | [capability requirement; specifics in `config/`] |
+| ... | ... |
 
-### 4.3 Coverage Matrix
+### 4.5 Hybrid Depth Strategy
 
-┌────────────────────────┬───────┬───────┬───────┬───────┐
-│ Test Aspect            │ TS-01 │ TS-02 │ TS-03 │ TS-04 │
-├────────────────────────┼───────┼───────┼───────┼───────┤
-│ [Relevant aspect 1]   │   ✓   │       │       │   ✓   │
-│ [Relevant aspect 2]   │       │   ✓   │   ✓   │       │
-└────────────────────────┴───────┴───────┴───────┴───────┘
+**Deep (representative case):** TS-XX — [reason it's the deep test]
 
-### 4.3.1 Hybrid Depth Strategy
+**Wide (variant scenarios):** TS-YY — [what makes them variants]
 
-| Scenario | Depth | Rationale |
-|----------|-------|-----------|
-| TS-XX | Deep | Representative case — covers most aspects |
-| TS-XX | Wide | Variant — differs by 1-2 parameters |
-
-### 4.4 Requirements Traceability
-
-| Requirement | Source | Covered By |
-|-------------|--------|------------|
-| [Req 1] | [Source] | TS-XX |
-
-### 4.5 Entry/Exit Criteria
+### 4.6 Entry/Exit Criteria
 
 **Entry Criteria:**
 - [ ] Enhancement deployed to test environment
@@ -429,12 +429,22 @@ test_plan/
 - [ ] 100% P0 pass, ≥90% P1 pass
 - [ ] No regression in existing functionality
 
-### 4.6 Risk Assessment
+### 4.7 Companion Artifacts
 
-| Scenario | Risk Level | Notes |
-|----------|-----------|-------|
-| TS-XX | [High/Medium/Low] | [Details] |
+Per ISO/IEC/IEEE 29119-3, the following live as separate artifacts in `test_design/`:
+
+| Artifact | Location | Contents |
+|---|---|---|
+| Scenario specifications | [`test_design/scenarios/`](../test_design/scenarios/) | One file per TS-XX |
+| Requirements Traceability Matrix | [`test_design/traceability_matrix.md`](../test_design/traceability_matrix.md) | Requirement → scenario mapping |
+| Risk Register | [`test_design/risk_register.md`](../test_design/risk_register.md) | Per-scenario risk |
+
+**Total Test Coverage:** [N] Test Scenarios — [N] estimated test cases.
 ```
+
+### test_design/scenarios/README.md, TS-XX_<Slug>.md, traceability_matrix.md, risk_register.md
+
+These files follow the same templates as Type A (Feature). See `/tw-plan-feature` Steps 6-9 and the `skills/planning-tests/references/` directory for full templates and conventions.
 
 ### test_plan/sections/05_References_Resources.md
 

--- a/commands/test-workflow/tw-plan-feature.md
+++ b/commands/test-workflow/tw-plan-feature.md
@@ -119,7 +119,19 @@ Determine how to test the feature:
 ### Step 5: Create Test Scenarios
 
 Define high-level test scenarios (5-8 typical). Each scenario becomes a
-Test Suite (TS-XX). Focus on WHAT to test, not HOW to test.
+Test Suite (TS-XX) in its own file under `test_design/scenarios/`. Focus
+on WHAT to test, not HOW to test.
+
+**Output location:**
+- One file per scenario: `test_design/scenarios/TS-XX_<Slug>.md`
+- Index file: `test_design/scenarios/README.md` (lists all TS-XX, includes Mermaid flow diagrams from Step 10)
+
+Every TS-XX file follows the uniform metadata header, an optional Scenario
+Preconditions block, and a `### Case N:` block per case (Objective +
+Checkpoints mandatory; Preconditions + Notes optional). Click-by-click
+steps belong in test cases, not scenarios. See
+`skills/planning-tests/references/scenario-conventions.md` for the
+header template, body-shape decision rule, and cross-link conventions.
 
 **IMPORTANT:** Follow Steps 5a-5f below to derive scenarios from user
 journeys rather than mirroring the HLD's technical architecture.
@@ -348,54 +360,30 @@ IF feature scope is ambiguous:
 
 ## BEST PRACTICE SECTIONS
 
-After finalizing test scenarios (Step 5), add the following sections to the
-test plan. These align with what `/tw-plan-review` checks — producing them
+After finalizing test scenarios (Step 5), produce the following companion
+artifacts. These align with what `/tw-plan-review` checks — producing them
 during creation prevents systematic review findings.
 
-### Step 6: Coverage Matrix
+The legacy "Coverage Matrix" section is **dropped** — it's a derivative of
+the traceability matrix and adds no information beyond it. Generate one
+on-demand from `traceability_matrix.md` only if a reviewer specifically
+asks. See `skills/planning-tests/references/file-layout.md`.
 
-For each test scenario, identify which coverage aspects it addresses.
-Include only aspects relevant to the feature — omit aspects that do not apply.
-
-| Coverage Aspect | Description |
-|-----------------|-------------|
-| UI Configuration | Tests that configure via user interface |
-| API Configuration | Tests that configure via API |
-| Data Flow | How data moves through the system |
-| Error Handling | Invalid inputs, edge cases, failures |
-| Backward Compatibility | Existing functionality still works |
-| Client/End-user Validation | End-to-end user scenarios |
-| Feature Flags | ON/OFF state behavior |
-| Edge Cases | Boundary conditions, empty/max states |
-| Performance | Response time, throughput |
-| Accessibility | WCAG compliance, keyboard navigation |
-
-Output an ASCII coverage matrix in `04_Test_Strategy.md` after the scenarios
-table:
-
-```
-┌────────────────────────┬───────┬───────┬───────┐
-│ Test Aspect            │ TS-01 │ TS-02 │ TS-03 │
-├────────────────────────┼───────┼───────┼───────┤
-│ UI Configuration       │   ✓   │       │   ✓   │
-│ Error Handling         │       │   ✓   │       │
-│ Edge Cases             │       │       │   ✓   │
-└────────────────────────┴───────┴───────┴───────┘
-```
-
-### Step 7: Hybrid Depth Strategy
+### Step 6: Hybrid Depth Strategy
 
 If the feature has variants (multiple types, modes, configurations):
 
-1. **Identify the representative case** — the scenario covering the most
-   coverage aspects. This gets deep, comprehensive testing.
+1. **Identify the representative case** — the scenario covering the broadest
+   set of behaviors. This gets deep, comprehensive testing.
 2. **Identify variants** — scenarios that differ by only 1-2 parameters.
    These get configuration + basic functionality tests only.
-3. Document which scenarios are "deep" vs "wide" in `04_Test_Strategy.md`.
+3. Document which scenarios are "deep" vs "wide" in `04_Test_Strategy.md` § 4.5.
 
-### Step 8: Requirements Traceability
+### Step 7: Requirements Traceability
 
-Map each requirement/acceptance criterion to test scenarios:
+Map each requirement/acceptance criterion to test scenarios. Output as a
+**standalone artifact** at `test_design/traceability_matrix.md` — not
+inlined in the strategy file.
 
 ```
 1. List requirements from:
@@ -404,25 +392,41 @@ Map each requirement/acceptance criterion to test scenarios:
    - confluence/HLD_*.md (if available)
 2. For each requirement, note which scenario(s) cover it
 3. Flag uncovered requirements — add scenarios or note as out of scope
+4. Add a "Coverage Gaps" subsection for items the HLD doesn't specify
+   but QA observed in the live build
 ```
 
-Add a traceability table to `04_Test_Strategy.md`:
+`test_design/traceability_matrix.md` template:
 
 ```markdown
-### 4.6 Requirements Traceability
+# Requirements Traceability Matrix — [PROJECT_ID]
+
+Maps each requirement to the scenario(s) that cover it. Source documents:
+[list source HLDs, FRs, review transcripts].
+
+## Coverage
 
 | Requirement | Source | Covered By |
 |-------------|--------|------------|
-| [Requirement 1] | HLD § X.X | TS-01, TS-02 |
-| [Requirement 2] | Jira AC #3 | TS-03 |
+| [Req 1] | HLD § X.X | [TS-01](scenarios/TS-01_<Slug>.md), [TS-02](scenarios/TS-02_<Slug>.md) |
+| [Req 2] | Jira AC #3 | [TS-03](scenarios/TS-03_<Slug>.md) |
+
+## Coverage Gaps
+
+- **[Gap description]** — the HLD does not specify [X]. Tested as observed
+  (TS-XX); the actual behavior will be captured live for the test plan review.
 ```
 
-### Step 9: Entry/Exit Criteria
+Cross-link from scenario → matrix uses `../traceability_matrix.md` if you
+want to add reverse references; matrix → scenario uses
+`scenarios/TS-XX_<Slug>.md` (relative within `test_design/`).
 
-Add to `04_Test_Strategy.md`:
+### Step 8: Entry/Exit Criteria
+
+Add to `04_Test_Strategy.md` § 4.6:
 
 ```markdown
-### 4.7 Entry/Exit Criteria
+### 4.6 Entry/Exit Criteria
 
 **Entry Criteria (when can testing start?):**
 - [ ] Build deployed to test environment
@@ -437,9 +441,10 @@ Add to `04_Test_Strategy.md`:
 - [ ] Sign-off from QA lead
 ```
 
-### Step 10: Risk Assessment
+### Step 9: Risk Assessment
 
-For each scenario, evaluate risk:
+For each scenario, evaluate risk. Output as a **standalone artifact** at
+`test_design/risk_register.md` — not inlined in the strategy file.
 
 | Risk Level | Criteria |
 |------------|----------|
@@ -447,26 +452,66 @@ For each scenario, evaluate risk:
 | **Medium** | Modified existing flow, partial rollback, affects subset of users |
 | **Low** | Well-understood path, easy rollback, internal-only impact |
 
-Add a risk table to `04_Test_Strategy.md`:
+`test_design/risk_register.md` template:
 
 ```markdown
-### 4.8 Risk Assessment
+# Risk Register — [PROJECT_ID]
+
+Per-scenario risk assessment. Risk level reflects the joint judgment of
+likelihood × impact; mitigation describes the action QA takes during
+execution.
 
 | Scenario | Risk Level | Likelihood | Impact | Mitigation |
 |----------|-----------|------------|--------|------------|
-| TS-01 | Medium | Moderate | User-facing | Deep testing |
-| TS-02 | Low | Low | Internal | Standard coverage |
+| [TS-01](scenarios/TS-01_<Slug>.md) | Medium | Moderate | User-facing | Deep testing |
+| [TS-02](scenarios/TS-02_<Slug>.md) | Low | Low | Internal | Standard coverage |
 ```
 
-### Step 11: Diagrams (5+ Scenarios)
+Cross-link to scenarios uses `scenarios/TS-XX_<Slug>.md` (relative within
+`test_design/`).
 
-If the test plan has 5 or more scenarios, run `/tw-diagrams` to generate:
-- Configuration Flow diagram
-- Data Flow diagram
-- Modular Test Design diagram
+### Step 10: Diagrams (5+ Scenarios)
 
-Place diagrams in `test_plan/diagrams/` or reference them from
-`04_Test_Strategy.md`.
+If the test plan has 5 or more scenarios, run `/tw-diagrams` to generate
+Mermaid flow diagrams. Place them at the top of
+`test_design/scenarios/README.md` (the scenario index), labeled with the
+TS-XX each node belongs to.
+
+Typical diagrams:
+- Admin flow (configuration journey)
+- End-user flow (visitor / consumer journey)
+- API flow (when there's a non-UI client path)
+
+Each Mermaid node should reference at least one TS-XX so reviewers can
+spot uncovered nodes (gaps) and shared edges (overlaps).
+
+### Step 11: Overlap Sweep
+
+After scenarios + traceability + risk register are written, run an
+overlap review against every scenario. The prompt:
+
+> *List any case in this scenario whose object-under-test or assertion
+> overlaps another scenario's case. Note as: layered (justified) or
+> duplicate (fix).*
+
+Apply per case, compare against every case in every other scenario.
+Resolutions either get applied immediately or batched for a final sweep
+before merge. See
+`skills/planning-tests/references/overlap-review.md` for the
+layered-vs-duplicate decision rule and examples.
+
+### Step 12: Environment Rules Check
+
+Before declaring the plan ready for review, confirm `04_Test_Strategy.md`
+§ 4.3 (Test Approach) and § 4.4 (Test Data Setup) describe environment
+**capability**, not specific instances:
+
+- ✅ *"Test Tenant: any tenant where the feature flag is operational; current selection in `config/`."*
+- ❌ *"Test Tenant: \<tenant-id\> (per HLD-review handoff from \<reviewer\>)."*
+
+Specific tenant names, credentials, hardware serials, and network names
+belong in `config/` files. See
+`skills/planning-tests/references/environment-rules.md`.
 
 ---
 
@@ -477,14 +522,26 @@ Place diagrams in `test_plan/diagrams/` or reference them from
 ```
 test_plan/
 ├── README.md                              # Index with metadata + linked TOC
-└── sections/
-    ├── 01_Project_Business_Context.md     # § 1.1-1.3
-    ├── 02_Feature_Definition.md           # § 2.1-2.3
-    ├── 03_Scope_Boundaries.md             # § 3.1-3.2
-    ├── 04_Test_Strategy.md                # § 4.1-4.9 (includes scenarios, coverage matrix, traceability, entry/exit, risk)
-    ├── 05_References_Resources.md         # § 5
-    └── 06_Revision_History.md             # § 6
+├── sections/
+│   ├── 01_Project_Business_Context.md     # § 1.1-1.3
+│   ├── 02_Feature_Definition.md           # § 2.1-2.3
+│   ├── 03_Scope_Boundaries.md             # § 3.1-3.2
+│   ├── 04_Test_Strategy.md                # § 4.1-4.7 (lean: levels, types, approach, data, depth, entry/exit, companion-artifacts pointer)
+│   ├── 05_References_Resources.md         # § 5
+│   └── 06_Revision_History.md             # § 6
+└── test_design/
+    ├── scenarios/
+    │   ├── README.md                      # Scenario index + Mermaid flow diagrams
+    │   ├── TS-01_<Slug>.md                # One file per scenario
+    │   ├── TS-02_<Slug>.md
+    │   └── ...
+    ├── traceability_matrix.md             # Requirements → scenarios mapping (was § 4.7)
+    └── risk_register.md                   # Per-scenario risk (was § 4.9)
 ```
+
+`test_design/` is a sibling of `sections/` under `test_plan/`. Do not nest one inside the other.
+
+See `skills/planning-tests/references/file-layout.md` for the rationale and migration policy (new projects use this layout; completed projects keep their original).
 
 ### test_plan/README.md
 
@@ -546,42 +603,45 @@ test_plan/
 ### 3.2 Out of Scope
 ```
 
-### test_plan/sections/04_Test_Strategy.md
+### test_plan/sections/04_Test_Strategy.md (lean)
 
 ```markdown
 ## 4. Test Strategy
+
 ### 4.1 Test Levels
+| Level | Approach |
+|-------|----------|
+| Functional | ... |
+| Integration | ... |
+| Regression | ... |
+
 ### 4.2 Test Types
+| Type | Coverage |
+|------|----------|
+| GUI Testing | ... |
+| API Testing | ... |
+| End-to-End | ... |
+
 ### 4.3 Test Approach
-### 4.4 Test Scenarios
+- **Verification Perspective:** Hybrid (Web GUI + API + ...)
+- **Test Environment:** [environment requirement; specific tenant in `config/`]
+- **Feature Flag:** `<flag-name>` (if applicable)
+- **Visual Baseline:** [path to wireframes / live captures]
 
-| ID | Test Scenario | Focus | Est. Cases | Test Activities |
-|----|---------------|-------|------------|-----------------|
-| **TS-01** | [Name] | [Focus] | [N] | • [Activity 1]<br>• [Activity 2] |
-| **TS-02** | [Name] | [Focus] | [N] | • [Activity 1]<br>• [Activity 2] |
+### 4.4 Test Data Setup
+| Item | Value |
+|------|-------|
+| Tenant | [capability requirement; specifics in `config/`] |
+| Networks | ... |
+| ... | ... |
 
-**Total Test Coverage:**
-- **[N] Test Suites**
-- **[N] Test Cases** (estimated)
+### 4.5 Hybrid Depth Strategy
 
-### 4.5 Test Data Setup (if applicable)
+**Deep (representative case):** TS-XX — [reason it's the deep test]
 
-### 4.6 Coverage Matrix
+**Wide (variant scenarios):** TS-YY — [what makes them variants]
 
-┌────────────────────────┬───────┬───────┬───────┐
-│ Test Aspect            │ TS-01 │ TS-02 │ TS-03 │
-├────────────────────────┼───────┼───────┼───────┤
-│ [Relevant aspect 1]   │   ✓   │       │   ✓   │
-│ [Relevant aspect 2]   │       │   ✓   │       │
-└────────────────────────┴───────┴───────┴───────┘
-
-### 4.7 Requirements Traceability
-
-| Requirement | Source | Covered By |
-|-------------|--------|------------|
-| [Req 1] | [Source] | TS-XX |
-
-### 4.8 Entry/Exit Criteria
+### 4.6 Entry/Exit Criteria
 
 **Entry Criteria:**
 - [ ] [Prerequisites]
@@ -590,11 +650,89 @@ test_plan/
 - [ ] 100% P0 pass, ≥90% P1 pass
 - [ ] All P0/P1 defects resolved or deferred
 
-### 4.9 Risk Assessment
+### 4.7 Companion Artifacts
 
-| Scenario | Risk Level | Likelihood | Impact | Mitigation |
-|----------|-----------|------------|--------|------------|
-| TS-XX | [High/Medium/Low] | [Details] | [Details] | [Strategy] |
+Per ISO/IEC/IEEE 29119-3, the following live as separate artifacts in `test_design/`:
+
+| Artifact | Location | Contents |
+|---|---|---|
+| Scenario specifications | [`test_design/scenarios/`](../test_design/scenarios/) | One file per TS-XX with focus, est. cases, activities |
+| Requirements Traceability Matrix | [`test_design/traceability_matrix.md`](../test_design/traceability_matrix.md) | Requirement → scenario mapping; coverage gaps |
+| Risk Register | [`test_design/risk_register.md`](../test_design/risk_register.md) | Per-scenario risk level, likelihood/impact, mitigation |
+
+**Total Test Coverage:** [N] Test Scenarios — [N] estimated test cases (see scenario index).
+```
+
+### test_design/scenarios/README.md
+
+```markdown
+# Scenario Specifications — [PROJECT_ID]
+
+Per ISO/IEC/IEEE 29119-3, scenarios live separate from the test plan. The plan in `test_plan/sections/04_Test_Strategy.md` describes the strategy, scope, and gates; this directory holds the detailed scenarios.
+
+[One-paragraph note about journey order or organizing principle.]
+
+## Admin Flow
+
+\`\`\`mermaid
+flowchart LR
+    A[step] --> B[step]
+\`\`\`
+
+## End-User Flow
+
+\`\`\`mermaid
+flowchart LR
+    A[step] --> B[step]
+\`\`\`
+
+## Scenario Index
+
+| ID | Scenario | Focus | Est. Cases |
+|---|---|---|---|
+| [TS-01](TS-01_<Slug>.md) | [Name] | [GUI / API / E2E] | [N] |
+| [TS-02](TS-02_<Slug>.md) | [Name] | [Focus] | [N] |
+
+**Total:** [N] estimated test cases.
+```
+
+### test_design/scenarios/TS-XX_<Slug>.md
+
+Each scenario file follows the uniform metadata header, an optional `## Scenario Preconditions` block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in the test cases, not the scenarios. See `skills/planning-tests/references/scenario-conventions.md` for the full template.
+
+```markdown
+# TS-XX: <name>
+
+**Focus:** <GUI / API / E2E / Config / hybrid>
+
+**Estimated test cases:** N
+
+**Test plan reference:** [`test_plan/sections/04_Test_Strategy.md`](../../sections/04_Test_Strategy.md)
+
+---
+
+<intro paragraph — what this scenario owns, what it doesn't, key cross-references. Split into 2-3 short paragraphs at conceptual seams when it crosses 3+ ideas — see `skills/reviewing-typography/references/typography-principles.md` anti-pattern A2.>
+
+## Scenario Preconditions
+
+- <setup that applies to every case>
+
+## Test Cases
+
+### Case 1: <Short imperative title>
+
+- **Objective:** <one sentence — what the case proves>
+- **Checkpoints:**
+  - <Observable 1>
+  - <Observable 2>
+
+### Case 2: <Short imperative title>
+
+- **Objective:** ...
+- **Preconditions:** <case-specific, optional>
+- **Checkpoints:**
+  - ...
+- **Notes:** <HLD-silent flags, TKT cross-refs, sequencing hints — optional>
 ```
 
 ### test_plan/sections/05_References_Resources.md
@@ -629,10 +767,11 @@ After creating the test plan, run `/tw-plan-review` to verify coverage before cr
     └── Detected Type A: New Feature
                               ↓
 /tw-plan-feature  ◄── YOU ARE HERE
-    └── Creates test_plan/README.md + test_plan/sections/*.md
+    └── Creates test_plan/{README, sections/*}
+        + test_plan/test_design/{scenarios/, traceability_matrix, risk_register}
                               ↓
 /tw-plan-review
-    └── Reviews test plan for gaps, generates coverage matrix
+    └── Reviews test plan for gaps + runs the overlap sweep
                               ↓
 /tw-case-init
     └── Routes to appropriate test case workflow

--- a/commands/test-workflow/tw-plan-review.md
+++ b/commands/test-workflow/tw-plan-review.md
@@ -58,14 +58,20 @@ Read the test plan index and section files:
    - "Enhancement Validation" → Standard profile (hybrid review)
 3. Announce detected profile: "Review profile: [Full/Standard/Focused]"
 4. Read all files in test_plan/sections/
-5. Extract test scenarios from the Test Strategy section file:
-   - Feature/Enhancement: sections/04_Test_Strategy.md § 4.4 / § 4.2
-   - Bug Fix: sections/03_Test_Strategy.md § 3.2
+5. Extract test scenarios — layout-aware:
+   IF test_plan/test_design/scenarios/ exists (new layout):
+     - Read each test_plan/test_design/scenarios/TS-XX_*.md file
+     - Each file's metadata header gives the Focus and Estimated test cases
+     - The intro paragraph + optional `## Scenario Preconditions` block establish the shared context
+     - Each `### Case N:` block (Objective + Checkpoints mandatory; Preconditions + Notes optional) is the source of truth for that case
+   ELSE (legacy layout):
+     - Feature/Enhancement: sections/04_Test_Strategy.md § 4.4 / § 4.2
+     - Bug Fix: sections/03_Test_Strategy.md § 3.2
 6. For each scenario, note:
    - Scenario ID and name
    - Focus area
    - Estimated test case count
-   - Test activities listed
+   - Per-case Objective + Checkpoints (use these for the coverage matrix; ignore Steps if any — those belong in the test cases)
 ```
 
 > **Fallback:** If `test_plan/sections/` does not exist, read `test_plan/README.md` directly.
@@ -87,9 +93,11 @@ For each test scenario, identify which aspects it covers. Select only the aspect
 | Performance | Response time, throughput | Scale-sensitive features |
 | Accessibility | WCAG compliance, keyboard navigation | UI features only |
 
-### Step 3: Generate Coverage Matrix [All Profiles]
+### Step 3: Generate Coverage Matrix (on demand) [All Profiles]
 
-Create an ASCII coverage matrix showing what each scenario covers:
+The coverage matrix is **no longer authored as a separate artifact** — it's a derivative of the requirements traceability matrix (`test_design/traceability_matrix.md` in the new layout). See `skills/planning-tests/references/file-layout.md`.
+
+For review purposes, generate one **on demand** if a reviewer specifically asks. Format:
 
 ```
 ┌────────────────────────┬───────┬───────┬───────┬───────┬───────┐
@@ -103,7 +111,7 @@ Create an ASCII coverage matrix showing what each scenario covers:
 └────────────────────────┴───────┴───────┴───────┴───────┴───────┘
 ```
 
-**Note:** This coverage matrix is the SINGLE source of truth. It should NOT be recreated in test case design.
+Output as part of the review report. Do NOT save it back into `04_Test_Strategy.md` or anywhere else under `test_plan/`.
 
 ### Step 4: Generate Diagrams (For 5+ Scenarios) [Full / Standard]
 
@@ -126,10 +134,24 @@ Report any issues found:
 - Missing edge case coverage
 - Missing integration tests
 
-**Overlaps:**
+**Overlaps (mandatory overlap sweep):**
+
+For each scenario, apply the prompt:
+
+> *List any case in this scenario whose object-under-test or assertion overlaps another scenario's case. Note as: layered (justified) or duplicate (fix).*
+
+For every flagged pair, record:
+- TS-X case N ⟷ TS-Y case M
+- object-under-test
+- layered (justified) vs duplicate (fix)
+- recommended resolution (keep both | merge | move to TS-X | delete from TS-Y)
+
+See `skills/planning-tests/references/overlap-review.md` for the layered-vs-duplicate decision rule and examples from past reviews.
+
+Common overlap shapes:
 - Multiple scenarios testing the same aspect
 - Redundant test activities
-- Duplicated coverage
+- Duplicated coverage between a "deep representative" scenario and a "wide variants" scenario when the latter re-runs the full case-set per variant instead of just placement + happy path
 
 **Recommendations:**
 - Scenarios to consolidate

--- a/commands/test-workflow/tw-templates.md
+++ b/commands/test-workflow/tw-templates.md
@@ -121,16 +121,25 @@ IF feature scope is ambiguous:
 
 ### Test Case File Header Template
 
+Each metadata label must be its own paragraph (blank line between). Stacking consecutive `**Label:**` lines without a blank line causes the markdown converter to render the whole block as a single `<p>` with `<br/>` separators, fusing the metadata visually with whatever follows. See `skills/reviewing-typography/references/typography-principles.md` anti-pattern A1.
+
 ```markdown
 # TS-XX: [Scenario Name]
 
-**Objective:** [Copy from test plan]
 **Focus:** [Test type - Functional, UI/UX, etc.]
+
 **Test Cases:** [Count]
+
 **Test Plan Reference:** test_plan/sections/[Section_File].md § X.X, TS-XX
+
+---
+
+**Objective:** [Copy from test plan — keep as its own paragraph after the divider; maps to TestLink Suite Details on sync]
 ```
 
 ### Test Case Template
+
+**Do NOT add `**Priority:**` or `**Test Type:**` to the markdown.** Priority and Test Type are managed in TestLink (per `/tw-case-review` Step 7 — Priority Recommendation runs against the markdown files and feeds TestLink; the values themselves don't live in markdown). Only `**Execution Type:**` belongs in the file (it's the markdown-to-TestLink mapping per the table below).
 
 ```markdown
 ## TC-XX: [Descriptive Name]
@@ -259,7 +268,7 @@ Create variations based on:
          └────────────────────┼────────────────────┘
                               ↓
 /tw-plan-review
-    └── Reviews test plan, generates coverage matrix
+    └── Reviews test plan, runs overlap sweep, generates coverage on demand
                               ↓
 /tw-case-init
     └── Detects type, routes to case workflow

--- a/skills/designing-cases/SKILL.md
+++ b/skills/designing-cases/SKILL.md
@@ -28,6 +28,7 @@ Copy and track your progress:
 - [ ] Validate: Scenario count + case count + quality assessment
 - [ ] Step 5: Create Confluence test case pages
 - [ ] Validate: Confluence URL + page count
+- [ ] Step 6: Review typography (run reviewing-typography skill on every published page)
 ```
 
 ## Steps
@@ -103,6 +104,17 @@ Run `/cf-review-page` to verify formatting. Use `/cf-format-guide` for Confluenc
 Report:
 - Confluence parent page URL
 - Number of pages created
+
+### Step 6: Review Typography (MANDATORY — gates publish completion)
+
+After Step 5 content-rendering is clean, run the `reviewing-typography` skill against every page just published. The skill applies Gestalt proximity and visual hierarchy principles to the **actual rendered content** — catching wall-of-text test cases, bold-label inflation across many cases on one page, and proximity collisions between case sections that no template could predict because they depend on the test cases' length and density.
+
+See `skills/reviewing-typography/SKILL.md` for the walk-and-fix procedure. Pass it the list of page IDs created in Step 5.
+
+### Validate
+
+Report:
+- Typography review verdict: N pages CLEAN, N pages had findings + fixes applied
 
 ## Expected Input
 

--- a/skills/designing-cases/references/test-case-design-rules.md
+++ b/skills/designing-cases/references/test-case-design-rules.md
@@ -1,0 +1,55 @@
+# Test Case Design Rules
+
+## Sanitization Checklist
+
+Before completing test case design, verify all test case content passes this checklist:
+
+- No hardcoded tenant names — use generic placeholders (e.g., "TestTenant-A")
+- No real credentials or passwords — use placeholders like `<password>`
+- No real IP addresses — use example ranges like `10.x.x.x` or `192.168.x.x`
+- No RBAC scope lines unless the scenario specifically tests RBAC
+- No real user email addresses — use generic addresses like `testuser@example.com`
+
+## Verification Perspective
+
+Before writing test cases for a scenario, decide and document the verification perspective: **"Web GUI"**, **"API"**, or **"Hybrid"**. Record this in the scenario file header. This prevents mid-stream perspective shifts that cause restructuring.
+
+## Verify Before Committing Expected Results
+
+When updating expected results based on actual system behavior, verify with a screenshot or live browser session before committing. Do not guess or assume behavior from documentation alone.
+
+## Navigation Step Strategy
+
+When writing test case steps, apply these rules to keep focus on the test objective:
+
+1. **Setup navigation → preconditions** when 3+ TCs in the same scenario navigate to the same page
+2. **Condense navigation to 1-2 steps max** — combine "Navigate to X" + "Click Add" into one step, not two
+3. **No URLs/routes in test steps** — use page names ("RADIUS Server creation form"), not paths (`/t/policies/aaa/create`)
+4. **Don't verify intermediate pages** — "Service Catalog page displays" adds no test value if it's not the test objective
+5. **Start steps at the test objective** — the feature behavior being validated, not the journey to reach it
+
+**Before (over-specified):**
+```
+| 1 | Navigate to Network Control → Service Catalog | Service Catalog page displays |
+| 2 | Click Add on RADIUS Server card | Form opens at /t/policies/aaa/create |
+| 3 | Enter Profile Name: Test-FQDN-{timestamp} | Field populated |
+```
+
+**After (condensed):**
+```
+Preconditions: RADIUS Server creation form open (Network Control → Service Catalog → Add on RADIUS Server card)
+
+| 1 | Enter Profile Name: Test-FQDN-{timestamp} | Field populated |
+```
+
+## Auto-Regenerate test_cases/README.md
+
+When adding or removing test cases, always regenerate `test_cases/README.md` by scanning all `sections/*.md` files rather than manually editing counts. The README should contain a scenario table with TC counts derived from actual files. Never hand-edit TC counts — they drift out of sync.
+
+## Bug Report Placement Convention
+
+Bug reports go in `bug/<slug>/bug_report.md` within the project directory. Never place bug report files directly in the project root — use a descriptive slug subdirectory (e.g., `bug/fqdn-config-not-updated/bug_report.md`).
+
+## Screenshot Placement Convention
+
+Screenshots go in `test_cases/diagrams/[scenario-slug]/` immediately when captured. Never place screenshots in the project root or `test_cases/` root — they will need to be reorganized later.

--- a/skills/planning-tests/SKILL.md
+++ b/skills/planning-tests/SKILL.md
@@ -15,6 +15,8 @@ tools:
 
 Creates a complete test plan from a project folder by detecting the ticket type, writing sections, and publishing to Confluence.
 
+The skill produces an ISO/IEC/IEEE 29119-3-aligned tree: lean strategy file in `sections/`, plus separate `test_design/` artifacts for scenarios, requirements traceability, and risk. Full layout and rationale in `references/file-layout.md`.
+
 ## Progress Checklist
 
 Copy and track your progress:
@@ -23,12 +25,13 @@ Copy and track your progress:
 - [ ] Step 1: Validate prerequisites
 - [ ] Step 1.5: Visual baseline check (wireframes, live UI, or flag as unverified)
 - [ ] Step 2: Detect ticket type and route
-- [ ] Step 3: Write test plan to test_plan/
-- [ ] Step 4: Review coverage (matrix + diagrams)
+- [ ] Step 3: Write test plan to test_plan/ + test_design/
+- [ ] Step 4: Review coverage (matrix derivation + diagrams + overlap sweep)
 - [ ] Validate: Scenario count + coverage assessment
 - [ ] Step 5: Create Confluence test plan pages
 - [ ] Validate: Confluence URL + page count
-- [ ] Step 6: Review Confluence for formatting issues
+- [ ] Step 6: Review Confluence for content-rendering issues (markdown converter gotchas)
+- [ ] Step 7: Review typography (run reviewing-typography skill on every published page)
 ```
 
 ## Steps
@@ -39,18 +42,27 @@ Check that `00_Main_Task_*.md` exists in the current project folder.
 
 If missing: "Please run `/receiving-tickets [TICKET]` first to gather all documentation."
 
-### Step 1.5: Visual Baseline Check
+### Step 1.5: UI Baseline Trace (strongly recommended)
 
-Before planning, establish visual understanding of the feature's UI:
+Before drafting scenarios, capture the **live UI** of the pages the feature touches — not just the wireframes. Wireframes describe the target state; the live UI shows what already exists, what's hidden by feature flag, and where the wireframes diverge from reality. Drafting from wireframes alone systematically over-specifies (cases for pre-existing behaviors) and miss-specifies (cases for UI elements the wireframe drew but the live app doesn't have, or vice versa).
 
-1. Check if `confluence/visual_references.md` exists (created by `/jr-trace-docs`)
-   - If yes: read it for wireframe summaries and UI element inventory
-2. Ask the user: "Is the feature available in a dev/stage environment? Can I open the browser?"
-   - If yes: open the browser, navigate to the feature, capture key states
-   - Save screenshots to `test_plan/visual_baseline/`
-3. If neither: review embedded wireframe images in HLD Confluence pages
+**Run** `/tw-baseline-trace [TICKET]` to drive Playwright through the affected pages, capture screenshots + accessibility snapshots, and emit a per-page `baseline.md` documenting:
 
-This step prevents writing test plans from text descriptions alone — industry best practice (ISTQB, ISO/IEC 29119) requires examining visual design artifacts during test analysis.
+- Current page structure (columns, controls, filters, tabs, wizard steps)
+- "Tab vs route" semantics (clicking a tab that changes the URL is a route, not a tab — selection / filter state does not survive across routes)
+- Wireframe diff (what the spec adds that's not visible today; what's visible today that the spec didn't draw)
+- Authoring guidance (pre-existing behaviors NOT to re-test; feature-flag-gated controls that belong in the flag-gating scenario)
+
+Output lands at `active/<TICKET>/ui_baseline/<YYYY-MM-DD>/`.
+
+**Fallbacks** (in order):
+
+1. If `/tw-baseline-trace` isn't usable (no Playwright session, no test environment access, no live precursor page), check `confluence/visual_references.md` (from `/jr-trace-docs`) for wireframe summaries
+2. If neither: review embedded wireframe images in `confluence/HLD_*.md` — and note in the scenario file's intro that no baseline was captured, so reviewers can ask
+
+This step is the single biggest defense against over-specified test plans. A recent project's self-review found roughly half the originally drafted cases were either pre-existing-behavior regression or based on UI misreadings — both visible at trace time, neither caught at draft time. Industry best practice (ISTQB, ISO/IEC 29119) likewise requires examining the actual implementation, not just the spec, during test analysis.
+
+**Environment specifics**: do not record specific tenant names, credentials, or URLs in any test plan file. They belong in `config/`. The baseline.md itself does record tenant + flag state as metadata — that's the artifact's purpose. See `references/environment-rules.md`.
 
 ### Step 2: Detect Ticket Type and Route
 
@@ -61,29 +73,85 @@ Run `/tw-plan-init` to detect the ticket type and route to the appropriate plann
 
 ### Step 3: Write Test Plan
 
-Execute the routed planning command from Step 2. It writes test plan sections to `test_plan/README.md` and `test_plan/sections/` based on the detected type:
+Execute the routed planning command from Step 2. It writes:
+
+- `test_plan/README.md` — entry point
+- `test_plan/sections/0X_*.md` — strategy file (lean) + supporting numbered sections
+- `test_design/scenarios/README.md` — scenario index with Mermaid flow diagrams
+- `test_design/scenarios/TS-XX_*.md` — one file per scenario
+- `test_design/traceability_matrix.md` — requirement → scenario mapping
+- `test_design/risk_register.md` — per-scenario risk
+
+Scenario counts by type:
 - Feature: 5-8 scenarios, comprehensive coverage
 - Bug Fix: 2-4 scenarios, focused on defect verification + regression
 - Enhancement: 4-6 scenarios, hybrid new + regression
 
+Each scenario file follows the uniform metadata header, an optional Scenario Preconditions block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in the test cases, not the scenarios — see `references/scenario-conventions.md`.
+
+The strategy file holds only stable content (levels, types, approach, test data, hybrid depth, entry/exit). The legacy "coverage matrix" subsection is no longer authored — derive it from the traceability matrix on demand. See `references/file-layout.md`.
+
+**Migration policy**: new projects use this layout from the start. Already-completed projects keep their original layout — do not migrate retroactively. In-flight projects: opt-in per project, in a single commit.
+
 ### Step 4: Review Plan
 
-Run `/tw-plan-review` to analyze coverage and generate:
-- Coverage matrix (ASCII table)
-- Gap and overlap analysis
+Run `/tw-plan-review` to analyze coverage and generate gap analysis.
 
-Run `/tw-diagrams` to generate diagrams for 5+ scenarios (configuration flow, data flow, modular design).
+Run `/tw-diagrams` to generate Mermaid flow diagrams for scenarios with 5+ entries (admin flow, end-user flow, etc.). Place under `test_design/scenarios/README.md`.
+
+**Overlap sweep (mandatory before sign-off):**
+
+For each scenario, prompt:
+
+> *List any case in this scenario whose object-under-test or assertion overlaps another scenario's case. Note as: layered (justified) or duplicate (fix).*
+
+Resolutions either get applied immediately or batched for a final sweep before merge. See `references/overlap-review.md` for examples and the layered-vs-duplicate decision rule.
 
 ### Validate
 
 Report:
 - Total scenario count
-- Estimated test case count
+- Estimated test case count (sum of per-scenario `**Estimated test cases:** N` headers)
+- Overlap sweep result (count of layered + duplicate findings; resolutions taken)
 - Coverage assessment: **READY FOR TEST CASES** or **NEEDS REVISION**
 
 ### Step 5: Create Confluence Pages
 
-Run `/cf-create-page` to create the test plan hierarchy in Confluence.
+Run `/cf-create-page` to create the test plan hierarchy in Confluence. The Confluence layout mirrors the local file layout as a **3-level tree** under the user-provided parent:
+
+```
+[User-provided parent]                                       ← level 0 (already exists)
+└── [PROJECT_ID]: Test Plan - <Feature Name>                 ← level 1 (README, the entry point)
+    ├── [PROJECT_ID]: 1. Project & Business Context          ← level 2
+    ├── [PROJECT_ID]: 2. Feature Definition
+    ├── [PROJECT_ID]: 3. Scope & Boundaries
+    ├── [PROJECT_ID]: 4. Test Strategy
+    ├── [PROJECT_ID]: 5. References & Resources
+    ├── [PROJECT_ID]: 6. Document Revision History
+    ├── [PROJECT_ID]: Test Scenarios                         ← level 2 (index + Mermaid diagrams)
+    │   ├── [PROJECT_ID]: TS-01 - <Scenario Name>            ← level 3
+    │   ├── [PROJECT_ID]: TS-02 - <Scenario Name>
+    │   └── ...
+    ├── [PROJECT_ID]: Requirements Traceability Matrix       ← level 2
+    └── [PROJECT_ID]: Risk Register                          ← level 2
+```
+
+**Why 3 levels and not flat:** the Test Scenarios index already lists every TS-XX with Mermaid flow diagrams that link to the per-scenario pages. Nesting the TS-XX pages under it (rather than as siblings of sections) keeps level 2 navigable (~9 pages) and makes the diagrams a true table-of-contents instead of decoration. With 5-8 scenarios per Feature project, a flat layout puts 13-16 pages at the same level under the user-provided parent — too noisy for review.
+
+#### Parent-ID assignment (load-bearing)
+
+When calling `mcp-atlassian:confluence_create_page` for each page, pass the correct `parent_id`. The chaining is what produces the 3-level tree:
+
+| Page | `parent_id` to pass |
+|------|---------------------|
+| README (level 1) | **user-provided parent** |
+| All 6 sections (level 2) | **README's just-created page ID** |
+| Test Scenarios index (level 2) | README's ID |
+| TS-01..TS-NN (level 3) | **Test Scenarios index's just-created page ID** (NOT README, NOT user-provided parent) |
+| Traceability Matrix (level 2) | README's ID |
+| Risk Register (level 2) | README's ID |
+
+Capture the page ID returned by each `confluence_create_page` call — the next page's `parent_id` depends on the previous response. If a level-2 or level-3 creation lands as a sibling of the user-provided parent, the wrong `parent_id` was passed: stop, delete the misplaced page via `confluence_get_page` + manual delete, and re-create with the correct parent.
 
 #### Page Naming Convention
 
@@ -98,6 +166,10 @@ Run `/cf-create-page` to create the test plan hierarchy in Confluence.
 | `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` |
 | `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` |
 | `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` |
 
 ##### Bug Fix (Type B)
 
@@ -109,6 +181,10 @@ Run `/cf-create-page` to create the test plan hierarchy in Confluence.
 | `sections/03_Test_Strategy.md` | `[PROJECT_ID]: 3. Test Strategy` |
 | `sections/04_References_Resources.md` | `[PROJECT_ID]: 4. References & Resources` |
 | `sections/05_Revision_History.md` | `[PROJECT_ID]: 5. Document Revision History` |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` |
 
 ##### Enhancement (Type C)
 
@@ -121,22 +197,83 @@ Run `/cf-create-page` to create the test plan hierarchy in Confluence.
 | `sections/04_Test_Strategy.md` | `[PROJECT_ID]: 4. Test Strategy` |
 | `sections/05_References_Resources.md` | `[PROJECT_ID]: 5. References & Resources` |
 | `sections/06_Revision_History.md` | `[PROJECT_ID]: 6. Document Revision History` |
+| `test_design/scenarios/README.md` | `[PROJECT_ID]: Test Scenarios` |
+| `test_design/scenarios/TS-XX_*.md` | `[PROJECT_ID]: TS-XX - <Scenario Name>` |
+| `test_design/traceability_matrix.md` | `[PROJECT_ID]: Requirements Traceability Matrix` |
+| `test_design/risk_register.md` | `[PROJECT_ID]: Risk Register` |
 
-Create parent page first, then child pages for each section. Parent page ID is provided by the user.
+**Creation order** (each step depends on the previous returning a page ID):
 
-**MCP tool:** `mcp-atlassian:confluence_create_page`
+1. **README** — `parent_id` = user-provided parent. Capture returned ID as `README_ID`.
+2. **Sections in numeric order** (1, 2, 3, ...) — `parent_id` = `README_ID` for each.
+3. **Test Scenarios index** (`test_design/scenarios/README.md`) — `parent_id` = `README_ID`. Capture returned ID as `SCENARIOS_ID`.
+4. **TS-XX pages in scenario-number order** — `parent_id` = **`SCENARIOS_ID`** for each (this is the level-2 → level-3 nesting; do not use `README_ID` here).
+5. **Traceability Matrix** — `parent_id` = `README_ID`.
+6. **Risk Register** — `parent_id` = `README_ID`.
+
+Parent page ID for step 1 is provided by the user.
+
+**MCP tool:** `mcp-atlassian:confluence_create_page` with `content_format: "markdown"` for flat content, `"storage"` for pages with nested lists or task lists. The MCP converter handles tables, top-level lists, code blocks, hyperlinks, and Mermaid fences cleanly — but **silently mangles four common patterns**:
+
+1. Bold paragraph + immediately-following list with no blank line → list collapses into the paragraph.
+2. 2-space-indented nested lists → flattened to the parent's level (so TS-XX `Checkpoints:` sub-items end up beside `Objective:` instead of below it).
+3. Metadata header block (multiple `**Label:**` lines on consecutive newlines) → merged into one paragraph.
+4. Task list `- [ ]` → bullet with literal `[ ]` text, not native checkboxes.
+
+**Per-page format decision (apply at create time):**
+
+| Page in this publish | Recommended `content_format` |
+|---|---|
+| README, Traceability Matrix, Risk Register, Scenarios index | `markdown` |
+| Numbered section pages (01..06) — usually flat | `markdown` (but ensure blank line before every list — see gotcha #1) |
+| TS-XX scenarios (have nested `Checkpoints:` lists) | `storage` — write `<ul><li><p>Checkpoints:</p><ul>…</ul></li></ul>` directly |
+| Test Strategy page if it has Entry/Exit task lists | `storage` — use `<ac:task-list>` macros for native checkboxes |
+
+Full gotcha table, storage-format templates, and the mixed-strategy decision rule live in `commands/confluence/cf-format-guide.md` (Path A gotchas + Path C). The schema enum allows `markdown`, `wiki`, `storage`; despite documentation claims, `html` and `adf` are rejected by the validator.
+
+**Mandatory pre-flight check after publish:** re-fetch every created page with `convert_to_markdown: false` and grep the storage HTML for these patterns before declaring the publish complete. Run `/cf-review-page` against each page. A typical first publish has multiple pages broken in some way; catching it requires re-fetching every page.
+
+#### After creation: record page IDs
+
+Write `test_plan/confluence_pages.md` capturing every page's ID, source-file path, level (0–3), and Confluence URL. Bold the load-bearing handles (`README_ID` and `SCENARIOS_ID`). This file is the contract for future updates: when a source `.md` changes, update the matching Confluence page via `mcp-atlassian:updateConfluencePage` against the recorded ID — never delete-and-recreate, because that breaks inbound links from Jira tickets, Slack messages, etc., and resets page version history.
 
 ### Validate
 
 Report:
-- Confluence parent page URL
-- Number of pages created
+- Confluence parent page URL (level 1 — the README)
+- Number of pages created (should be `1 + N_sections + 1 + N_scenarios + 2`, e.g. `1 + 6 + 1 + 7 + 2 = 17` for a Type A feature with 7 scenarios)
+- Path to the `confluence_pages.md` record file
 
-### Step 6: Review Confluence
+### Step 6: Review Confluence (MANDATORY — gates publish completion)
 
-Run `/cf-review-page` to fetch each created page and check for markdown conversion issues (lists rendering as plain text, missing tables, etc.).
+This step is not optional. Run `/cf-review-page` against every page ID recorded in `confluence_pages.md` and check for the four markdown-converter failure modes documented in Step 5. The four red-flag patterns to search for in each page's raw storage HTML:
+
+| Red flag in storage HTML | Indicates |
+|---|---|
+| `<p>…<strong>…:</strong>\s*-\s` | Bold-paragraph + immediately-following list collapsed (gotcha #1) |
+| `<li><p>\[ \]` or `<li>\[ \]` | Task-list markers un-converted (gotcha #4) |
+| `<p>…<strong>Focus:</strong>…<strong>Estimated test cases:</strong>` (or similar bold-label sequence) | Metadata block merged (gotcha #3) |
+| `Checkpoints:` `</li>` followed immediately by `<li>(End-user)` or `<li>(Admin)` at the same depth | Nested checkpoints flattened (gotcha #2) |
+
+For each page that fails: call `mcp-atlassian:confluence_update_page` with the same page ID (NEVER delete-and-recreate) using `content_format: "storage"` and explicit HTML for the affected sections. A typical first publish exposes broken pages with all four failure modes. Trust nothing until you've re-fetched.
 
 **MCP tool:** `mcp-atlassian:confluence_get_page` with `convert_to_markdown: false`
+
+**Scope of Step 6 vs Step 7:** Step 6 catches *content-rendering failures* — the markdown converter broke the page; lists collapsed, task lists never converted, metadata fused. Once Step 6 is clean, the content is on the page but it may still read badly. **Step 7 is where the design judgment lives.**
+
+### Step 7: Review Typography (MANDATORY — gates publish completion)
+
+Run the `reviewing-typography` skill against every page ID in `confluence_pages.md`. The skill applies two principles — Gestalt proximity (spacing groups or separates) and visual hierarchy (weight signals importance) — to flag and fix typography problems that templates cannot predict because they depend on the actual content's length and shape.
+
+Typical findings the skill catches that Step 6 cannot:
+
+- Metadata block visually fused with the intro paragraph (proximity collision across zones)
+- A 6-sentence paragraph that crosses 3 ideas with no resting point
+- 10 different bold inline labels on one page, all competing, none anchoring
+- A nested `<li>` block of 8+ items where the parent label is silently doing heading work
+- A page with 800 words of body content and no `<h3>` break anywhere
+
+These are **content-shape problems**, not converter problems. They surface only after real prose lands in the templates. See `skills/reviewing-typography/SKILL.md` for the full walk-and-fix procedure and `skills/reviewing-typography/references/typography-principles.md` for the anti-pattern catalog (A1–A6) with storage-format before/after.
 
 ## Expected Input
 
@@ -145,3 +282,12 @@ Path to project folder containing `00_Main_Task_*.md` and optional Confluence do
 ## Next Step
 
 After planning tests, run `/designing-cases` to create detailed test cases.
+
+## References
+
+- `references/file-layout.md` — `test_plan/` + `test_design/` + `ui_baseline/` tree, what each artifact holds, dropped sections, migration policy
+- `references/scenario-conventions.md` — uniform metadata header, optional Scenario Preconditions block, per-case format (Objective + Checkpoints mandatory; Preconditions + Notes optional), `### Case N:` headings for anchor links, graph-node mapping, cross-link conventions, scenarios index README requirements, **the "don't author regression of pre-existing behavior" rule that uses the UI baseline**. Steps belong in test cases, not scenarios
+- `references/api-vs-journey.md` — when to split a journey-shaped TS from an API-contract TS; the longest-path rule; diagram + Scenario Index conventions that follow from the split
+- `references/environment-rules.md` — environment specifics out of the plan (tenant names, credentials, URLs go in `config/`, not in `04_Test_Strategy.md`)
+- `references/overlap-review.md` — the overlap-review prompt, layered vs duplicate decision rule, graph-staleness check, examples from past reviews
+- `references/test-sequencing.md` — state-preserving step order; when sequence is load-bearing at planning time, record the constraint in the case's `**Notes:**` field so the test-case author preserves it

--- a/skills/planning-tests/references/api-vs-journey.md
+++ b/skills/planning-tests/references/api-vs-journey.md
@@ -1,0 +1,72 @@
+# Journey vs. API-Contract Separation
+
+When the feature under test has both a GUI (or device-driven) user flow AND a backend API surface, the test plan splits cleanly along two axes. Mixing them in the same scenario creates noise — reviewers can't tell whether a case asserts user-visible behavior or wire contract.
+
+## The split
+
+| Tier | What it owns | Test approach | Where it lives |
+|---|---|---|---|
+| **Journey scenarios** (TS-01..TS-N) | The longest path a real actor can take through the feature | Web UI walk for admin; real client device for end user; assert on the visible outcome (incl. downloaded file contents) | One TS per journey lane (admin / end-user / cross-system / feature flag / backward compat) |
+| **API contract scenario** (TS-N+1) | Behaviors the GUI longest path cannot generate | Direct API calls (curl / Postman / MCP) | One dedicated TS — append at the end of the scenario numbering |
+
+## When the API tier is needed
+
+You need a dedicated API contract scenario when **any** of these is in scope:
+
+1. **Test-environment provisioning.** End-user scenarios need a fixture / network / identity / tenant data pre-existing. An admin who clicks through the UI to set it up is fragile; an API-driven fixture is reproducible and fast.
+2. **Payload contract negatives.** The UI form validation prevents the test condition from ever being submitted (missing required keys, unknown extras, contradictory field combos). The only way to assert the backend's contract is to bypass the UI.
+3. **Schema-drift backward compatibility.** Pre-feature records hit via the new API version. The user-visible side is journey (it renders without crash); the wire contract side is API (which fields are absent vs null, which version markers, whether the new API gracefully handles legacy records).
+4. **Version skew.** Old clients (`Accept: v1.0`) hitting the new endpoint, or new clients hitting an older deployment. Pure contract concern; the UI is pinned to one version.
+5. **Error-code semantics.** The design spec typically enumerates happy-path payloads but not 4xx / 5xx responses. Empirical capture per endpoint pins the contract and feeds undocumented findings to a follow-up ticket.
+
+When **none** of these apply (feature is GUI-only, no published API contract, no version surface) — skip the API tier. Don't author it just for completeness.
+
+## The longest-path rule
+
+For every journey-tier case, ask: **what is the longest path a real actor takes to produce this assertion?**
+
+- Admin saves a configuration → the longest path is *click Save → re-open profile → fields persist*. Not *click Save → curl GET /resources/{id}*.
+- Admin observes records → longest path is *open the records tab → click Download → verify the downloaded file's contents*. Not *POST /records/query directly*.
+- End user connects → longest path is *associate the device → open the page in browser → submit form → see the post-auth resource*. Not *POST /authenticate synthetically*.
+
+The GUI / device click *implicitly* exercises the API; asserting on the visible outcome means a single test covers both surfaces. Drop to API-direct only for the conditions the longest path can't generate (see the list above).
+
+## What this means for diagram structure
+
+`test_design/scenarios/README.md` should keep its mermaid flow blocks **journey-shaped**: nodes name actions ("Save configuration", "Click Connect") not HTTP verbs ("POST /resources"). API plumbing inside journey nodes is noise — reviewers reading the journey diagram want to validate that the test script covers the user-visible flow, not the implementation.
+
+When the API tier is needed, give it its **own diagram** under `diagrams/api_admin.mmd` (or `api_<surface>.mmd`). Shape: per-endpoint flowchart with branches for happy / negative / compat / version-skew / error-code outcomes, each branch tagged with the TS-N+1 subsection it belongs to. This is a *matrix* shape, not a journey shape — don't try to render it as a sequence diagram (sequence = journey).
+
+## Scenario Index columns
+
+Update the Scenario Index in `test_design/scenarios/README.md` to make the split visible at a glance:
+
+| ID | Scenario | Focus | Test approach | Est. Cases |
+
+- **Focus** values: `Admin GUI` / `End-user E2E` / `Admin GUI + End-user E2E` / `API`. Drop hybrid values like "GUI + API" — they hide which tier owns the case.
+- **Test approach** values: `Web UI walk` / `Real device` / `Real device + admin UI observation` / `Web UI + downloaded file content` / `Direct API call`. This column is load-bearing for executors picking up the suite cold.
+
+## TS-N+1 internal structure
+
+The API contract TS should be sub-headed by concern, not by endpoint. Endpoints touch multiple concerns; concerns touch multiple endpoints. Suggested headings:
+
+- **A. Test-Env Fixtures** — what to provision and how to assert on the response
+- **B. Payload Contract Negatives** — missing required, unknown extras, defensive contracts
+- **C. Schema-Drift Backward Compatibility** — pre-feature records via new API
+- **D. Version Skew** — Accept header variations
+- **E. Error-Code Semantics** — empirical per-endpoint capture
+
+Where the design spec doesn't enumerate the expected behavior, the case wording should be **capture and flag for follow-up**, not assert an expected response. The API tier's job is partly to discover what the contract actually is.
+
+## What stays in journey TS files
+
+When promoting API-only bullets out to TS-N+1, the journey TS files should:
+
+- Keep cases driven by web UI walks or device walks
+- Keep user-visible compatibility cases (e.g., "pre-existing profile loads in admin UI without crash") — the UI-side assertion is journey
+- Drop bullets that are API-only (e.g., "PUT with `optionalSection.enabled=false` + populated content")
+- Add a one-line preamble pointing at TS-N+1 for the moved scope: *"Direct-API payload negatives, contract round-trip, and defensive-contract checks live in [TS-N+1](TS-NN_API_Contract.md)."*
+
+## Reference shape
+
+A canonical applied-shape: TS-01 / TS-06 are journey-pure (no HTTP verbs in the diagram), TS-09 owns the contract surface in 5 sub-sections (A–E above), and the journey diagrams read as actor scripts. When in doubt, that shape is the target.

--- a/skills/planning-tests/references/environment-rules.md
+++ b/skills/planning-tests/references/environment-rules.md
@@ -1,0 +1,49 @@
+# Environment Specifics — Out of the Plan
+
+The plan describes test environment **requirements** (what capability is needed). It never names a specific instance.
+
+Specific tenant names, URLs, credentials, hardware serial numbers, network names, or test-account identifiers belong in `config/` files, not in any markdown that ships with the plan.
+
+## Why
+
+Three reasons drive this rule:
+
+1. **Open-source repository hygiene.** Identifiers like specific tenant names and credentials must not appear in committed `commands/`, `demo/`, or test plan documents. Even tenant names alone are mild leakage.
+2. **Volatility.** The test tenant rotates per feature or sprint. Specific tenant names written into `04_Test_Strategy.md` make the plan rot every project.
+3. **ISO 29119 separation.** ISO/IEC/IEEE 29119 distinguishes test environment **requirements** (in the plan) from test environment **configuration** (in a separate, often gitignored artifact). Mixing them is a documented anti-pattern.
+
+## What goes in the plan
+
+In `04_Test_Strategy.md` § 4.3 (Test Approach) and § 4.4 (Test Data Setup), describe capability — not instance:
+
+Good:
+> *Test Tenant: any tenant where the feature flag `<flag-name>` is operational; current selection in `config/`.*
+
+Good:
+> *Test Hardware: at least one device assigned to the venue, broadcasting each variant's network. Specific serial numbers in `config/test_env.md`.*
+
+Good:
+> *Client Device: Android (primary); iOS spot-check.*
+
+Bad:
+> *Test Tenant: \<tenant-id\> (per design-review credential handoff from \<reviewer\> on \<date\>).*
+
+Bad:
+> *Login: \<email\> / \<password\>.*
+
+## What goes in `config/`
+
+| File | Purpose |
+|---|---|
+| `config/env-<tenant>.txt` | Tenant-specific credentials and runtime values |
+| `config/.env.runtime` | Runtime configuration (gitignored) |
+
+The plan can reference the file by name (*"current selection in `config/env-<tenant>.txt`"*) but should not embed its contents.
+
+## Reviewing existing plans
+
+When reviewing a plan that violates this rule, replace specific tenant names with the capability description and note the change in the plan's revision history. Do not commit a fix that retains the specific tenant name "for context" — the whole point is that context belongs in `config/`.
+
+## Reference
+
+When a past project's strategy file still names a specific tenant, schedule the cleanup as a follow-up rather than blocking on it. When you encounter such cases on new work, apply this rule from the start.

--- a/skills/planning-tests/references/file-layout.md
+++ b/skills/planning-tests/references/file-layout.md
@@ -1,0 +1,87 @@
+# Test Plan File Layout
+
+The skill produces an ISO/IEC/IEEE 29119-3-aligned tree, splitting the plan into stable artifacts and volatile artifacts.
+
+## Target shape
+
+```
+ui_baseline/                          ← captured BEFORE scenarios via /tw-baseline-trace
+└── <YYYY-MM-DD>/
+    ├── baseline.md                  ← per-page structure + wireframe diff + authoring guidance
+    ├── screenshots/<page_slug>.png
+    └── snapshots/<page_slug>.yml    ← raw accessibility snapshots
+
+test_plan/
+├── README.md
+├── sections/
+│   ├── 01_Project_Business_Context.md
+│   ├── 02_Feature_Definition.md
+│   ├── 03_Scope_Boundaries.md
+│   ├── 04_Test_Strategy.md         ← lean: levels, types, approach, data, depth, entry/exit
+│   ├── 05_References_Resources.md
+│   └── 06_Revision_History.md
+└── test_design/
+    ├── scenarios/
+    │   ├── README.md                ← scenario index + Mermaid flow diagrams
+    │   ├── TS-01_<name>.md
+    │   ├── TS-02_<name>.md
+    │   └── ...
+    ├── traceability_matrix.md       ← formerly § 4.8
+    └── risk_register.md             ← formerly § 4.10
+```
+
+The numeric prefixes in `sections/` shift by one between project types (Type A: 1-6, Type B: 1-5, Type C: 1-6) — the "Test Strategy" file is § 4 for Types A and C, § 3 for Type B. The same lean-content rule applies regardless.
+
+## What lives where
+
+### `ui_baseline/<YYYY-MM-DD>/`
+
+**Captured before scenarios are drafted** (via `/tw-baseline-trace`). Holds the live UI state for pages the feature touches:
+
+- `baseline.md` — per-page structure (columns, controls, tabs, wizard steps, form fields) + wireframe diff + authoring guidance for scenarios. Documents which controls are pre-existing behavior (not to retest) and which are feature-flag-gated (route to a flag-gating scenario).
+- `screenshots/<page_slug>.png` — visual capture per page
+- `snapshots/<page_slug>.yml` — raw accessibility tree per page (useful for grepping later when a column name or button label is needed)
+
+Multiple dated folders may coexist (capture before flag flip, capture after flag flip, capture after a build update). The most recent dated folder is canonical for current planning. The scenario-conventions rule "Don't author regression of pre-existing behavior" reads from the latest `baseline.md`.
+
+### `sections/04_Test_Strategy.md` (or § 3 for Type B)
+
+**Stable** content — reviewed once per project, rarely churns:
+
+- 4.1 Test Levels (Functional / Integration / Regression)
+- 4.2 Test Types (GUI / API / E2E / Negative / Backward-Compat / etc.)
+- 4.3 Test Approach (verification perspective, environment requirements, visual baseline)
+- 4.4 Test Data Setup (per-tenant setup requirements)
+- 4.5 Hybrid Depth Strategy (the deep representative + wide variants split)
+- 4.6 Entry / Exit Criteria
+- 4.7 Companion Artifacts (pointer to `test_design/`)
+
+### `test_design/scenarios/`
+
+**Volatile** — scenarios churn as understanding deepens. Each TS-XX gets its own file. See `scenario-conventions.md` for the required header, optional Scenario Preconditions block, and per-case format (Objective + Checkpoints mandatory; Preconditions + Notes optional). Steps belong in the test cases, not the scenarios.
+
+The directory's `README.md` is the index — it lists every TS-XX with focus + estimated cases, plus Mermaid flow diagrams for the admin and end-user flows.
+
+### `test_design/traceability_matrix.md`
+
+Requirement → scenario mapping. Was § 4.8 of the legacy strategy file. Includes a "Coverage Gaps" subsection for items the design spec doesn't specify or that QA observed but couldn't pin to a requirement.
+
+### `test_design/risk_register.md`
+
+Per-scenario risk row (likelihood / impact / mitigation). Was § 4.10 of the legacy strategy file. Cross-cutting; updated independently of the strategy.
+
+## Sections explicitly dropped
+
+### Coverage Matrix (legacy § 4.6)
+
+The X-marks grid mapping scenarios × test aspects is **dropped**. It's a derivative of the traceability matrix and adds no information beyond it. Modern QA tools (TestRail, Xray, Polarion) auto-derive coverage from the RTM rather than authoring it by hand.
+
+If a reviewer specifically asks for a coverage matrix, generate it on-demand from `traceability_matrix.md` rather than committing one as a separate artifact.
+
+## Migration policy
+
+**New projects:** generate this layout from the start.
+
+**Already-completed projects:** preserve their original layout — do not migrate retroactively. The `tw-case-*` reader commands fall back to the legacy `sections/`-only layout when `test_design/` is absent.
+
+**In-flight projects:** opt-in migration. Reviewer or QA lead decides per project. If migrating, do it as one commit on a feature branch, with the strategy file slim-down and the `test_design/` extraction in the same change.

--- a/skills/planning-tests/references/overlap-review.md
+++ b/skills/planning-tests/references/overlap-review.md
@@ -1,0 +1,71 @@
+# Overlap Review
+
+After every scenario revision, run an overlap review against every other scenario in the plan. This catches duplicate coverage that prose-only review misses.
+
+## The prompt
+
+For each scenario being revised, ask:
+
+> *List any case in this scenario whose object-under-test or assertion overlaps another scenario's case. Note as: **layered** (justified) or **duplicate** (fix).*
+
+Apply to every case in the revised scenario. Compare against every case in every other scenario.
+
+## Layered vs duplicate
+
+**Layered** = the same predicate is verified at multiple abstractions or surfaces, by design. Justify the split in writing within the scenario file (one-line preamble or per-case note).
+
+Examples of legitimately layered:
+
+- DTO bean-validation + custom domain validator both fire on the same bad input — both reported, both caught
+- UI-driven mode switch enforces mutual exclusion + API directly tests rejection — UI test + API test cover different client paths
+- A configuration JSON round-trips through admin UI write + API direct write — both ensure schema is honored
+
+**Duplicate** = the same case appears twice with no different lens. Fix by deleting from one scenario or moving to where it belongs.
+
+Examples of duplicates surfaced during a past plan review:
+
+- TS-06 case 2 and TS-07 case 1 both asserted "API rejects new fields with flag OFF" — same assertion, two homes. Resolved by giving TS-07 sole ownership of flag-OFF behavior across both surfaces.
+- TS-04 case 4 and TS-06 case 1 both targeted the same flow with an existing fixture — split by structural vs content claims, but the test object and access path were identical. Merged.
+- TS-05 case 1 (`POST` with legacy field only) became a subset of TS-06 case 1 step 1 once TS-06 grew into a lifecycle. Removed from TS-05.
+
+## When to run the review
+
+- After collapsing or expanding any case set
+- After splitting a scenario into multiple smaller ones
+- After moving a case between scenarios
+- Before declaring a scenario "done" in a TS review pass
+- During `tw-plan-review` when preparing the plan for sign-off
+
+## Output
+
+The reviewer maintains a list of overlaps in a working buffer (the issue or PR description, the planning notes, etc.). Each entry:
+
+```
+TS-X case N ⟷ TS-Y case M
+  - object: <thing being tested>
+  - layered? yes / no
+  - reason: <one line>
+  - resolution: keep both | merge | move to TS-X | delete from TS-Y
+```
+
+Resolutions either get applied immediately or batched for a final overlap sweep before merge.
+
+## Anti-pattern: "wide" scenarios re-executing "deep" cases
+
+A common cause of overlap is a "wide variant" scenario re-executing the full case-set of the "deep representative" scenario. When the depth strategy says *"do not re-execute the full case-set per variant — only confirm placement, gating, and accept-and-connect"*, enforce that in the wide-variant scenario's wording too. If the wide-variant cases read like full deep-representative runs, they're duplicates pretending to be variants.
+
+## Coverage-gap symmetry
+
+The flip-side of overlap is coverage gap. While reviewing for overlaps, also note any node or edge in the implicit flow graph (visible in `scenarios/README.md` Mermaid diagrams) that no case touches. A scenario revision is a good time to discover both kinds of issues — they tend to surface together.
+
+## Graph-staleness check
+
+When you revise a scenario, also verify that the Mermaid diagrams in `scenarios/README.md` still reflect current scope ownership:
+
+- Each node's TS-XX label points at the scenario that *currently* owns that node
+- New nodes for added scope are present
+- Removed nodes for descoped behavior are gone
+
+Stale diagrams cause prose-level review to mislead — reviewers think a node is covered by TS-X when it's actually been moved to TS-Y. Update the diagram in the same commit as the scenario revision.
+
+The graph-staleness check is mandatory before declaring a scenario revision done. See `scenario-conventions.md` § "Graph-node mapping" for the related smell list (phantom case, misplaced assertion, stale node ownership).

--- a/skills/planning-tests/references/scenario-conventions.md
+++ b/skills/planning-tests/references/scenario-conventions.md
@@ -1,0 +1,189 @@
+# Scenario File Conventions
+
+Every `test_design/scenarios/TS-XX_*.md` file follows the same metadata header, an optional scenario-level Preconditions block, and a uniform per-case format.
+
+Scenarios are **planning artifacts**, not execution artifacts. They state *what* each case proves and *what* should be observable — not *how* to perform it. Click-by-click steps belong in the test cases (`test_cases/TS-XX/TC-NN_*.md`), authored later via the `designing-cases` skill.
+
+## Uniform metadata header
+
+Mandatory at the top of every scenario file:
+
+```markdown
+# TS-XX: <name>
+
+**Focus:** <GUI / API / E2E / Config / hybrid>
+**Estimated test cases:** N
+**Test plan reference:** [`test_plan/sections/04_Test_Strategy.md`](../../sections/04_Test_Strategy.md)
+
+<intro paragraph — what this scenario owns, what it does not, key cross-references>
+
+## Scenario Preconditions   ← optional, see below
+
+- <setup that applies to every case>
+
+## Test Cases
+
+### Case 1: <Short imperative title>
+
+- **Objective:** ...
+- **Checkpoints:**
+  - ...
+
+### Case 2: ...
+```
+
+### Header fields
+
+- **Focus** — one of `GUI`, `API`, `E2E`, `Config`, or a hybrid (`Admin GUI + End-user E2E`). Pick the dominant verification surface; this drives reviewer expectations.
+- **Estimated test cases** — integer. The number that ends up in TestLink. Update on every revision.
+- **Test plan reference** — link to the strategy file. Numeric prefix may be `04` (Types A and C) or `03` (Type B). The link uses the cross-link convention below.
+
+### Intro paragraph
+
+A paragraph directly under the header describing what the scenario owns, what it explicitly does not, and the key cross-references to other scenarios. This is where scope is pinned. Keep it tight — most intros run 2–5 sentences.
+
+## Scenario Preconditions (optional)
+
+Setup that applies to **every case** in the scenario. Use this block when scenarios share non-trivial preconditions (feature flag state, device availability, pre-configured fixtures, test-data fixtures). Cases may add **case-specific** preconditions on top via their own `**Preconditions:**` field.
+
+```markdown
+## Scenario Preconditions
+
+- Feature flag `<name>` is ON
+- Parent fixture already configured per TS-01
+- A real client device available to exercise the end-user flow
+```
+
+Skip the block entirely when the scenario has no shared precondition worth stating up-front. Don't pad with obvious things ("user logged in to admin UI").
+
+## Per-case format
+
+Every case is its own `### Case N: <Title>` block. Title is a short imperative phrase that summarizes the case; detail lives in the body.
+
+Mandatory fields:
+
+- **`**Objective:**`** — one sentence describing what the case proves. Forces clarity. If you can't write it in one sentence, the case is doing too much — split it.
+- **`**Checkpoints:**`** — unordered list (`-`) of the observable assertions. Each checkpoint is something a reviewer or test-case author can verify by reading the UI / response / artifact.
+
+Optional fields (omit when not needed):
+
+- **`**Preconditions:**`** — case-specific setup that differs from scenario-level preconditions. Do not repeat scenario-wide preconditions here.
+- **`**Notes:**`** — design-spec-silent flags, ticket cross-references, observability hints, edge-case caveats, sequencing hints. Anything that helps the test-case author or reviewer but isn't an assertion.
+
+### Example
+
+```markdown
+### Case 6: Disable optional sub-section while content is present
+
+- **Objective:** capture how the UI handles `optionalSection.enabled=false`
+  when rich-text content has already been saved (defensive contract).
+- **Preconditions:** profile has the optional section's rich-text body + at
+  least one child entry, saved.
+- **Checkpoints:**
+  - Hidden rich-text body either persists or is cleared — capture which
+  - End user on next page load does not see the optional checkbox
+- **Notes:** Design spec silent on persistence behavior — flag observation
+  for follow-up ticket.
+```
+
+### What does NOT go in a scenario case
+
+- **Click-by-click steps** — author these later in the test case file via `designing-cases`. The scenario's Objective + Checkpoints give the test-case author enough to derive the steps.
+- **Specific selectors, button IDs, API request bodies** — these are execution detail.
+- **Test data values** — except where the value is part of the assertion (e.g., a priority-resolution rule uses specific input combinations to prove the rule).
+- **Pass/fail wording** — checkpoints describe the observable; whether it's a pass or fail is the test-case author's call.
+
+### Title style
+
+- Short imperative phrase ("Disable optional section while content is present", not "When the user disables the optional section and there is content saved on it").
+- One title per case — don't bundle two objectives behind a slash.
+- Avoid generic titles ("Happy path", "Validation"). Be specific about which path or which validation.
+
+### Heading level
+
+Use `### Case N:` (H3) — not bold bullets. H3 gives every case a stable anchor for cross-linking from the traceability matrix and from other scenarios (e.g., `[TS-04 case 2](TS-04_Identity_Mapping.md#case-2-no-identity-assigned)`).
+
+## Don't author regression of pre-existing behavior
+
+Before authoring a case, cross-check it against the UI baseline at `<project_root>/ui_baseline/<YYYY-MM-DD>/baseline.md` (captured via `/tw-baseline-trace`).
+
+Three buckets for each candidate case:
+
+| Bucket | What it means | What to do |
+|---|---|---|
+| **Pre-existing behavior in the baseline** | A control / column / interaction visible today that this feature does not modify (typical examples: column sorting on list pages, free-text search in toolbars, navigation between unrelated routes presented as "tabs", wizard back-button, list-page filter widgets, etc.) | **Do not author the case.** The existing regression suite owns this. |
+| **Feature-flag-gated control in the baseline** | A control the design spec adds but the live UI hides under flag OFF (typical: new field on an existing page, new section in the side panel) | Author it in the flag-gating scenario, not in a per-feature scenario. |
+| **New behavior, not in the baseline** | A genuinely new column / field / page / interaction the feature introduces | Author the case — this is real coverage. |
+
+When no baseline exists (e.g., bug fix on a page where the trace was skipped), the rule degrades to: do not draft cases for behaviors a reviewer would recognize as standard list-page or wizard behavior (sort, search, pagination, filter widgets, route navigation). Note the missing baseline in the scenario's intro so reviewers can ask.
+
+### "Tab vs route" trap
+
+The baseline's tab-vs-route check is load-bearing. Many web apps present two related routes as a tablist (e.g., a "Users" tab next to a "Roles" tab, where clicking switches `/admin/users` ↔ `/admin/roles`). These look like tabs but share no state — clicking switches the URL, the filters / selection / scroll position do not survive the switch and were never designed to.
+
+If a candidate case asserts "switching between these tabs preserves filter / selection / state" → **drop the case.** The behavior the case is claiming doesn't exist and isn't a bug. The baseline catches this at draft time; otherwise it surfaces only in execution as a confused failure.
+
+### Why this rule exists
+
+A recent project's self-review (after the live UI trace landed mid-planning) found that roughly half of the originally drafted cases fell into the "pre-existing behavior" bucket or the "tab vs route" trap. Both were invisible at draft time when working from spec + wireframes alone. Both were obvious at trace time. Capturing the baseline first prevents the wasted work of authoring those cases and then trimming them during review.
+
+## Graph-node mapping
+
+Every case in a scenario file must be traceable to one or more nodes in the Mermaid flow diagrams under `test_design/scenarios/README.md`. Reason about graph nodes *before* writing prose; the prose follows from the node mapping, not the other way around.
+
+When you write or revise a scenario, ask:
+
+- Which graph node(s) does each case touch?
+- Is any case touching multiple distinct nodes? → likely needs a split.
+- Are multiple cases in this scenario touching the same node from the same angle? → likely needs a merge.
+- Is any case's primary observation about a node *owned by another scenario*? → misplacement; move the assertion to the owning scenario.
+
+### Smells the graph-node check catches
+
+These were actual mistakes from past plan reviews. Each was invisible at the prose level, obvious at the graph level:
+
+- **Phantom case** — a one-line observation set as its own case but actually a side-observation made while another case is running. Example: "warning copy is displayed inline inside sub-dialog" listed as case 4 of TS-01, when it's observed *while* case 2 has the sub-dialog open. Fold into case 2.
+- **Misplaced assertion** — a case mentioning an observation outside its primary graph node. Example: "switching from Mode A → Mode B ... warning copy displayed in Mode A" — the warning is observable while you're IN Mode A, not while switching away. Move to the Mode-A setup case.
+- **Stale node ownership** — a graph node still labeled with its old TS-XX after scope ownership moved between scenarios. Example: "Inline error / no state change / TS-03" after gating ownership moved to TS-04. The diagram must be updated as part of the scope change.
+
+When merging or splitting cases, write down the graph-node coverage for each candidate shape *first*. If two candidate cases map to the same node from the same angle, merge. If one candidate case maps to two unrelated nodes, split.
+
+## Cross-link conventions
+
+`test_design/` is nested **inside** `test_plan/` (sibling of `sections/`). Cross-links assume that layout:
+
+| From | To | Path |
+|---|---|---|
+| `test_plan/sections/04_*.md` | `test_design/scenarios/` etc. | `../test_design/...` |
+| `test_design/scenarios/TS-*.md` | strategy file | `../../sections/04_*.md` |
+| Within `test_design/` (e.g., `traceability_matrix.md` ↔ a scenario) | sibling | `scenarios/TS-XX_*.md` |
+| Scenario case → another scenario's case | sibling + anchor | `TS-XX_*.md#case-N-title-slug` |
+| Scenario file → live baseline screenshot | repo top-level | `../../../ui_baseline/<date>/screenshots/<file>.png` |
+
+When a scenario references a design-spec page or wireframe image, prefer linking to the local `confluence/hld_images/<file>.png` capture (or equivalent) over a remote URL — local references survive remote reorganization.
+
+## Scenarios index README
+
+`test_design/scenarios/README.md` is the directory's table of contents. It must:
+
+- List every TS-XX with `[name]` link, focus, and estimated case count
+- Total estimated case count (sum of all rows)
+- Mermaid flow diagrams for at least the admin flow and the end-user flow (or whichever flow groupings make sense for the feature)
+- Each Mermaid node labeled with the TS-XX it belongs to
+
+The Mermaid diagrams document the implicit graph that the scenarios traverse. Reviewers use them to spot uncovered nodes (gaps) and shared edges (overlaps).
+
+## Why no Steps
+
+Scenarios and test cases are the two halves of a deliberate two-phase split:
+
+| | Scenario (planning) | Test case (design) |
+|---|---|---|
+| Owns | Objective + observable assertions | Click-by-click execution |
+| Abstraction | What proves the behavior | How to drive the UI / API |
+| Authored by | `planning-tests` skill | `designing-cases` skill |
+| Lives in | `test_plan/test_design/scenarios/TS-XX_*.md` | `test_cases/TS-XX/TC-NN_*.md` |
+
+Putting steps in the scenario duplicates the test case and makes the scenario stale the first time a UI selector changes. Keep the scenario abstract; let the test case bind to the UI.
+
+If execution **sequence** matters at planning time (e.g., "destructive operation must run last to preserve test-data state across earlier observations"), record that constraint in the case's `**Notes:**` field so the test-case author preserves the order. The full sequence still lives in the test case, not here. See `test-sequencing.md` for the canonical examples.

--- a/skills/planning-tests/references/test-sequencing.md
+++ b/skills/planning-tests/references/test-sequencing.md
@@ -1,0 +1,60 @@
+# Test Sequencing — State-Preserving Order
+
+When a test case includes state-changing operations, the order of steps affects which subsequent observations are valid. Pick the order that keeps the test environment usable for all observations on a single device / single profile / single tenant.
+
+## Principle
+
+If step A irreversibly changes the system into a state that step B cannot run from, **step B must come first**.
+
+State-preserving order is not a stylistic choice. Wrong order forces a device reset, a fresh profile, or a re-provisioned tenant — each of which is expensive and easy to forget under execution pressure.
+
+## Common patterns
+
+### Permissive vs strict toggle — strict first, permissive last
+
+When a single test verifies both states of a permissive-vs-strict toggle (allow-list OFF vs ON, feature flag OFF vs ON, etc.) for the same trigger, run **strict first** (action blocked) then **permissive last** (action succeeds).
+
+Why: a successful permissive action often releases the device / session from the constrained state under test (authenticates, navigates away, consumes a one-shot token). Subsequent attempts to observe the strict state from the same session are then invalidated. Reversing the order keeps the session firmly in the constrained state through both observations on one device.
+
+### Mode switching — destructive observation last
+
+When testing mutual-exclusion via mode switching (e.g., admin switches from Mode A to Mode B), record the field-cleared assertion *during* the switch, not after subsequent operations that might further mutate the field.
+
+### Lifecycle tests — read-after-write before destructive operations
+
+When a test includes both persistence (write → read round-trip) and a destructive operation (delete, clear, switch mode), put the read-after-write first. The destructive operation should be the last action in the trace.
+
+### Single-session flows — observe before authenticating
+
+For sessions that have a pre-auth phase, any action that successfully authenticates ends the pre-auth phase. Observations that require pre-auth state (rendering, blocked-link behavior, gating) must precede the authenticating action.
+
+## Application to scenario authoring
+
+Scenarios don't carry click-by-click steps (those live in the test cases). But when execution **sequence** is load-bearing at planning time — i.e., the order of operations is necessary to preserve a piece of state across multiple observations — capture the constraint in the case's `**Notes:**` field so the test-case author preserves it later.
+
+Example:
+
+```markdown
+### Case 3: Allow-list toggle (state-preserving)
+
+- **Objective:** verify the end user's tap-through behavior matches the
+  allow-list config in both states.
+- **Checkpoints:**
+  - With URL not on allow-list → action blocked
+  - With URL added to allow-list → action loads in pre-auth context
+- **Notes:** Run **strict (not on allow-list) first, then permissive (on allow-list)**
+  for the same device session, so the session stays pre-auth across both
+  observations (avoid post-auth contamination).
+```
+
+Reviewers check that the noted sequence makes sense; the test-case author binds it to actual steps later.
+
+## What this prevents
+
+- Unnecessary device resets between observations (slows execution by minutes per case)
+- Confusing test results where the failure mode looks like a render bug but is actually post-auth contamination
+- Writing setup-heavy cases that need fresh tenant/profile state for each step
+
+## Reference
+
+A past plan applied this rule when reordering a "render + state behavior" case from permissive→strict to strict→permissive specifically to keep one device pre-auth through both observations. Treat that as the canonical example.

--- a/skills/reviewing-typography/SKILL.md
+++ b/skills/reviewing-typography/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: reviewing-typography
+description: |
+  Audits just-published Confluence pages for typography problems — Gestalt
+  proximity violations, visual hierarchy collisions, wall-of-text paragraphs —
+  that templates cannot predict because they depend on the actual content's
+  length and shape. Use when a QA engineer wants to review typography, audit
+  page design, check Confluence formatting quality, or after running
+  planning-tests or designing-cases against real content.
+disable-model-invocation: true
+tools:
+  - mcp-atlassian:confluence_get_page
+  - mcp-atlassian:confluence_update_page
+---
+
+# reviewing-typography
+
+Walks each just-published Confluence page block-by-block and applies two design principles — **Gestalt proximity** (spacing groups or separates) and **visual hierarchy** (weight signals importance) — to flag and fix typography problems.
+
+## Why this is an AI-judgment skill, not a checklist template
+
+Content shape is unknowable at template time. A metadata block looks fine on an empty shell but reads as a wall the moment real prose lands under it. A bold inline label looks like an anchor when three exist on a page; once ten exist on the same page, they all compete and the hierarchy collapses. A 4-item bullet list reads cleanly; a 17-item bullet list reads as paragraph soup. **The agent must look at the rendered content and decide** — there is no rule set that survives contact with arbitrary content.
+
+This skill is invoked after the page is published — typically as `planning-tests` Step 7 (after Step 6's content-rendering check) or `designing-cases` Step 6 (immediately after publish). Because the skill fetches raw storage HTML, it catches both content-rendering failures (collapsed lists, fused metadata — the same patterns `planning-tests` Step 6 calls out) **and** the design-level problems (proximity, hierarchy) that templates cannot predict. The fix recipe is the same for both classes of finding: re-push the page via `content_format: "storage"` with a corrected HTML body. Treating them as one pass is intentional — it avoids the artificial seam between "did the page render?" and "does the page read well?", since both surface as the same storage-HTML defects.
+
+## Progress Checklist
+
+```
+- [ ] Step 1: Collect page IDs in scope
+- [ ] Step 2: Fetch each page in storage format
+- [ ] Step 3: Proximity pass — adjacent-block group/separate check
+- [ ] Step 4: Hierarchy pass — squint test for weight collisions
+- [ ] Step 5: Compose per-page critique with proposed storage-format diffs
+- [ ] Validate: N pages reviewed, N clean, N needing fixes
+- [ ] Step 6: Apply approved fixes via confluence_update_page
+- [ ] Validate: Re-fetch each fixed page and confirm changes landed
+```
+
+## Steps
+
+### Step 1: Collect Page IDs
+
+Source order:
+
+1. **From a project folder:** if `test_plan/confluence_pages.md` exists, every page recorded there is in scope by default. The agent may also accept a narrower scope from the user ("just review TS-XX pages", "just the README").
+2. **Explicit list:** the user names specific page IDs.
+
+If no page IDs can be resolved, stop and ask the user.
+
+### Step 2: Fetch Each Page in Storage Format
+
+For each page, call:
+
+```
+mcp-atlassian:confluence_get_page
+  page_id: <id>
+  convert_to_markdown: false
+```
+
+Do **not** work from the markdown render. Markdown smooths over the very problems this skill exists to catch (collapsed paragraphs, weight inversions). Read the raw `storage` HTML.
+
+### Step 3: Proximity Pass
+
+Walk the storage HTML top to bottom. For each **adjacent pair of block-level elements** (`<p>`, `<ul>`, `<ol>`, `<h2>`, `<h3>`, `<table>`, `<ac:structured-macro>`, `<hr/>`, etc.), ask:
+
+> *Are these two blocks the same conceptual group, or different conceptual groups?*
+
+| Decision | Required separation |
+|---|---|
+| Same group | One `<p>`-to-`<p>` gap is fine; no separator between a heading and its first body block is fine. |
+| Different group | Need visible separation: a heading break, an `<hr/>`, or a clearly labeled new block. |
+| Crossing layers (e.g. metadata → body, intro → first scenario) | Need the **loosest** separation: heading or `<hr/>`. Two adjacent `<p>` blocks here will fuse visually. |
+
+Specific patterns to watch for are catalogued in `references/typography-principles.md` — at minimum: metadata-block-fused-with-intro (A1), prose paragraph crossing 3+ ideas (A2), nested `<li>` doing the job of a heading (A6).
+
+### Step 4: Hierarchy Pass — Squint Test
+
+Look at the rendered page (open it in a browser tab if possible, or visualize from the storage HTML) with eyes unfocused. Without reading any word, the visible weight order should be:
+
+```
+Page title (heaviest)
+  H2
+    H3
+      Bold inline labels (Objective:, Status:, Focus:) — anchor words
+        Body text
+          Inline code / monospaced refs (lightest)
+```
+
+For each pair of adjacent levels, ask:
+
+> *Can the eye tell these apart at a glance?*
+
+Specific failure modes (full catalog in `references/typography-principles.md`):
+
+- **Bold-label inflation (A3):** every paragraph starts with a different bold phrase. The labels were meant to be skim anchors below H3 — but at density >6 per page, none of them anchor anything.
+- **Heading promotion needed (A6):** a `<p><strong>Label:</strong></p>` followed by a long list is doing heading work without heading weight. Promote to `<h3>`.
+- **No hierarchy at all:** the page has only `<p>` and `<ul>` for 800+ words. Insert at least one `<h3>` break at the natural mid-page boundary.
+- **Weight collision:** two adjacent levels (H2 vs H3, or H3 vs bold-inline) render at indistinguishable weights for this Confluence theme. Pick one and demote the other, or insert intermediary content.
+
+### Step 5: Compose Critique
+
+For each page, emit a short markdown report:
+
+```
+## [PROJECT_ID]: [Page Title] (page ID `xxx`)
+
+**Proximity findings:** N items
+- [block A] adjacent to [block B] — same group / different group, current separation is too tight / too loose.
+  - Proposed fix: <concrete change, e.g. "insert <hr/> between metadata and intro paragraph">
+
+**Hierarchy findings:** N items
+- [observation, e.g. "10 bold inline labels compete; no level above them"]
+  - Proposed fix: <concrete change, e.g. "promote the 3 case-anchor labels to <h3>, remove bold from remaining 7">
+
+**Verdict:** CLEAN | NEEDS FIXES
+```
+
+If a page is CLEAN, say so explicitly with no findings. **Inventing findings on a clean page is its own anti-pattern** — it trains the agent and the reader to ignore real findings next time.
+
+### Validate
+
+Report:
+
+- Pages reviewed: N
+- Pages CLEAN: N
+- Pages NEEDS FIXES: N
+- Total findings by type: proximity X, hierarchy Y
+
+### Step 6: Apply Approved Fixes
+
+Wait for human approval of the critique before editing. Then for each page with findings:
+
+```
+mcp-atlassian:confluence_update_page
+  page_id: <id>
+  content_format: "storage"
+  content: <corrected HTML>
+```
+
+Use `storage` format (not `markdown`) for every fix — these are precision edits and markdown will re-introduce the same problems.
+
+After all fixes, re-fetch each updated page with `convert_to_markdown: false` and confirm the fix landed in the raw HTML. **Do not trust the update response alone.** A typical first publish has multiple pages broken in some way after the initial publish (markdown converter dropped lists, fused metadata, etc.); the fix cycle is the same trust-nothing loop.
+
+Watch specifically for known publish-time pitfalls (see `references/typography-principles.md` § "Publish-Time Pitfalls"): markdown task-list flattening, inline code drift, and the metadata-as-one-block illusion. Round-trip drift through `content_format: "markdown"` on update can silently break content that rendered correctly on the initial publish.
+
+### Validate
+
+Report:
+
+- Pages updated: N
+- Re-fetch confirmation: N landed clean | N still pending (with details)
+
+## Expected Input
+
+- A list of Confluence page IDs (typically from `test_plan/confluence_pages.md`)
+- Access to `mcp-atlassian:confluence_get_page` and `mcp-atlassian:confluence_update_page`
+
+## Next Step
+
+After typography review passes, return control to the calling skill (`planning-tests`, `designing-cases`, etc.) or move on to the next workflow phase.
+
+## References
+
+- `references/typography-principles.md` — Gestalt proximity and visual hierarchy in full, anti-pattern catalog (A1–A6) with storage-format before/after, fix recipes, and the "when to leave it alone" rule.

--- a/skills/reviewing-typography/references/typography-principles.md
+++ b/skills/reviewing-typography/references/typography-principles.md
@@ -1,0 +1,252 @@
+# Typography Principles for Confluence Pages
+
+This is the catalog of design judgments the `reviewing-typography` skill applies. It is **not a rule template** — it is principles plus a documented anti-pattern catalog. The skill walks real content and decides which patterns are present in the actual page.
+
+## The Two Principles
+
+### Principle 1: Gestalt Proximity
+
+Elements close together read as belonging to the same group. Elements far apart read as separate groups. **Spacing is meaning.**
+
+In Confluence storage format, the proximity knobs are:
+
+| Distance | Storage construct | Reads as |
+|---|---|---|
+| Tightest | inline text, `<br/>` inside a `<p>` | "these tokens are one thought" |
+| Tight | adjacent `<p>` blocks | "related thoughts, same section" |
+| Medium | `<p>` then `<ul>` / `<table>` / `<ol>` | "claim, then evidence" |
+| Loose | `<hr/>` divider | "different zones of the page" |
+| Looser | `<h3>` boundary | "new sub-topic" |
+| Loosest | `<h2>` boundary | "new section" |
+
+Use the **smallest distance that still signals the right relationship**. Over-separating is just as broken as under-separating: a page with an `<h3>` every two paragraphs reads as choppy and fragmented — none of the headings carry weight.
+
+### Principle 2: Visual Hierarchy
+
+The reader's eye lands on the heaviest, biggest element first. A well-designed page has a clear weight gradient:
+
+```
+Page title           (Confluence renders large, bold)
+  H2                 (large, bold)
+    H3               (medium, bold)
+      Bold inline    ("Objective:", "Status:") — anchor words inside body
+        Body         (regular weight)
+          Inline code  (de-emphasized, monospace)
+```
+
+Rules of thumb:
+
+1. **Two adjacent weight levels must be visibly different.** If H2 and H3 render at the same weight in this Confluence theme, the hierarchy is broken.
+2. **A page should have no more than 3 active weight levels in body content.** Title + H3 + body is plenty for most pages. Bold inline labels add a 4th — fine if sparse (3–4 per page); broken if dense (every paragraph).
+3. **Don't use bold to mean "important."** Use it to mean "this is an anchor word a skimming reader should land on." When every body sentence has a bold word, no word is an anchor.
+
+## Anti-Pattern Catalog
+
+Each anti-pattern is documented from past reviews. Each entry includes: what the broken HTML looks like, why it's broken in terms of the principles, and the recommended fix.
+
+### A1: Metadata block crammed into one paragraph
+
+**Broken:**
+
+```html
+<p><strong>Focus:</strong> End-user E2E (case 1 only)<br/>
+<strong>Estimated test cases:</strong> 4<br/>
+<strong>Test plan reference:</strong> <code>test_plan/sections/04_Test_Strategy.md</code></p>
+<p>The deep happy-path on the end-user side — a real client device exercises the feature…</p>
+```
+
+**Why broken (proximity):** each `<br/>` is the tightest tier ("one thought"), so the metadata items read as one continuous line. Then the intro paragraph follows with only a `<p>`-to-`<p>` gap — the same separator used between body paragraphs. The eye perceives the entire metadata block + intro as one mass.
+
+**Fixed:**
+
+```html
+<p><strong>Focus:</strong> End-user E2E (case 1 only)</p>
+<p><strong>Estimated test cases:</strong> 4</p>
+<p><strong>Test plan reference:</strong> <code>test_plan/sections/04_Test_Strategy.md</code></p>
+<hr/>
+<p>The deep happy-path on the end-user side — a real client device exercises the feature…</p>
+```
+
+The metadata items each get medium proximity (their own paragraph, but visually adjacent), and an `<hr/>` (loose tier) breaks the page into a metadata zone and a body zone.
+
+### A2: Long prose paragraph crossing multiple ideas
+
+**Broken:** a 5–7 sentence paragraph that explains what each scenario case covers, then mentions what's in/out of scope, then drops a connection to another scenario. The reader hits a wall of text with no resting point.
+
+**Why broken (proximity):** proximity says "everything inside this `<p>` is one thought." But the paragraph contains 3–4 distinct thoughts. The visual signal contradicts the actual content.
+
+**Fixed:** split at the conceptual seams. Look for transition words: "Meanwhile," "Also," "However," "The X belongs to…," "Case 1 vs Case 2…" — those are usually the seams. Three short paragraphs often read faster than one long one carrying the same content.
+
+**Note:** A2 is *not* a defect when the long paragraph is genuinely one idea (a narrative summary of a complex flow, a multi-clause definition). Author intent matters. If the prose really is one idea and the user has chosen narrative-prose style, leave it.
+
+### A3: Bold-inline-label inflation
+
+**Broken:** every paragraph on the page begins with **A different bold phrase:** followed by body text. Looks "structured" at a glance; in reality, the bold labels were meant to be skim anchors and now there are 10 of them on a single page, none anchoring anything.
+
+**Why broken (hierarchy):** the bold labels are supposed to sit one level below H3 in the weight gradient — readers' eyes were supposed to land on them while skimming. Density killed the weight differential. The page now has H3 → 10 bold labels → body, with no way to tell which labels matter.
+
+**Fixed (one of three options):**
+
+1. **Promote the most important 2–3 labels to `<h3>`** and remove bold from the rest. The promoted labels become real navigation anchors; the demoted ones become plain body text.
+2. **Group all bold labels under a new `<h3>`** that names the category. The reader's eye lands on the `<h3>`, and the bold labels under it become a legitimate sub-list.
+3. **Remove bold entirely** if the labels are repetitive ("Focus:," "Notes:," "Focus:," "Notes:," ...) — at that density they're noise.
+
+### A4: Adjacent headings collide
+
+If the Confluence theme renders H2 and H3 at similar visual weights for this space, two adjacent headings of those levels look like the same level — the user can't tell what's a major break vs a minor one.
+
+**Fixed:** either pick one level and stick with it, or insert intermediary body content (one paragraph of context) between the H2 and the first H3 so the hierarchy resets.
+
+### A5: Bold-paragraph + immediately-following list, no blank line in source
+
+This is the markdown-converter gotcha already documented in `planning-tests` Step 5. From a typography view, it produces a `<p>` containing the list items as inline text — total proximity collapse, the bullets aren't bullets at all.
+
+**Fixed:** insert a blank line in the markdown source, or emit `storage` HTML with separate `<ul>`. See A6 below for when to also promote the bold paragraph to `<h3>`.
+
+### A6: Nested `<li>` doing the job of a heading
+
+**Broken:**
+
+```html
+<ul>
+  <li>
+    <p><strong>Checkpoints:</strong></p>
+    <ul>
+      <li>Item 1</li>
+      <li>Item 2</li>
+      <li>Item 3</li>
+      <li>Item 4</li>
+      <li>Item 5</li>
+      <li>Item 6</li>
+      <li>Item 7</li>
+      <li>Item 8</li>
+    </ul>
+  </li>
+</ul>
+```
+
+**Why broken (hierarchy):** when the inner list has more than ~5 items, the parent `<li>` containing only "Checkpoints:" is doing the job of a heading without the visual weight of one. Readers expect the outer list's items to be siblings; they're not.
+
+**Fixed:**
+
+```html
+<h3>Checkpoints</h3>
+<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+  ...
+  <li>Item 8</li>
+</ul>
+```
+
+**Cutover threshold:** roughly 5–7 inner items. Below that, the bold-label-+-nested-list pattern is fine and reads as a tidy mini-group. Above that, promote to `<h3>` for real hierarchy.
+
+## Fix Recipes (storage-format snippets)
+
+### Insert a horizontal divider between zones
+
+```html
+<hr/>
+```
+
+One line. Confluence renders a thin horizontal rule. Use it sparingly — once or twice per page at zone boundaries (e.g. metadata → body, scenario summary → first case). Multiple `<hr/>` per page becomes noise.
+
+### Promote a bold label to a sub-heading
+
+Before:
+
+```html
+<p><strong>Objective:</strong> Verify the end user can submit the form…</p>
+```
+
+After (only if a list / table / multi-paragraph block follows):
+
+```html
+<h3>Objective</h3>
+<p>Verify the end user can submit the form…</p>
+```
+
+For a single-sentence objective with no follow-on, leave it as a bold inline. Promotion is for content that *deserves* heading weight.
+
+### Split a long paragraph
+
+Find the conceptual seam (often a sentence starting with "Meanwhile," "Also," "However," "The X belongs to…"). Replace the in-sentence break with `</p><p>` at the seam. If the resulting paragraphs are very short (one clause each), the split was too aggressive — re-merge.
+
+### Demote competing bold labels
+
+If a page has 10 bold inline labels, identify the 2–3 most semantically heavy ones. Promote those to `<h3>`. Remove `<strong>…:</strong>` from the rest, leaving plain prose. The page goes from "everything important" to "three things important, the rest is context."
+
+## Publish-Time Pitfalls (markdown → storage conversion)
+
+These aren't typography defects in the source — they're conversion bugs that surface only after a Confluence update. The reviewing-typography skill should re-fetch the page after every update and check that the rendered storage matches expectations.
+
+### Pitfall 1: Task lists collapse when pushed via markdown content format
+
+**Symptom:** Source markdown like:
+
+```markdown
+**Entry Criteria (when can testing start?):**
+- [ ] Build deployed to the selected tenant
+- [ ] BE stories Resolved: ...
+```
+
+renders correctly on the **initial** publish (via `/cf-create-page`'s markdown path) as `<ac:task-list>` macros with proper checkboxes. But re-pushing the same content via `confluence_update_page` with `content_format: "markdown"` flattens it to a single `<p>` with literal `- [ ]` text:
+
+```html
+<p><strong>Entry Criteria (when can testing start?):</strong> - [ ] Build deployed... - [ ] BE stories Resolved...</p>
+```
+
+**Cause:** The markdown converter requires a blank line between the bold-prefix paragraph and the first task-list item. Without it, the converter treats the whole block as one paragraph and embeds `- [ ]` as literal characters.
+
+**Fix:** When updating any page that contains task lists, use `content_format: "storage"` with explicit `<ac:task-list>` macros:
+
+```html
+<p><strong>Entry Criteria (when can testing start?):</strong></p>
+<ac:task-list>
+<ac:task><ac:task-id>1</ac:task-id><ac:task-status>incomplete</ac:task-status><ac:task-body>Build deployed to the selected tenant</ac:task-body></ac:task>
+<ac:task><ac:task-id>2</ac:task-id><ac:task-status>incomplete</ac:task-status><ac:task-body>BE stories Resolved: ...</ac:task-body></ac:task>
+</ac:task-list>
+```
+
+Task IDs must be unique across the page. Pick numbers that don't collide with any other task-list on the same page.
+
+**Detection:** After any update to a page that previously had task lists, re-fetch and check for `<ac:task-list>` presence. If you see `<p>...- [ ]...</p>` instead, the conversion broke.
+
+### Pitfall 2: Inline code spans drift between markdown and rendered storage
+
+**Symptom:** Source markdown has `` `README.md` `` (backticked code). After publishing once via markdown content_format, the rendered storage may show `the README` (plain text, no `<code>` wrapper).
+
+**Cause:** The markdown converter can drop inline code when it's adjacent to certain punctuation or inside certain enclosing contexts. The drift is silent — no error.
+
+**Fix:** When updating, use storage format with explicit `<code>README.md</code>` to guarantee the code styling lands. The reviewing-typography skill should diff source → rendered storage and flag drift.
+
+### Pitfall 3: Multiple consecutive `<p>` bold-label paragraphs render visually distinct only with `<hr/>` zone breaks
+
+This isn't strictly a conversion bug — it's a visual-density tradeoff already covered by anti-pattern A1. But it interacts with the markdown converter: if the source has blank-line-separated `**Label:** value` paragraphs, the converter produces correct `<p>` blocks, but readers may still perceive them as one block of metadata unless an `<hr/>` divider follows. Add the `---` divider in source to translate to `<hr/>` in storage.
+
+### Pitfall 4: Space eaten between `**Label:**` and an immediately-following inline element
+
+**Symptom:** Source markdown has `**Test Plan Reference:** \`test_plan/path.md\`` (or `**Label:** [link](url)`) — a single space separates the bold label from the next inline element. After publishing via `content_format: markdown`, the rendered storage shows `<p><strong>Test Plan Reference:</strong><code>test_plan/path.md</code></p>` — **no space** between `</strong>` and `<code>`. The page reads "Test Plan Reference:test_plan/path.md" with the colon glued to the backtick.
+
+**Cause:** Confluence's markdown converter discards the space when an emphasis run ends right before an inline code span or a link. The bug only triggers when the bold label is at paragraph start AND followed by an inline element (code/link); plain text after the label preserves spacing correctly. This is distinct from Pitfall 2 (which drops the code entirely) — here the code is preserved but the leading space is lost.
+
+**Fix:** Use `content_format: storage` with an explicit space character between `</strong>` and the next inline element:
+
+```html
+<p><strong>Test Plan Reference:</strong> <a href="..."><code>test_plan/path.md</code></a></p>
+```
+
+Trying to fix this from the markdown source side (double spaces, NBSP, etc.) doesn't reliably work because the converter normalizes whitespace before parsing. Storage is the only deterministic fix. As a side benefit, the storage push lets you replace local file-path code spans with proper Confluence cross-page hyperlinks, turning a cosmetic patch into a navigation upgrade.
+
+**Detection:** Grep the rendered storage HTML for `</strong><code>` or `</strong><a` (no space). If you find any inside a `<p>` block, the conversion ate the space.
+
+## When to Leave It Alone
+
+Not every page needs fixing. Report **CLEAN** when:
+
+- The proximity is correct for the content — no two distinct groups have collided into one mass.
+- The hierarchy gradient is visible at a squint — H2 reads heavier than H3 reads heavier than bold inline reads heavier than body.
+- A reader can skim the page in under 30 seconds and walk away with the page's key claims.
+- The author's stylistic choices (narrative prose vs structured lists) are respected. Style preference is not a defect.
+
+**Inventing findings on a clean page is its own anti-pattern.** It trains the agent (and the human reviewer) to ignore real findings next time. CLEAN is a valid verdict — use it when it applies.


### PR DESCRIPTION
## Summary

Backports three coupled improvements proven across two recent feature plans in the r1-test-cases repo, fully sanitized to product-agnostic.

- **Graph-path check** — every scenario case must trace to a Mermaid node in `test_design/scenarios/README.md`. Catches phantom cases, misplaced assertions, and stale node ownership at draft time. Lives in new `scenario-conventions.md` (graph-node mapping rule) + `overlap-review.md` (graph-staleness check).
- **Format adjust** — ISO/IEC/IEEE 29119-3 layout (`test_plan/sections/` lean + `test_plan/test_design/{scenarios/, traceability_matrix.md, risk_register.md}` + `ui_baseline/<DATE>/`); uniform scenario metadata header + `### Case N:` template (Objective + Checkpoints mandatory); Coverage Matrix dropped (derived from RTM on demand). New `tw-baseline-trace` command drives Playwright through affected pages before scenarios are drafted. Plus publish-format learnings: four markdown-converter gotchas, Path C mixed markdown/storage strategy, mandatory pre-flight re-fetch.
- **Typography audit** — new `reviewing-typography` skill (Gestalt proximity + visual hierarchy with anti-pattern catalog A1–A6 and storage-format fix recipes) wired in as the mandatory final step of `planning-tests` (Step 7) and `designing-cases` (Step 6).

Three commits:
1. `feat: backport ISO 29119 folder layout + content templates + publish-format` (16 files)
2. `feat: add graph-path check + scenario / overlap / api-vs-journey / sequencing / environment references` (5 files)
3. `feat: add reviewing-typography skill + integrate typography audit into planning + designing skills` (6 files)

All product-specific content (RUCKUS One, ACX-* ticket IDs, dog1051, ruckus.cloud, Captive Portal, Wi-Fi/walled-garden examples, driving-wireless-client) replaced with generic CRUD-form / list-page / feature-flag / submission-form examples. Three R1-only skills (`drafting-effort-story`, `driving-wireless-client`, `switching-env`) intentionally NOT backported.

## Test plan

- [ ] **Sanitization audit** — confirm no R1-specific identifiers leaked: `grep -rn -i -E 'ACX-[0-9]+|RUCKUS|dog1051|ruckus\.cloud|captive.portal|walled.garden|wpa-mcp|driving-wireless' skills/ commands/test-workflow/ commands/confluence/` returns nothing meaningful (the pre-existing `wpa-mcp` line in `CLAUDE.md` § MCP Dependencies is out of scope for this backport).
- [ ] **Cross-link integrity** — every reference path uses `skills/...` (no `.claude/skills/...` leftovers): `grep -rn '\.claude/skills' skills/ commands/test-workflow/ commands/confluence/` returns empty.
- [ ] **`/review-install`** — run against a project that already has the older planning-tests / designing-cases skills installed; confirm the new `reviewing-typography` skill, `tw-baseline-trace` command, and 6 new reference files are flagged as "new" and the diff for updated SKILL.md / cf-create-page.md / cf-format-guide.md / tw-* commands looks reasonable.
- [ ] **Dry-run on a fresh project** — `/jr-trace` → `/tw-baseline-trace` → `/tw-plan-feature` → confirm scenarios land in `test_design/scenarios/`, RTM and Risk Register are standalone artifacts, no Coverage Matrix is generated, overlap-sweep prompt fires.
- [ ] **Confluence publish dry-run** — `/cf-create-page` produces a 3-level tree (README → sections + Test Scenarios index → TS-XX pages); pre-flight re-fetch detects any of the four markdown-converter gotchas; `reviewing-typography` runs as the final gate.
- [ ] **README + CLAUDE.md** — skills table includes `reviewing-typography`; tw-* listing includes `tw-baseline-trace`; project structure shows the new skills directory entry.

## Out of scope

- `drafting-effort-story` skill — RUCKUS-specific Jira-Story narrative workflow.
- `driving-wireless-client` skill — Android Wi-Fi captive-portal client orchestration.
- `switching-env` skill — RUCKUS-specific MCP env profiles.
- `dev-workflow/` `dw-*` commands — unrelated to this backport.

## Post-merge

Run `/sync` from any consumer project to pick up the changes. Projects mid-flight on the older layout keep their original `sections/`-only structure (the migration policy in `file-layout.md` covers this — `tw-case-*` reader commands fall back to legacy `sections/`-only when `test_design/` is absent).


Made with [Cursor](https://cursor.com)