### PR TITLE
Two-axis audit: commands, skills, CLAUDE.md, README

### DIFF
--- a/.claude/skills/auditing-artifacts/SKILL.md
+++ b/.claude/skills/auditing-artifacts/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: auditing-artifacts
+description: |
+  Audits this repo's commands/, skills/, and CLAUDE.md on two axes — Format (structural
+  correctness) and Purpose (does the artifact deliver its stated goal). Use when the
+  user wants to audit, review, or sanity-check the project's commands, skills, or
+  CLAUDE.md as a whole.
+disable-model-invocation: true
+---
+
+# auditing-artifacts
+
+Two-axis audit across the three artifact types in this repo:
+
+- `commands/**/*.md` — slash command source files
+- `skills/*/SKILL.md` — skill source files
+- `CLAUDE.md` — project root config
+
+This skill is the **top-level sweep**. For a deep, command-only audit, use `reviewing-commands` (8 quality dimensions, line-level issues).
+
+## The Two Axes
+
+| Axis | Question it answers |
+|------|---------------------|
+| **Format** | Is the artifact structurally valid and well-formed? |
+| **Purpose** | Does the artifact deliver on its stated goal, without sprawl or redundancy? |
+
+Both axes are scored per artifact: **Pass / Partial / Fail / N/A**.
+
+## Progress Checklist
+
+```
+- [ ] Step 1: Determine scope
+- [ ] Step 2: Enumerate target files
+- [ ] Step 3: Audit Format axis
+- [ ] Step 4: Audit Purpose axis
+- [ ] Step 5: Cross-cutting checks (CLAUDE.md ↔ filesystem)
+- [ ] Validate: every target scored on both axes
+- [ ] Step 6: Generate report
+- [ ] Step 7: Apply fixes (if --fix requested)
+```
+
+## Steps
+
+### Step 1: Determine Scope
+
+Parse user input:
+
+| Input | Scope |
+|-------|-------|
+| (no args) | All three: `commands/`, `skills/`, `CLAUDE.md` |
+| `commands` or `commands/<subfolder>` | Commands only (folder or subfolder) |
+| `skills` or `skills/<name>` | Skills only (all or one) |
+| `claude.md` | CLAUDE.md only |
+| `--fix` | After report, apply fixes with user confirmation |
+
+### Step 2: Enumerate Target Files
+
+Use `Glob` for each in-scope target:
+
+- Commands: `commands/**/*.md`
+- Skills: `skills/*/SKILL.md`
+- Root: `CLAUDE.md`
+
+Announce the count before reading.
+
+### Step 3: Audit Format Axis
+
+Apply the checklist for each artifact type.
+
+#### Commands (`commands/**/*.md`)
+
+- [ ] File name matches `prefix-name.md` convention (lowercase, hyphenated)
+- [ ] File lives in the correct subfolder for its prefix (e.g., `tl-*` in `commands/testlink/`)
+- [ ] Has a top-level `# Heading` (command name / title)
+- [ ] Under 500 lines (official Claude Code limit)
+- [ ] Markdown is well-formed (no broken tables, unclosed code fences, dangling links)
+- [ ] Cross-references to other commands use `/prefix-name` and the target exists
+- [ ] No private identifiers leaked (real ticket IDs, page IDs, project names — see CLAUDE.md "Information Leak Check")
+
+#### Skills (`skills/*/SKILL.md`)
+
+- [ ] File is named exactly `SKILL.md`
+- [ ] Folder name matches `name:` in frontmatter
+- [ ] Folder name is lowercase-kebab-case
+- [ ] Frontmatter is valid YAML with at least `name` and `description`
+- [ ] `description` under 250 chars (truncated otherwise)
+- [ ] Has a Progress Checklist or step sequence
+- [ ] Under 500 lines
+- [ ] Cross-references to commands (`/cmd-name`) resolve to existing files
+
+#### CLAUDE.md
+
+- [ ] Has `## Project Overview` and `## Architecture` (or equivalent)
+- [ ] `## Skills` table is present (when the project ships skills)
+- [ ] Directory Structure block reflects the actual `commands/` and `skills/` layout
+- [ ] Skills table entries match `skills/*/` folders (no orphans, no missing)
+- [ ] Command subfolders listed match `commands/*/` folders
+- [ ] MCP dependencies section lists each MCP server referenced in commands
+
+Score Format per artifact: **Pass** (all applicable checks satisfied), **Partial** (minor gaps), **Fail** (key checks missing).
+
+### Step 4: Audit Purpose Axis
+
+For each artifact, evaluate four sub-checks:
+
+| Sub-check | What to look for |
+|-----------|------------------|
+| **P1: Goal clarity** | Is the purpose/description a single clear objective? Or vague ("manages X", "handles Y"), multi-purpose, or buried? |
+| **P2: Description ↔ content alignment** | Do the actual steps/instructions deliver what the description promises? Flag mismatches (e.g., description says "audit", body only formats output). |
+| **P3: Scope discipline** | Does every step trace back to the stated goal? Flag scope creep (steps that do something off-topic) and dead steps (instructions that produce no useful output). |
+| **P4: Redundancy / necessity** | Does this artifact substantially duplicate another (>50% overlap with another command/skill)? Could it be merged or removed? |
+
+For CLAUDE.md, P3/P4 translate to:
+- P3: Does each section justify its presence, or is there stale/orphaned content?
+- P4: Are there entries that reference removed commands/skills (orphans), or commands/skills missing from the table (gaps)?
+
+Score Purpose per artifact: **Pass** (all four sub-checks satisfied), **Partial** (1 sub-check failing), **Fail** (2+ sub-checks failing).
+
+### Step 5: Cross-Cutting Checks (CLAUDE.md ↔ Filesystem)
+
+Run these even when scope is narrower than all-three, if CLAUDE.md is in scope or all three are in scope:
+
+1. **Skills drift** — every row in CLAUDE.md's Skills table has a matching `skills/<name>/SKILL.md`, and vice versa.
+2. **Command folder drift** — every subfolder listed in the Directory Structure block exists in `commands/`, and every actual subfolder appears in the block.
+3. **Orphan references** — search CLAUDE.md for `/cmd-name` patterns; confirm each resolves to an existing command file.
+4. **MCP references** — every MCP server name appearing in command bodies appears in CLAUDE.md's MCP Dependencies section.
+
+### Validate
+
+Confirm every in-scope target has both axes scored. Confirm cross-cutting checks ran when applicable.
+
+### Step 6: Generate Report
+
+Use this format:
+
+```markdown
+# Artifact Audit — <YYYY-MM-DD>
+
+**Scope:** <commands | skills | CLAUDE.md | all>
+**Targets audited:** <count>
+
+## Scorecard
+
+| Artifact | Format | Purpose | Critical | Major | Minor |
+|----------|--------|---------|----------|-------|-------|
+| commands/testlink/tl-create-case.md | ✓ | ~ | 0 | 1 | 2 |
+| skills/planning-tests/SKILL.md | ~ | ✓ | 0 | 1 | 0 |
+| CLAUDE.md | ✓ | ✓ | 0 | 0 | 1 |
+
+Legend: ✓ Pass · ~ Partial · ✗ Fail · — N/A
+
+## Cross-Cutting Findings
+
+- <e.g., "CLAUDE.md Skills table lists `reviewing-commands` but folder is missing">
+- <e.g., "`commands/testlink/tl-foo.md` references `/tl-bar` which does not exist">
+
+## Issues by Severity
+
+### Critical (must fix — artifact will fail or mislead)
+| # | Artifact | Axis | Issue | Suggested Fix |
+|---|----------|------|-------|---------------|
+
+### Major (should fix — ambiguity or drift)
+| # | Artifact | Axis | Issue | Suggested Fix |
+|---|----------|------|-------|---------------|
+
+### Minor (optional)
+| # | Artifact | Axis | Issue | Suggested Fix |
+|---|----------|------|-------|---------------|
+
+## Overall: APPROVED / NEEDS REVISION
+```
+
+Severity rubric:
+
+| Severity | Definition |
+|----------|-----------|
+| **Critical** | Format failure that breaks loading (invalid frontmatter, missing SKILL.md), or Purpose failure that means the artifact does not do what it claims |
+| **Major** | Significant drift or ambiguity (description/content mismatch, orphan reference, scope creep) |
+| **Minor** | Style, naming polish, redundant phrasing |
+
+### Step 7: Apply Fixes (if `--fix` requested)
+
+1. Present the full report first.
+2. Wait for user confirmation per group (Critical → Major → Minor).
+3. Apply fixes one artifact at a time, smallest blast radius first.
+4. Never delete an artifact without explicit user approval — flag for removal in the report instead.
+5. Re-score affected artifacts after fixes; confirm improvement.
+
+## Expected Input
+
+- `(no args)` → audit all three artifact types
+- `commands` | `commands/<subfolder>` → commands only
+- `skills` | `skills/<name>` → skills only
+- `claude.md` → CLAUDE.md only
+- Append `--fix` to any of the above to apply fixes after the report
+
+## Relationship to `reviewing-commands`
+
+| Skill | Scope | Depth |
+|-------|-------|-------|
+| `auditing-artifacts` (this) | commands + skills + CLAUDE.md | Two-axis sweep, cross-cutting checks |
+| `reviewing-commands` | commands only | 8 quality dimensions, line-level issues |
+
+Run this skill first for a project-wide health check. Drill into specific commands with `reviewing-commands` when this skill flags something at the command level.
+
+## Next Step
+
+After the report, common follow-ups:
+- `reviewing-commands <path>` — deep audit on any command flagged here
+- Fix orphan references in CLAUDE.md (most common Major finding)
+- Re-run `auditing-artifacts` after fixes to confirm scorecard improvement

--- a/.claude/skills/auditing-readme/SKILL.md
+++ b/.claude/skills/auditing-readme/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: auditing-readme
+description: |
+  Audits the project README.md for typography (visual grouping via space, line
+  breaks, font weight) and phrasing (human voice, not technical jargon, doesn't
+  read like machine output). Use when README has been edited, or before
+  publishing changes to ensure the user-facing intro stays approachable.
+disable-model-invocation: true
+---
+
+# auditing-readme
+
+A README is the first thing a visitor sees on GitHub. Unlike command files (internal, technical) or skill files (agent-facing), the README is read by humans deciding whether to use the project. This skill audits it on the two axes that matter for that decision.
+
+| Axis | Question |
+|------|----------|
+| **Typography** | Does visual structure use space, line breaks, and font weight to group related ideas and separate distinct ones? |
+| **Phrasing** | Does the prose read like a person wrote it for another person — direct, concrete, free of jargon dumps? |
+| **Other reader friction** | Anything outside the two axes that would confuse, mislead, or put off a new reader — open observation. |
+
+Both axes scored per section: **Pass / Partial / Fail**. The third bucket is open-ended — flag whatever you see.
+
+**Important: the checklists in Step 2 and Step 3 are a *floor*, not a *ceiling*.** They name the failure modes that come up most often. If you notice an issue that hurts readability but doesn't match a checklist item, flag it anyway under the relevant axis (or Other reader friction). The goal is the reader's experience, not the checklist's completeness.
+
+## Progress Checklist
+
+```
+- [ ] Step 1: Map README sections (H2 + H3)
+- [ ] Step 2: Audit Typography per section
+- [ ] Step 3: Audit Phrasing per section
+- [ ] Step 4: Scan for Other reader friction (open observation)
+- [ ] Validate: every section scored on both axes; open issues captured
+- [ ] Step 5: Generate report with line numbers + concrete fixes
+- [ ] Step 6: Apply fixes (if --fix requested)
+```
+
+## Steps
+
+### Step 1: Map Sections
+
+Read `README.md`. Index every `##` and `###` heading with line range and the block types it contains (paragraph / list / table / code / blockquote). The resulting map is what you score in Steps 2-3.
+
+### Step 2: Typography Audit
+
+The visual job of a README is to let a skimming reader find their answer without reading every word. Bad typography forces linear reading. The principles below come from `skills/reviewing-typography/references/typography-principles.md` (proximity / hierarchy / emphasis) — adapted to GitHub-rendered markdown.
+
+#### Proximity — space tells the reader what goes together
+
+- [ ] Blank line *before and after* every heading, list, table, and code fence
+- [ ] Related items sit close (one blank line, not two); unrelated items separated more clearly (heading or horizontal rule)
+- [ ] Paragraphs break at conceptual seams — no wall of text that mixes three ideas
+- [ ] Lists are wrapped or kept short — bullets longer than ~150 chars in source usually mean the bullet is doing the job of a paragraph and should be one
+
+#### Hierarchy — heading levels mirror conceptual nesting
+
+- [ ] `#` (H1) appears exactly once (the project title)
+- [ ] `##` for top-level sections, `###` for subsections — no skipping levels (no `##` followed directly by `####`)
+- [ ] Heading depth matches conceptual depth — "Installation" is a sub-step under "Quick Start", not a sibling
+- [ ] Section ordering follows reader journey: what the project is → why care → how to use → reference details, in that order
+
+#### Emphasis — bold / italic / code mean specific things
+
+- [ ] `**bold**` reserved for genuine emphasis (the one critical word in a sentence). Not for every command name, not for decorative shouting
+- [ ] `*italic*` for secondary emphasis, term-on-first-mention, or work titles. Sparingly
+- [ ] Inline `code` for actual code, paths, command names, file names. Not for arbitrary highlighting
+
+#### Block choice — match the form to the content
+
+- [ ] Tables for actual tabular data (parallel rows × columns). Not for two-column "label: value" pairs that should be a definition list or paragraph
+- [ ] Code blocks for code, command output, or file contents only. Mermaid / ASCII diagrams are fine; decorative ASCII art is not
+- [ ] Blockquotes for actual quotes or callouts (notes, warnings). Not as a styling trick
+
+Score Typography per section.
+
+### Step 3: Phrasing Audit
+
+The README is public-facing. The reader is a developer evaluating the project, not an agent executing instructions. Tone matters.
+
+#### Section names — describe the destination, not the mechanism
+
+- [ ] Section title tells the reader what they get there ("Quick Start", "How It Works", "Available Commands") — not internal phases ("Phase 1: Module Bootstrap")
+- [ ] Heading uses Title Case or sentence case consistently — not `snake_case`, `kebab-case`, or `CONSTANT_CASE`
+- [ ] No undefined acronyms in headings (MCP is OK once defined; lesser-known acronyms aren't)
+
+#### Voice — direct and human
+
+- [ ] Active voice over passive ("Run `/jr-trace` to fetch the ticket" ✓ / "The ticket is fetched by `/jr-trace`" ✗)
+- [ ] Direct address ("you" or imperative) over impersonal ("the user shall...")
+- [ ] No corporate-marketing voice ("leverages cutting-edge AI", "revolutionizes workflows" ✗)
+- [ ] No robotic voice ("the system processes requests", "the module is initialized" ✗)
+
+#### Reads-like-machine-code red flags
+
+- [ ] No `MODULE.SUBMODULE.METHOD_NAME` style identifiers used as prose subjects
+- [ ] No bare path dumps (`/foo/bar/baz`) without context
+- [ ] No tables of internal enum values pretending to be documentation
+- [ ] No copy-pasted CLI `--help` output where prose would explain better
+- [ ] No verbatim YAML/JSON config snippets where a sentence + one example suffices
+
+#### Audience fit — GitHub README, mixed-expertise readers
+
+- [ ] Opening sentence of each section states value within ~20 words
+- [ ] Concrete examples over abstract claims (show `gh issue create --label feature` rather than "supports labeled issue creation")
+- [ ] Jargon introduced with a one-line definition on first use
+- [ ] No assumed prior knowledge of internal commands, MCP servers, or skill names beyond what's already been introduced in the README
+
+Score Phrasing per section.
+
+### Step 4: Other Reader Friction (open observation)
+
+Read each section as a first-time visitor evaluating the project. Note anything that would slow them down, mislead them, or make them close the tab — even when it doesn't match a Typography or Phrasing checklist item. Common examples (non-exhaustive):
+
+- **Stale or wrong content** — commands that no longer exist, paths that have moved, version numbers that are out of date
+- **Broken or unhelpful links** — 404s, links labeled "click here", links to internal-only docs
+- **Buried lede** — the project's purpose or main hook arrives too late
+- **Missing prerequisites** — examples assume tools, accounts, or environment the reader doesn't have, with no upfront mention
+- **Inconsistent tone or terminology** — same concept named two different ways across sections; voice flips between casual and formal
+- **Examples that don't actually run** — copy-pasted commands with placeholders that aren't marked as such, or syntax that's subtly wrong
+- **Unclear next step** — section ends without telling the reader what to do or read next
+- **Promise without delivery** — claims a feature ("ready in 5 minutes") that the rest of the doc doesn't actually deliver
+- **Accessibility gaps** — image without alt text, color-only meaning, link text that's not descriptive out of context
+- **Anything else** — trust your reader instinct. If you'd be confused, frustrated, or unconvinced, write it down.
+
+For each issue, capture: section + line, what's wrong, and the smallest concrete fix.
+
+### Validate
+
+Confirm every section has both axes scored.
+
+### Step 5: Generate Report
+
+```markdown
+# README Audit — <YYYY-MM-DD>
+
+**File:** `README.md`
+**Sections audited:** <count>
+
+## Scorecard
+
+| Section | Lines | Typography | Phrasing | Issues |
+|---------|-------|------------|----------|--------|
+| Project Goal | 5-16 | ✓ | ✓ | 0 |
+| Quick Start | 16-47 | ~ | ✓ | 1 |
+| ... | ... | ... | ... | ... |
+
+Legend: ✓ Pass · ~ Partial · ✗ Fail
+
+## Issues by Severity
+
+### Major (a reader on first encounter would stumble, get lost, or be put off)
+
+| # | Section:Line | Axis | Issue | Suggested Fix |
+|---|--------------|------|-------|---------------|
+
+### Minor (polish)
+
+| # | Section:Line | Axis | Issue | Suggested Fix |
+|---|--------------|------|-------|---------------|
+
+Axis can be Typography, Phrasing, or Other (open observation).
+
+## Structural Recommendations (Medium / Large scope)
+
+For each recommendation that touches structure or adds content (section split / merge / reorder / rename / new section / substantial new prose), present the tradeoff explicitly:
+
+| # | Scope | Recommendation | Pros | Cons | Decision |
+|---|-------|---------------|------|------|----------|
+| 1 | Medium | Split "Quick Start" into "Installation" + "First Use" | Each step gets its own scannable section; lets new readers stop after install if that's all they need | One extra heading in the ToC; small risk of duplication if both need the same prerequisites | Pending user |
+| 2 | Large | Move "Project Goal" above "Quick Start" | New readers see the value prop before the how-to; matches typical GitHub README convention | Loses the "show, don't tell" effect of leading with `Quick Start`; changes the URL anchor `#project-goal` would still exist but the page order ranking in GitHub previews changes | Pending user |
+
+Rules:
+- Pros and Cons are **specific and concrete**, not generic ("improves readability" is not a pro — say *what* improves and *for whom*)
+- At least one Con must be named for every recommendation. If you can't think of one, the recommendation may not be ready
+- Decision column starts as "Pending user" and is updated when the user approves / rejects / defers
+
+## Overall: APPROVED / NEEDS REVISION
+```
+
+Severity rubric:
+
+| Severity | Definition |
+|----------|-----------|
+| **Major** | A new reader would be confused, misled, or click away. Examples: skipped heading levels that break the ToC; section that reads like raw machine output; jargon dump with no explanation; wall of text where structure was needed. |
+| **Minor** | Polish — phrasing tightening, whitespace cleanup, consistency tweaks. Nice to have, won't lose readers. |
+
+### Step 6: Apply Fixes (if `--fix` requested)
+
+The audit may identify issues at three different scopes. `--fix` only applies the small scope automatically; medium and large always need the user in the loop.
+
+| Scope | What it touches | Behavior |
+|-------|-----------------|----------|
+| **Small** | Whitespace adjustments, heading-level fixes, emphasis (`**` / `*` / inline code), sentence-level rewording, stale link or version updates, typo corrections | Apply in batch after one confirmation of the Major + Minor groups |
+| **Medium** | Splitting one section into two, merging two adjacent sections, adding a missing subsection (`###`) inside an existing section, rewording a heading | Report recommends; user approves each medium change individually before apply |
+| **Large** | Reordering top-level sections, renaming H2 headings (breaks external anchors), creating new H2 sections, removing existing sections, drafting new content longer than one paragraph | Report flags as a recommendation only. Never applied by `--fix`. The user must explicitly request the skill to draft the change for review, then approve before apply |
+
+#### `--fix` flow
+
+1. Present the full report first — including the **Structural Recommendations** table with pros/cons for every Medium and Large item.
+2. For **Small** changes: ask for a single batch confirmation (Major group, then Minor group). Apply one section at a time, smallest blast radius first.
+3. For **Medium** changes: walk through each one with the user. Show pros + cons. Get per-change approval before apply.
+4. For **Large** changes: do NOT apply under `--fix`. Leave them in the report as recommendations with full pros/cons. If the user wants one drafted, they ask explicitly ("draft the new Prerequisites section"), the skill writes a proposal, and the user approves before any write happens.
+5. Re-score affected sections after fixes to confirm improvement.
+
+**The principle:** the audit's job is to see everything that hurts the reader. The skill's authority to *change* what it sees scales with reversibility. Small changes are easy to revert; large structural changes affect external links, search indexing, and reader expectations across the project's ecosystem — those stay under the user's direct control.
+
+## Expected Input
+
+- `(no args)` → audit `README.md` at the repo root
+- `<path>` → audit any user-facing markdown file at that path
+- Append `--fix` to apply fixes after the report
+
+## Relationship to other audit skills
+
+| Skill | Audience | Focus |
+|-------|----------|-------|
+| `auditing-readme` (this) | Public reader on GitHub | Typography + Phrasing — readability |
+| `auditing-artifacts` | The agent executing this project | Format + Purpose — internal correctness |
+| `reviewing-typography` (source skill) | Confluence reader | Proximity + hierarchy on rendered HTML |
+| `reviewing-commands` (source skill) | Command authors | 6-dimension deep audit of one command |
+
+## Next Step
+
+After the report, common follow-ups:
+- Apply Major fixes immediately — these are the ones costing you readers
+- Sweep Minors as a polish pass before a release or external announcement
+- Re-run after edits to confirm scorecard improvement

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Personal Claude Code settings — not shared
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ When adopting ai-qa-workflow across multiple projects for the first time:
 1. **Create `~/.claude/CLAUDE.md`** — Define your identity (roles, project types), universal git workflow rules, information leak prevention rules, and the command hierarchy (what's at home vs project level)
 2. **Install home-level commands** — Copy universal commands from this repo to `~/.claude/commands/`:
    - `commands/utility/` → evolve, session-summary, compare, sync, command-review, review-install, rewrite-text, robot-log-analyzer
-   - `commands/dev-workflow/` → dw-story, dw-plan, dw-implement, dw-create-pr, dw-review-pr, dw-merge
+   - `commands/dev-workflow/` → dw-story, dw-plan, dw-tasks, dw-implement, dw-test-design, dw-create-pr, dw-review-pr, dw-merge
 3. **Audit all projects** — Run `/review-install all` to scan every project for duplicates, misplacements, and drift
 4. **Clean up duplicates** — Run `/review-install --fix` per project to remove commands shadowed by home level
 5. **Update project CLAUDE.md files** — Remove references to deleted commands, update counts and listings
@@ -134,15 +134,34 @@ Updates follow the same flow as installation. The agent re-reads this CLAUDE.md 
 
 ## Architecture
 
+### Three-Tier Route: CLAUDE.md → Skills → Commands
+
+The agent navigates this project in three layers. Each layer has a specific job and a specific size.
+
+1. **CLAUDE.md (this file) — Orientation.** Read first. Provides the project overview, directory map, Skills table (when to invoke what), and Key Workflows (the 7-phase test lifecycle). The agent reads CLAUDE.md to find the right entry point for the user's intent.
+
+2. **Skills (`skills/<name>/SKILL.md`) — Routers.** Loaded on demand when the trigger condition matches. Each skill is a thin step sequence + progress checklist; it orchestrates the workflow and delegates implementation to commands. Skills answer WHAT to do at the workflow level. Typical size: 50-150 lines.
+
+3. **Commands (`commands/<folder>/<cmd>.md`) — Implementation.** Hold the detail: MCP tool names, parameter shapes, HTML formatting rules, API quirks, error handling. Commands answer HOW each step is executed. Size varies by complexity — some are 8 lines, some are 500.
+
+### Why the layering
+
+- **Skills stay lean** because the heavy lifting lives in commands.
+- **Commands can be minimal where the task is LLM-native** (e.g., "summarize this page" needs no instructions beyond the MCP tool name) and rich where it's not (e.g., a TestLink CRUD command with HTML formatting and entity encoding).
+- **CLAUDE.md changes once** when adding a new workflow; skills change per orchestration tweak; commands change per integration detail.
+
+### When to write what
+
+| You're adding... | Touch... |
+|------------------|----------|
+| A new top-level workflow / lifecycle phase | CLAUDE.md (Skills table, Key Workflows) + new skill + supporting commands |
+| A new step in an existing workflow | Existing skill (insert step) + new command (the step's detail) |
+| A new way to call an existing integration | New command in the right subfolder; no skill change needed |
+| A reusable convention (HTML rules, format guides) | Reference command (e.g. `tl-format`) + cross-references from siblings |
+
 ### Command-as-Documentation Pattern
 
-Each command is a markdown file in `commands/` that serves as both documentation and executable instruction for AI agents. Commands include:
-- Purpose and expected input format
-- Step-by-step agent processing instructions
-- HTML formatting rules (for TestLink)
-- API call details and best practices
-
-Commands are installed by copying markdown files to `~/.claude/commands/`. Skills are thin routers that delegate to slash commands — each SKILL.md contains only the step sequence and progress checklist, routing to commands for implementation details.
+Each command markdown file is both documentation and executable instruction. Commands include: purpose, expected input format, step-by-step processing, MCP call details. Skills are installed to `.claude/skills/`; commands are installed to `.claude/commands/` or `~/.claude/commands/` depending on whether they're project-specific or universal (see [Tier Design](#tier-design)).
 
 ### Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,31 +182,15 @@ Commands expect these MCP servers configured in the IDE:
 - **mcp-atlassian** (sooperset/mcp-atlassian) - Jira/Confluence API access
 - **testlink-mcp** (dogkeeper886/testlink-mcp) - TestLink API access
 - **playwright-mcp** (microsoft/playwright-mcp) - Browser automation
-- **wpa-mcp** (dogkeeper886/wpa-mcp) - WPA supplicant control
-- **radius-sql** (dogkeeper886/ldap) - RADIUS database queries
+
+Additional integrations documented in `docs/integrations/` but not currently used by any command: `wpa-mcp` (WPA supplicant control), `radius-sql` (RADIUS database queries).
 
 ## Adding New Commands
 
 1. Create markdown file in appropriate `commands/` subfolder
-2. Follow this template structure:
-   ```markdown
-   # Command Name
-
-   ## Purpose
-   One-sentence description
-
-   ## Agent Instructions:
-   1. Step-by-step processing guidance
-   
-   ## Expected User Input Format:
-   What parameters the user should provide
-   
-   ## Example Usage:
-   Concrete examples with agent processing steps
-   
-   ## API Notes:
-   MCP tool calls and quirks
-   ```
+2. Follow the conventions of sibling commands in the same subfolder. Two reference exemplars:
+   - **Task commands** (multi-step workflows with `gh`/MCP calls): `commands/dev-workflow/dw-implement.md` — `## PURPOSE`, `## WORKFLOW` (ASCII tree), `## EXAMPLE`, `## API Notes`
+   - **Reference commands** (rules/conventions): `commands/utility/rewrite-text.md` — minimal task statement + guidelines table
 3. Tell your AI agent to re-read `CLAUDE.md` and sync the new command
 4. Commit only the source file in `commands/`
 
@@ -232,7 +216,7 @@ Skills are thin routers — each SKILL.md contains the step sequence and progres
 
 ## Key Workflows
 
-The test lifecycle flows through 6 phases:
+The test lifecycle flows through 7 phases:
 1. **Discover** - Gather requirements via `/jr-trace`
 2. **Baseline** - Capture live UI state via `/tw-baseline-trace` (recommended before planning)
 3. **Plan** - Create test strategy via `/tw-plan-init` (routes to feature/enhance/bugfix). Plans follow the ISO/IEC/IEEE 29119-3 layout: `test_plan/sections/` (lean strategy) + `test_plan/test_design/{scenarios/, traceability_matrix.md, risk_register.md}`. The Confluence publish runs `reviewing-typography` as its final gate.

--- a/README.md
+++ b/README.md
@@ -167,14 +167,14 @@ The `/evolve` command analyzes project history and proposes improvements to CLAU
 ## Available Commands
 
 ### [Jira Commands (jr-*)](commands/jira/)
-Trace tickets, fetch linked issues, and convert Jira content to Markdown.
+Trace tickets and fetch linked issues.
 
-`jr-trace` · `jr-trace-fetch` · `jr-trace-structure` · `jr-trace-docs` · `jr-trace-verify` · `jr-issue-summary` · `jr-to-markdown`
+`jr-trace` · `jr-trace-fetch` · `jr-trace-structure` · `jr-trace-docs` · `jr-trace-verify`
 
 ### [Confluence Commands (cf-*)](commands/confluence/)
-Summarize, convert, create, update, and review Confluence pages.
+Create, update, and review Confluence pages.
 
-`cf-page-summary` · `cf-to-markdown` · `cf-create-page` · `cf-update-page` · `cf-review-page` · `cf-format-guide`
+`cf-create-page` · `cf-update-page` · `cf-review-page` · `cf-format-guide`
 
 ### [Test Workflow Commands (tw-*)](commands/test-workflow/)
 Plan test strategies and design test cases, with fan-out routing by ticket type (feature/enhance/bugfix). Includes `tw-baseline-trace` to capture the live UI state via Playwright before scenarios are drafted (anchors the plan in observable reality, prevents over-specified test plans — see `skills/planning-tests/references/scenario-conventions.md`).
@@ -199,7 +199,7 @@ Issue-driven development lifecycle: plan issues, implement on branches, open PRs
 ### [Project Commands (pm-*)](commands/project/)
 Cross-cutting project management: bug reports, scrum tasks, meeting invites, demo materials, and script review.
 
-`pm-init` · `pm-bug-report` · `pm-scrum-task` · `pm-meeting-invite` · `pm-demo-content` · `pm-demo-review` · `pm-demo-ppt` · `pm-demo-email` · `pm-script-review`
+`pm-init` · `pm-bug-report` · `pm-meeting-invite` · `pm-demo-content` · `pm-demo-review` · `pm-demo-ppt` · `pm-demo-email` · `pm-script-review`
 
 ### [Utility Commands](commands/utility/)
 Text rewriting, log analysis, self-improvement, cross-repo sync, installation auditing, and command quality review.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Enable **end-to-end test automation** from a single source of truth. Instead of 
 5. **Automate** test execution with the dual-judge framework
 6. **Report** results back to source systems
 
+## Notable Features
+
+| Feature | Description |
+|---------|-------------|
+| **Agent-Driven Installation** | No installer script — the AI agent reads CLAUDE.md, detects context, and syncs commands |
+| **Two-Tier Architecture** | Home tier (universal) + project tier (specific) eliminates duplication across projects |
+| **Single Source of Truth** | Requirements flow from Jira/Confluence through test design to execution |
+| **MCP Integrations** | Direct access to Atlassian, TestLink, and Playwright via Model Context Protocol |
+| **Detect-and-Route** | Entry commands detect the type of work (new feature / enhancement / bug fix) and hand off to the right specialist command |
+| **Agent Skills** | Thin routers covering complete lifecycle phases with progress checklists |
+| **Dual-Judge Framework** | Test execution checked by both deterministic assertions and an LLM judge — catches the cases each misses |
+| **Self-Improvement** | `/evolve` analyzes project history and proposes actionable improvements |
+
 ## Quick Start
 
 ### Installation
@@ -35,10 +48,15 @@ The agent will:
 
 ### After Installation
 
+**Activate:**
+
 1. Restart your IDE to load new commands
-2. Skills available as slash commands (e.g., `/receiving-tickets`)
-3. All commands also available (e.g., `/jr-trace`)
-4. Configure MCP integrations (see [docs/integrations/](docs/integrations/))
+2. Configure MCP integrations (see [docs/integrations/](docs/integrations/))
+
+**What's now available:**
+
+- Skills as slash commands (e.g., `/receiving-tickets`)
+- Individual commands (e.g., `/jr-trace`)
 
 ### Updating
 
@@ -73,36 +91,27 @@ Commands are organized in two tiers to reduce maintenance across multiple projec
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                         COMPLETE TEST LIFECYCLE                         │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                         │
-│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐              │
-│  │   PHASE 1    │    │   PHASE 2    │    │   PHASE 3    │              │
-│  │   DISCOVER   │───▶│    PLAN      │───▶│   DESIGN     │              │
-│  │              │    │              │    │              │              │
-│  │ Jira/Conflu- │    │ Test Plan    │    │ Test Cases   │              │
-│  │ ence via MCP │    │ Checklist    │    │ Checklist    │              │
-│  └──────────────┘    └──────────────┘    └──────────────┘              │
-│         │                   │                   │                      │
-│         ▼                   ▼                   ▼                      │
-│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐              │
-│  │   PHASE 4    │    │   PHASE 5    │    │   PHASE 6    │              │
-│  │   MANAGE     │───▶│   AUTOMATE   │───▶│   EXECUTE    │              │
-│  │              │    │              │    │              │              │
-│  │ TestLink     │    │ Test         │    │ Run & Report │              │
-│  │ via MCP      │    │ Framework    │    │ Results      │              │
-│  └──────────────┘    └──────────────┘    └──────────────┘              │
-│                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │ DISCOVER │ → │ BASELINE │ → │   PLAN   │ → │  DESIGN  │
+  └──────────┘   └──────────┘   └──────────┘   └──────────┘
+                                                     │
+                                                     ▼
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │ EXECUTE  │ ← │ AUTOMATE │ ← │  MANAGE  │
+  └──────────┘   └──────────┘   └──────────┘
 ```
 
 | Phase | Action | Skill | Key Command |
 |-------|--------|-------|-------------|
 | 1. Discover | Gather requirements | `/receiving-tickets` | `/jr-trace` |
-| 2. Plan | Create test strategy | `/planning-tests` | `/tw-plan-init` |
-| 3. Design | Write test cases | `/designing-cases` | `/tw-case-init` |
-| 4. Manage | Import to TestLink | `/syncing-testlink` | `/tl-sync` |
-| 5. Automate | Create YAML tests | — | [test-framework-template](https://github.com/dogkeeper886/test-framework-template) |
-| 6. Execute | Run & record results | `/executing-tests` | `/tl-execute-case` |
+| 2. Baseline | Capture live UI state (recommended before planning) | — | `/tw-baseline-trace` |
+| 3. Plan | Create test strategy | `/planning-tests` | `/tw-plan-init` |
+| 4. Design | Write test cases | `/designing-cases` | `/tw-case-init` |
+| 5. Manage | Import to TestLink | `/syncing-testlink` | `/tl-sync` |
+| 6. Automate | Create YAML tests | — | [test-framework-template](https://github.com/dogkeeper886/test-framework-template) |
+| 7. Execute | Run & record results | `/executing-tests` | `/tl-execute-case` |
 
 See [docs/workflows/test-lifecycle.md](docs/workflows/test-lifecycle.md) for the complete workflow guide.
 
@@ -126,9 +135,9 @@ Skills are the recommended high-level interface. Each skill is a thin router tha
 
 See [docs/workflows/skills.md](docs/workflows/skills.md) for invocation patterns, trigger phrases, and MCP requirements per skill.
 
-## Issue-Driven Development with `dw-*`
+## Issue-Driven Development
 
-The dev workflow commands provide a structured development lifecycle where every change is driven by a GitHub issue.
+The dev workflow commands (`dw-*`) provide a structured development lifecycle where every change is driven by a GitHub issue.
 
 ```
 /dw-plan → /dw-implement → /dw-create-pr → /dw-review-pr → /dw-merge
@@ -149,7 +158,7 @@ The dev workflow commands provide a structured development lifecycle where every
 
 Branches follow `issue-<N>-<short-slug>` convention (e.g., `issue-27-release-notes`). Issues get status labels and progress comments automatically. The PR's `Fixes #N` auto-closes the issue on merge.
 
-## Self-Improvement with `/evolve`
+## Self-Improvement Loop
 
 The `/evolve` command analyzes project history and proposes improvements to CLAUDE.md, commands, and skills.
 
@@ -194,7 +203,7 @@ Set up milestone/label tracking for QA artifacts and monitor progress through Gi
 ### [Dev Workflow Commands (dw-*)](commands/dev-workflow/)
 Issue-driven development lifecycle: plan issues, implement on branches, open PRs, review, and merge.
 
-`dw-story` · `dw-plan` · `dw-implement` · `dw-create-pr` · `dw-review-pr` · `dw-merge`
+`dw-story` · `dw-plan` · `dw-tasks` · `dw-implement` · `dw-test-design` · `dw-create-pr` · `dw-review-pr` · `dw-merge`
 
 ### [Project Commands (pm-*)](commands/project/)
 Cross-cutting project management: bug reports, scrum tasks, meeting invites, demo materials, and script review.
@@ -206,28 +215,23 @@ Text rewriting, log analysis, self-improvement, cross-repo sync, installation au
 
 `rewrite-text` · `robot-log-analyzer` · `evolve` · `session-summary` · `command-review` · `compare` · `sync` · `review-install`
 
-## Notable Features
-
-| Feature | Description |
-|---------|-------------|
-| **Agent-Driven Installation** | No installer script — the AI agent reads CLAUDE.md, detects context, and syncs commands |
-| **Two-Tier Architecture** | Home tier (universal) + project tier (specific) eliminates duplication across projects |
-| **Single Source of Truth** | Requirements flow from Jira/Confluence through test design to execution |
-| **MCP Integrations** | Direct access to Atlassian, TestLink, and Playwright via Model Context Protocol |
-| **Detect-and-Route** | Entry commands classify context (feature/enhance/bugfix) and route to specialist commands |
-| **Agent Skills** | Thin routers covering complete lifecycle phases with progress checklists |
-| **Dual-Judge Framework** | Test execution with both deterministic and semantic (LLM) verification |
-| **Self-Improvement** | `/evolve` analyzes project history and proposes actionable improvements |
-
 ## Documentation
 
 ### Integrations
 
+**Required** — used by current commands:
+
 - [MCP Atlassian](docs/integrations/mcp-atlassian.md) - Jira and Confluence access
 - [MCP TestLink](docs/integrations/mcp-testlink.md) - Test management
 - [MCP Playwright](docs/integrations/mcp-playwright.md) - Browser automation
+
+**Optional** — documented but not currently called by any command:
+
 - [MCP WPA](docs/integrations/mcp-wpa.md) - WPA supplicant control
 - [MCP RADIUS SQL](docs/integrations/mcp-radius-sql.md) - RADIUS database queries
+
+**Related framework:**
+
 - [Test Framework Template](docs/integrations/test-framework-template.md) - Dual-judge execution
 
 ### Workflows
@@ -279,14 +283,13 @@ ai-qa-workflow/
 │   ├── reviewing-typography/  # Audit just-published Confluence pages
 │   ├── syncing-testlink/      # Import cases to TestLink
 │   └── tracking-changes/      # GitHub artifact tracking
-├── templates/          # Project templates
+├── templates/          # Sample CLAUDE.md for projects adopting this workflow
 ├── docs/
 │   ├── design/         # Design principles and patterns
 │   ├── examples/       # Sample command outputs
 │   ├── integrations/   # MCP integration guides
 │   ├── references/     # Command and skill format specs
 │   └── workflows/      # End-to-end workflows
-├── Makefile            # Legacy installation (deprecated)
 └── README.md
 ```
 

--- a/commands/confluence/cf-format-guide.md
+++ b/commands/confluence/cf-format-guide.md
@@ -33,9 +33,9 @@ Four common patterns DO NOT round-trip cleanly. Each failure mode is silent — 
 | Source pattern | What the converter produces | Fix |
 |---|---|---|
 | **Bold paragraph + immediately-following list with no blank line:**<br/>`**Heading:**`<br/>`- item A`<br/>`- item B` | Whole block collapses to one `<p>` paragraph with the hyphens preserved as plain text. **The list never renders.** | Insert a blank line between the bold paragraph and the first `-`. |
-| **Nested list (2-space-indented sub-bullets):**<br/>`- Parent`<br/>`  - Sub-item 1`<br/>`  - Sub-item 2` | Sub-bullets are **flattened** to the same level as the parent — "Parent" sits next to "Sub-item 1" instead of containing it. | Either restructure as sibling lists separated by a paragraph, or switch the page to `content_format: "storage"` and write `<ul><li><p>Parent</p><ul><li><p>Sub-item 1</p></li></ul></li></ul>` directly (see § 1.3). |
+| **Nested list (2-space-indented sub-bullets):**<br/>`- Parent`<br/>`  - Sub-item 1`<br/>`  - Sub-item 2` | Sub-bullets are **flattened** to the same level as the parent — "Parent" sits next to "Sub-item 1" instead of containing it. | Either restructure as sibling lists separated by a paragraph, or switch the page to `content_format: "storage"` and write `<ul><li><p>Parent</p><ul><li><p>Sub-item 1</p></li></ul></li></ul>` directly (see [§ 1.3 in confluence-format.md](../../docs/references/confluence-format.md#13-nested-lists)). |
 | **Metadata block (multiple bold-prefixed lines, single newlines between):**<br/>`**Focus:** A`<br/>`**Estimated cases:** 3`<br/>`**Test plan reference:** ...` | All lines **merge** into one `<p>` paragraph with bold labels run together as one wall of inline text. | Insert blank lines (each line becomes its own `<p>`), or switch to storage format with `<p>...<br/>...<br/>...</p>` (the cleanest visual result). |
-| **Task list checkboxes (`- [ ]`)** in a paragraph context | Render as **bullet items with literal `[ ]` text**, not as native `<ac:task-list>` macros — even with a blank line before. The native task-list conversion is unreliable across contexts. | Use `content_format: "storage"` with explicit `<ac:task-list>` + `<ac:task>` macros (see § 1.4 below). |
+| **Task list checkboxes (`- [ ]`)** in a paragraph context | Render as **bullet items with literal `[ ]` text**, not as native `<ac:task-list>` macros — even with a blank line before. The native task-list conversion is unreliable across contexts. | Use `content_format: "storage"` with explicit `<ac:task-list>` + `<ac:task>` macros (see [§ 1.4 in confluence-format.md](../../docs/references/confluence-format.md#14-task-lists-native-confluence-checkboxes)). |
 
 **Decision rule (apply before every publish):** scan the source markdown for the four patterns above.
 
@@ -70,515 +70,35 @@ Both `mcp-atlassian:confluence_create_page` and `mcp-atlassian:confluence_update
 
 ## Path B — Direct Confluence REST API call (legacy, manual conversion required)
 
-When NOT going through the MCP tool (direct `POST /wiki/rest/api/content` calls), the older guidance below applies: write Confluence storage format (HTML-based) by hand because the REST API's markdown intake was unreliable for tables and lists.
+When NOT going through the MCP tool (direct `POST /wiki/rest/api/content` calls), write Confluence storage format (HTML-based) by hand because the REST API's markdown intake was unreliable for tables and lists.
 
 This path is retained for completeness but should not be the default. The MCP tool covers all current authoring needs.
 
-### Legacy Key Principle
+**Legacy Key Principle:** Use Confluence `storage` format (HTML-based) instead of `markdown` format when creating pages programmatically through the legacy REST API.
 
-**Use Confluence `storage` format (HTML-based) instead of `markdown` format** when creating pages programmatically through the legacy REST API. Markdown format often fails to convert lists and tables properly, resulting in plain text with markdown syntax instead of proper HTML elements.
+## Storage-Format HTML Reference
 
----
+When writing `content_format: "storage"` (Path A gotchas 2 or 4, Path C, or Path B legacy), the full HTML element reference — lists, tables, code blocks, headers, links, text formatting, special characters, complete examples, common mistakes, and format conversion checklist — lives in:
 
-## 1. Lists
+**[`docs/references/confluence-format.md`](../../docs/references/confluence-format.md)**
 
-### 1.1 Bullet Lists (Unordered Lists)
-
-**Correct Format (Storage/HTML):**
-```html
-<ul>
-  <li><p>First item</p></li>
-  <li><p>Second item</p></li>
-  <li><p>Third item</p></li>
-</ul>
-```
-
-**Incorrect (Markdown converted):**
-```html
-<p> * First item * Second item * Third item</p>
-```
-
-**Example:**
-```html
-<ul>
-  <li><p>First feature requirement with <strong>important detail</strong></p></li>
-  <li><p>Second feature requirement with additional information</p></li>
-</ul>
-```
-
-**Key Points:**
-- Each list item (`<li>`) must contain a paragraph (`<p>`) tag
-- Use `<ul>` for unordered/bullet lists
-- Nested lists: Place nested `<ul>` or `<ol>` inside the parent `<li>` element
-
-### 1.2 Numbered Lists (Ordered Lists)
-
-**Correct Format (Storage/HTML):**
-```html
-<ol start="1">
-  <li><p>First step</p></li>
-  <li><p>Second step</p></li>
-  <li><p>Third step</p></li>
-</ol>
-```
-
-**Incorrect (Markdown converted):**
-```html
-<p> 1. First step 2. Second step 3. Third step</p>
-```
-
-**Example:**
-```html
-<ol start="1">
-  <li><p><strong>Precondition:</strong> Set up test environment</p></li>
-  <li><p>Navigate to the feature page</p></li>
-  <li><p><strong>Test Execution:</strong> Perform the test steps</p></li>
-</ol>
-```
-
-**Key Points:**
-- Use `<ol>` for ordered/numbered lists
-- Include `start="1"` attribute (or appropriate start number)
-- Each list item (`<li>`) must contain a paragraph (`<p>`) tag
-
-### 1.3 Nested Lists
-
-**Correct Format:**
-```html
-<ul>
-  <li><p>Parent item</p>
-    <ul>
-      <li><p>Nested item 1</p></li>
-      <li><p>Nested item 2</p></li>
-    </ul>
-  </li>
-  <li><p>Another parent item</p></li>
-</ul>
-```
-
-**Key Points:**
-- Nested list goes inside the parent `<li>` element, after the `<p>` tag
-- Can mix `<ul>` and `<ol>` for nested lists
-- **Markdown cannot express nesting reliably** — the MCP converter flattens 2-space-indented sub-bullets (see Path A gotchas above). For any page with nested lists, use `content_format: "storage"` with the structure above.
-
-### 1.4 Task Lists (Native Confluence Checkboxes)
-
-When the page needs **interactive checkboxes** (Entry/Exit criteria, sign-off checklists, definition-of-done lists), use Confluence's native task-list macro. The markdown `- [ ]` shortcut converts unreliably (see Path A gotchas) — write storage format directly.
-
-**Correct Format (Storage):**
-```html
-<ac:task-list>
-  <ac:task>
-    <ac:task-id>1</ac:task-id>
-    <ac:task-status>incomplete</ac:task-status>
-    <ac:task-body>First criterion to verify</ac:task-body>
-  </ac:task>
-  <ac:task>
-    <ac:task-id>2</ac:task-id>
-    <ac:task-status>incomplete</ac:task-status>
-    <ac:task-body>Second criterion — inline <code>code</code> and <strong>bold</strong> are fine inside <code>ac:task-body</code></ac:task-body>
-  </ac:task>
-</ac:task-list>
-```
-
-**Key Points:**
-- Each task needs a unique `<ac:task-id>` (any integer; just keep them unique within the page).
-- `<ac:task-status>` is `incomplete` or `complete`.
-- `<ac:task-body>` accepts inline HTML (`<code>`, `<strong>`, `<a>`, etc.) but not block-level elements.
-- The rendered output is a checkbox the reader can tick directly in Confluence — much better than a bullet list with `[ ]` placeholder text.
-- Reference example: a Test Strategy page § 4.5 with 16 task-list items split across Entry Criteria (9) and Exit Criteria (7).
+Section index in that file:
+- § 1 Lists (bullet, numbered, nested, task lists)
+- § 2 Tables (basic, bullets-in-cells, multi-column)
+- § 3 Code Blocks (inline, fenced with language)
+- § 4 Headers
+- § 5 Links (external, Confluence page links)
+- § 6 Text Formatting (bold, italic, paragraphs)
+- § 7 Horizontal Rules
+- § 8 Special Characters (bullet char, HTML entities)
+- § 9 Complete Example Structure
+- § 10 Common Mistakes to Avoid
+- § 11 Best Practices
+- § 12 Format Conversion Checklist
 
 ---
 
-## 2. Tables
-
-### 2.1 Basic Table Structure
-
-**Correct Format (Storage/HTML):**
-```html
-<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
-  <tbody>
-    <tr>
-      <th><p>Header 1</p></th>
-      <th><p>Header 2</p></th>
-    </tr>
-    <tr>
-      <td><p>Cell 1</p></td>
-      <td><p>Cell 2</p></td>
-    </tr>
-  </tbody>
-</table>
-```
-
-**Incorrect (Markdown converted):**
-```html
-<p>|| Header 1 || Header 2 || | Cell 1 | Cell 2 |</p>
-```
-
-**Example:**
-```html
-<table ac:local-id="unique-id-here" data-layout="center" data-table-width="1800">
-  <tbody>
-    <tr>
-      <th><p>Category</p></th>
-      <th><p>Description</p></th>
-    </tr>
-    <tr>
-      <td><p>Feature A</p></td>
-      <td><p>Description of feature A</p></td>
-    </tr>
-  </tbody>
-</table>
-```
-
-**Key Points:**
-- Use `<table>` with Confluence attributes:
-  - `ac:local-id`: Unique identifier (can be generated UUID)
-  - `data-layout="center"`: Center alignment
-  - `data-table-width="1800"`: Table width in pixels
-- Table structure: `<table>` → `<tbody>` → `<tr>` → `<th>` or `<td>`
-- Each cell content should be wrapped in `<p>` tags
-- Use `<th>` for header cells, `<td>` for data cells
-
-### 2.2 Tables with Bullet Points in Cells
-
-**Correct Format:**
-```html
-<table>
-  <tbody>
-    <tr>
-      <td><p>• First bullet point<br/>• Second bullet point<br/>• Third bullet point</p></td>
-    </tr>
-  </tbody>
-</table>
-```
-
-**Key Points:**
-- Use bullet character `•` (not asterisk `*`)
-- Use `<br/>` for line breaks between bullet points
-- All bullet points in one `<p>` tag
-
-**Example:**
-```html
-<td><p>• First feature requirement<br/>• Second feature requirement<br/>• Third feature requirement</p></td>
-```
-
-### 2.3 Tables with Multiple Columns
-
-**Correct Format:**
-```html
-<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
-  <colgroup>
-    <col style="width: 124.0px;"/>
-    <col style="width: 155.0px;"/>
-    <col style="width: 1350.0px;"/>
-  </colgroup>
-  <tbody>
-    <tr>
-      <th><p>Column 1</p></th>
-      <th><p>Column 2</p></th>
-      <th><p>Column 3</p></th>
-    </tr>
-    <tr>
-      <td><p>Data 1</p></td>
-      <td><p>Data 2</p></td>
-      <td><p>Data 3</p></td>
-    </tr>
-  </tbody>
-</table>
-```
-
-**Key Points:**
-- Use `<colgroup>` with `<col>` elements to define column widths
-- Column widths can be specified in pixels (e.g., `width: 124.0px`)
-
----
-
-## 3. Code Blocks
-
-### 3.1 Inline Code
-
-**Correct Format:**
-```html
-<code>feature-flag-name</code>
-```
-
-### 3.2 Code Blocks
-
-**Correct Format (Using Confluence Code Macro):**
-```html
-<ac:structured-macro ac:name="code" ac:schema-version="1">
-  <ac:parameter ac:name="language">json</ac:parameter>
-  <ac:plain-text-body><![CDATA[{
-  "name": "example-config",
-  "type": "EXAMPLE"
-}]]></ac:plain-text-body>
-</ac:structured-macro>
-```
-
-**Or Simple Code Block:**
-```html
-<ac:structured-macro ac:name="code" ac:schema-version="1">
-  <ac:plain-text-body><![CDATA[POST /api/v1.1/example-endpoint]]></ac:plain-text-body>
-</ac:structured-macro>
-```
-
-**Key Points:**
-- Use `<ac:structured-macro>` with `ac:name="code"`
-- Wrap code content in `<![CDATA[...]]>` to preserve formatting
-- Optional: Add `ac:parameter` with `ac:name="language"` for syntax highlighting
-
----
-
-## 4. Headers
-
-### 4.1 Header Levels
-
-**Correct Format:**
-```html
-<h1>Main Title</h1>
-<h2>Section Title</h2>
-<h3>Subsection Title</h3>
-<h4>Sub-subsection Title</h4>
-<h5>Operation Title</h5>
-```
-
-**Key Points:**
-- Use appropriate header levels for document hierarchy
-- H1 for main title, H2 for major sections, H3 for subsections, etc.
-
----
-
-## 5. Links
-
-### 5.1 External Links
-
-**Correct Format:**
-```html
-<a href="https://example.atlassian.net/browse/PROJ-123">PROJ-123</a>
-```
-
-### 5.2 Confluence Page Links
-
-**Correct Format:**
-```html
-<ac:link>
-  <ri:page ri:content-title="Page Title" ri:space-key="SPACE"></ri:page>
-  <ac:link-body>Page Title</ac:link-body>
-</ac:link>
-```
-
-**Or Simple Link Format:**
-```html
-<a href="https://example.atlassian.net/wiki/spaces/SPACE/pages/123456789">Confluence Page Title</a>
-```
-
-**Key Points:**
-- Replace `SPACE` with your Confluence space key
-- Replace `123456789` with the actual page ID
-- Replace `example.atlassian.net` with your Confluence instance URL
-
----
-
-## 6. Text Formatting
-
-### 6.1 Bold Text
-
-**Correct Format:**
-```html
-<strong>Bold Text</strong>
-```
-
-### 6.2 Italic Text
-
-**Correct Format:**
-```html
-<em>Italic Text</em>
-```
-
-### 6.3 Paragraphs
-
-**Correct Format:**
-```html
-<p>Paragraph text here.</p>
-```
-
-**Key Points:**
-- Always wrap text content in `<p>` tags
-- Use `<br/>` for line breaks within paragraphs
-
----
-
-## 7. Horizontal Rules
-
-**Correct Format:**
-```html
-<hr/>
-```
-
----
-
-## 8. Special Characters
-
-### 8.1 Bullet Character in Tables
-
-**Use:** `•` (bullet character, Unicode U+2022)
-
-**Not:** `*` (asterisk)
-
-### 8.2 HTML Entities
-
-- Less than: `&lt;` or `<`
-- Greater than: `&gt;` or `>`
-- Ampersand: `&amp;` or `&`
-- Quotes: `&quot;` or `"`
-
----
-
-## 9. Complete Example Structure
-
-### 9.1 Section with Lists and Tables
-
-```html
-<h2>1. Project &amp; Business Context</h2>
-<h3>1.1 Product Overview</h3>
-<p><strong>Product:</strong> Product Name<br/> <strong>Feature:</strong> Feature Name<br/> <strong>Release Version:</strong> Version Number</p>
-
-<h3>1.2 Business Value</h3>
-<p>Description text here.</p>
-<p><strong>User Benefits:</strong></p>
-<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
-  <tbody>
-    <tr>
-      <th><p>Benefit</p></th>
-      <th><p>Description</p></th>
-    </tr>
-    <tr>
-      <td><p>Benefit Name</p></td>
-      <td><p>Description of the benefit</p></td>
-    </tr>
-  </tbody>
-</table>
-
-<p><strong>Business Impact:</strong></p>
-<ul>
-  <li><p>Addresses customer feature request</p></li>
-  <li><p>Prioritized feature for upcoming release</p></li>
-</ul>
-```
-
-### 9.2 Section with Numbered List
-
-```html
-<h4>Workflow Steps</h4>
-<ol start="1">
-  <li><p>First step with configuration (e.g., <code>example.com</code>, port 8080)</p></li>
-  <li><p>Second step in the workflow</p></li>
-  <li><p>Third step to complete the process</p></li>
-</ol>
-```
-
----
-
-## 10. Common Mistakes to Avoid
-
-### ❌ Mistake 1: Using Markdown Format
-**Problem:** Markdown format doesn't convert lists and tables properly
-```javascript
-// DON'T DO THIS
-content_format: "markdown"
-```
-
-**Solution:** Use storage format
-```javascript
-// DO THIS
-content_format: "storage"
-```
-
-### ❌ Mistake 2: Lists Without Paragraph Tags
-**Problem:**
-```html
-<ul>
-  <li>Item without paragraph</li>
-</ul>
-```
-
-**Solution:**
-```html
-<ul>
-  <li><p>Item with paragraph</p></li>
-</ul>
-```
-
-### ❌ Mistake 3: Tables as Plain Text
-**Problem:**
-```html
-<p>|| Header || | Cell |</p>
-```
-
-**Solution:**
-```html
-<table>
-  <tbody>
-    <tr>
-      <th><p>Header</p></th>
-    </tr>
-    <tr>
-      <td><p>Cell</p></td>
-    </tr>
-  </tbody>
-</table>
-```
-
-### ❌ Mistake 4: Numbered Lists as Plain Text
-**Problem:**
-```html
-<p>1. First step 2. Second step</p>
-```
-
-**Solution:**
-```html
-<ol start="1">
-  <li><p>First step</p></li>
-  <li><p>Second step</p></li>
-</ol>
-```
-
----
-
-## 11. Best Practices
-
-1. **Always use `storage` format** when creating pages programmatically
-2. **Wrap all text content in `<p>` tags** - even inside list items and table cells
-3. **Use proper HTML structure** - `<ul>`, `<ol>`, `<table>`, etc.
-4. **Include Confluence attributes** for tables (`ac:local-id`, `data-layout`, `data-table-width`)
-5. **Use bullet character `•`** (not asterisk `*`) in table cells
-6. **Use `<br/>` for line breaks** within paragraphs or table cells
-7. **Test the page** after creation to verify formatting
-8. **Reference existing well-formatted pages** in your Confluence instance as examples
-
----
-
-## 12. Format Conversion Checklist
-
-When converting markdown to Confluence storage format:
-
-- [ ] Convert `*` bullet lists to `<ul><li><p>...</p></li></ul>`
-- [ ] Convert numbered lists to `<ol start="1"><li><p>...</p></li></ol>`
-- [ ] Convert `||` tables to proper `<table>` HTML
-- [ ] Wrap all text in `<p>` tags
-- [ ] Convert inline code `` `code` `` to `<code>code</code>`
-- [ ] Convert code blocks to `<ac:structured-macro ac:name="code">`
-- [ ] Convert markdown links `[text](url)` to `<a href="url">text</a>`
-- [ ] Convert `**bold**` to `<strong>bold</strong>`
-- [ ] Convert `*italic*` to `<em>italic</em>`
-- [ ] Add Confluence table attributes (`ac:local-id`, `data-layout`, `data-table-width`)
-- [ ] Use `•` character (not `*`) for bullets in table cells
-- [ ] Use `<br/>` for line breaks in table cells
-
----
-
-## 13. Multi-Page Sync Workflow
+## Multi-Page Sync Workflow
 
 When syncing multiple related pages to Confluence:
 
@@ -597,7 +117,7 @@ When syncing multiple related pages to Confluence:
 
 ---
 
-## 14. Content Completeness Checklist
+## Content Completeness Checklist
 
 When reviewing synced pages, verify:
 
@@ -639,14 +159,12 @@ When reviewing synced pages, verify:
 
 ---
 
-## 15. Reference
+## Reference
 
 - **Confluence Storage Format Documentation:** [Confluence Storage Format](https://developer.atlassian.com/cloud/confluence/apis-for-confluence-content/)
 - **Confluence REST API:** [Confluence REST API Documentation](https://developer.atlassian.com/cloud/confluence/rest/)
-- **Created:** 2025-11-06
-- **Based on:** Analysis of Confluence page formatting patterns and common conversion issues
+- **HTML reference (sections 1-12):** [`docs/references/confluence-format.md`](../../docs/references/confluence-format.md)
 
 ---
 
 **Note:** This document should be updated as new formatting patterns are discovered or Confluence formatting requirements change.
-

--- a/commands/confluence/cf-page-summary.md
+++ b/commands/confluence/cf-page-summary.md
@@ -1,7 +1,0 @@
-# Confluence Page Summary Generator
-
-```
-Generate AI-powered summary of Confluence page for customer communication and reporting, including comments:
-
-Confluence Page ID: {{input}}
-```

--- a/commands/confluence/cf-review-page.md
+++ b/commands/confluence/cf-review-page.md
@@ -142,6 +142,6 @@ mcp__mcp-atlassian__confluence_get_page
 - convert_to_markdown: false (important - see raw storage format)
 
 ## Related Commands
-- /confluence-format-guidelines - Full formatting reference
-- /update-confluence-page - Update page with fixes
+- /cf-format-guide - Full formatting reference
+- /cf-update-page - Update page with fixes
 ```

--- a/commands/confluence/cf-to-markdown.md
+++ b/commands/confluence/cf-to-markdown.md
@@ -1,7 +1,0 @@
-# Confluence to Markdown Converter
-
-```
-Convert Confluence page to Markdown format for documentation and sharing, including comments:
-
-Confluence Page ID: {{input}}
-```

--- a/commands/confluence/cf-update-page.md
+++ b/commands/confluence/cf-update-page.md
@@ -12,8 +12,8 @@ Steps:
 4. Add version comment if provided
 
 ## Example Usage:
-/update-confluence-page 987654321 @test_plan/README.md
-/update-confluence-page 987654321 "Updated content here"
+/cf-update-page 987654321 @test_plan/README.md
+/cf-update-page 987654321 "Updated content here"
 
 ## Agent Processing:
 1. Call confluence_get_page with page_id to get current title

--- a/commands/jira/jr-issue-summary.md
+++ b/commands/jira/jr-issue-summary.md
@@ -1,7 +1,0 @@
-# Jira Issue Summary Generator
-
-```
-Generate AI-powered summary of Jira issue for customer communication and reporting, including comments:
-
-Jira Issue Key: {{input}}
-```

--- a/commands/jira/jr-to-markdown.md
+++ b/commands/jira/jr-to-markdown.md
@@ -1,7 +1,0 @@
-# Jira to Markdown Converter
-
-```
-Convert Jira ticket to Markdown format for documentation and sharing, including comments:
-
-Jira Issue Key: {{input}}
-```

--- a/commands/jira/jr-trace-verify.md
+++ b/commands/jira/jr-trace-verify.md
@@ -209,5 +209,5 @@ Output summary:
 | README | ✅/❌ | Generated with synthesis |
 | Relationship diagram | ✅/❌ | Generated |
 
-Suggested next step: `/planning-tests`
+Suggested next step: `/tw-plan-init`
 ```

--- a/commands/project/pm-scrum-task.md
+++ b/commands/project/pm-scrum-task.md
@@ -1,7 +1,0 @@
-# QualityQuest Scrum Task Generator
-
-```
-Generate detailed Scrum task content for Software Quality Assurance Engineers based on task description:
-
-{{input}}
-```

--- a/commands/test-workflow/tw-plan-feature.md
+++ b/commands/test-workflow/tw-plan-feature.md
@@ -100,10 +100,7 @@ IF neither mockups nor live environment available:
   → Flag: "Visual baseline not verified — review with UX team before test case design."
 ```
 
-**Why this matters (industry consensus):**
-- ISTQB: Test analysis must examine the test basis including wireframes — early testing catches defects cheapest
-- ISO/IEC 29119-3: Expected results must allow "objective pass/fail" — text descriptions alone are insufficient for UI features
-- Microsoft: "Do not write detailed test cases until the UI has been verified against the design"
+**Why this matters:** Test analysis must examine wireframes early (ISTQB); expected results must allow objective pass/fail, which text alone cannot provide for UI features (ISO/IEC 29119-3).
 
 ### Step 3: Define Scope
 Clarify what will and won't be tested:
@@ -296,15 +293,7 @@ When sources disagree:
 
 #### Persona/Role Check
 
-```
-IF feature has multiple user roles (e.g., admin vs operator):
-  -> Each role may have different available states and actions
-  -> Consider role-specific journeys as separate scenarios
-  -> At minimum, note which role each scenario applies to
-
-IF single-role:
-  -> Note the assumed role in test plan preconditions
-```
+If the feature has multiple user roles (e.g., admin vs operator), consider role-specific journeys as separate scenarios. At minimum, note which role each scenario applies to. For single-role features, note the assumed role in test plan preconditions.
 
 #### Anti-Patterns Checklist
 
@@ -322,30 +311,12 @@ Before finalizing scenarios, verify NONE of these apply:
 ## DECISION TREES: HANDLING MISSING INFORMATION
 
 ### No Confluence HLD Found
-```
-IF no HLD in confluence/ folder:
-  1. Check Main Ticket description for technical details
-  2. Check UX ticket for feature definition
-  3. Check README.md for feature summary
-  4. Ask user: "I don't see an HLD document. Can you provide:
-     - Confluence HLD link, OR
-     - Feature definition and acceptance criteria?"
-  5. If user provides link: Use WebFetch to retrieve
-  6. If user says "proceed without it":
-     - Use ticket descriptions as primary source
-     - Note in test plan: "HLD not available - based on ticket descriptions"
-  7. Continue with available information
-```
+
+Check the Main Ticket description, UX ticket, and README.md for feature definition. If still missing, ask the user for a Confluence HLD link or the feature definition + acceptance criteria. If the user says "proceed without it," use ticket descriptions as primary source and note in the test plan: "HLD not available — based on ticket descriptions."
 
 ### Unclear Feature Scope
-```
-IF feature scope is ambiguous:
-  1. Check HLD "In Scope" / "Out of Scope" sections
-  2. Check acceptance criteria in Main Ticket
-  3. Ask user specific clarifying questions
-  4. Document assumptions clearly with "ASSUMPTION:" prefix
-  5. Continue with documented assumptions
-```
+
+Check HLD "In Scope" / "Out of Scope" sections and acceptance criteria. Ask the user clarifying questions when scope is ambiguous. Document assumptions with "ASSUMPTION:" prefix and continue.
 
 ---
 
@@ -360,14 +331,7 @@ IF feature scope is ambiguous:
 
 ## BEST PRACTICE SECTIONS
 
-After finalizing test scenarios (Step 5), produce the following companion
-artifacts. These align with what `/tw-plan-review` checks — producing them
-during creation prevents systematic review findings.
-
-The legacy "Coverage Matrix" section is **dropped** — it's a derivative of
-the traceability matrix and adds no information beyond it. Generate one
-on-demand from `traceability_matrix.md` only if a reviewer specifically
-asks. See `skills/planning-tests/references/file-layout.md`.
+After finalizing test scenarios (Step 5), produce the following companion artifacts. These align with what `/tw-plan-review` checks — producing them during creation prevents systematic review findings. The legacy "Coverage Matrix" section is **dropped** as a derivative of the traceability matrix; generate on-demand only if a reviewer asks. See `skills/planning-tests/references/file-layout.md`.
 
 ### Step 6: Hybrid Depth Strategy
 
@@ -396,50 +360,11 @@ inlined in the strategy file.
    but QA observed in the live build
 ```
 
-`test_design/traceability_matrix.md` template:
-
-```markdown
-# Requirements Traceability Matrix — [PROJECT_ID]
-
-Maps each requirement to the scenario(s) that cover it. Source documents:
-[list source HLDs, FRs, review transcripts].
-
-## Coverage
-
-| Requirement | Source | Covered By |
-|-------------|--------|------------|
-| [Req 1] | HLD § X.X | [TS-01](scenarios/TS-01_<Slug>.md), [TS-02](scenarios/TS-02_<Slug>.md) |
-| [Req 2] | Jira AC #3 | [TS-03](scenarios/TS-03_<Slug>.md) |
-
-## Coverage Gaps
-
-- **[Gap description]** — the HLD does not specify [X]. Tested as observed
-  (TS-XX); the actual behavior will be captured live for the test plan review.
-```
-
-Cross-link from scenario → matrix uses `../traceability_matrix.md` if you
-want to add reverse references; matrix → scenario uses
-`scenarios/TS-XX_<Slug>.md` (relative within `test_design/`).
+See [`skills/planning-tests/references/file-templates.md § test_design/traceability_matrix.md`](../../skills/planning-tests/references/file-templates.md) for the template and cross-link conventions.
 
 ### Step 8: Entry/Exit Criteria
 
-Add to `04_Test_Strategy.md` § 4.6:
-
-```markdown
-### 4.6 Entry/Exit Criteria
-
-**Entry Criteria (when can testing start?):**
-- [ ] Build deployed to test environment
-- [ ] Test data provisioned
-- [ ] Dependencies available (list specific dependencies)
-- [ ] Feature flag enabled (if applicable)
-
-**Exit Criteria (when is testing done?):**
-- [ ] 100% P0 test cases pass
-- [ ] ≥90% P1 test cases pass
-- [ ] All P0/P1 defects resolved or deferred with approval
-- [ ] Sign-off from QA lead
-```
+Add an Entry/Exit Criteria block to `04_Test_Strategy.md` § 4.6. The template is embedded in the section-04 template — see [`skills/planning-tests/references/file-templates.md § 04_Test_Strategy.md`](../../skills/planning-tests/references/file-templates.md).
 
 ### Step 9: Risk Assessment
 
@@ -452,23 +377,7 @@ For each scenario, evaluate risk. Output as a **standalone artifact** at
 | **Medium** | Modified existing flow, partial rollback, affects subset of users |
 | **Low** | Well-understood path, easy rollback, internal-only impact |
 
-`test_design/risk_register.md` template:
-
-```markdown
-# Risk Register — [PROJECT_ID]
-
-Per-scenario risk assessment. Risk level reflects the joint judgment of
-likelihood × impact; mitigation describes the action QA takes during
-execution.
-
-| Scenario | Risk Level | Likelihood | Impact | Mitigation |
-|----------|-----------|------------|--------|------------|
-| [TS-01](scenarios/TS-01_<Slug>.md) | Medium | Moderate | User-facing | Deep testing |
-| [TS-02](scenarios/TS-02_<Slug>.md) | Low | Low | Internal | Standard coverage |
-```
-
-Cross-link to scenarios uses `scenarios/TS-XX_<Slug>.md` (relative within
-`test_design/`).
+See [`skills/planning-tests/references/file-templates.md § test_design/risk_register.md`](../../skills/planning-tests/references/file-templates.md) for the template and cross-link conventions.
 
 ### Step 10: Diagrams (5+ Scenarios)
 
@@ -543,214 +452,21 @@ test_plan/
 
 See `skills/planning-tests/references/file-layout.md` for the rationale and migration policy (new projects use this layout; completed projects keep their original).
 
-### test_plan/README.md
+### File Templates
 
-```markdown
-# Test Plan: [Feature Name] ([Epic ID])
+See [`skills/planning-tests/references/file-templates.md`](../../skills/planning-tests/references/file-templates.md) for the markdown template of each file shown above:
 
-**Test Plan Type:** New Feature Validation
-**Test Plan Version:** 1.0
-**Created:** [Date]
-**Last Updated:** [Date]
-**QA Engineer:** [Name]
-**Epic:** [Link]
-**Feature Request:** [Link]
-**Target Release:** [Date]
-**Feature Flag:** `[flag-name]` (if applicable)
-
----
-
-## Test Plan Sections
-
-1. [Project & Business Context](sections/01_Project_Business_Context.md)
-2. [Feature Definition](sections/02_Feature_Definition.md)
-3. [Scope & Boundaries](sections/03_Scope_Boundaries.md)
-4. [Test Strategy](sections/04_Test_Strategy.md)
-5. [References & Resources](sections/05_References_Resources.md)
-6. [Revision History](sections/06_Revision_History.md)
-
----
-
-## Quick Reference
-
-- **Total Test Scenarios:** [N]
-- **Estimated Test Cases:** [N]
-```
-
-### test_plan/sections/01_Project_Business_Context.md
-
-```markdown
-## 1. Project & Business Context
-### 1.1 Product Overview
-### 1.2 Business Value
-### 1.3 Stakeholders
-```
-
-### test_plan/sections/02_Feature_Definition.md
-
-```markdown
-## 2. Feature Definition
-### 2.1 Core Functionality
-### 2.2 Feature Control
-### 2.3 Non-Functional Requirements
-```
-
-### test_plan/sections/03_Scope_Boundaries.md
-
-```markdown
-## 3. Scope & Boundaries
-### 3.1 In-Scope Testing
-### 3.2 Out of Scope
-```
-
-### test_plan/sections/04_Test_Strategy.md (lean)
-
-```markdown
-## 4. Test Strategy
-
-### 4.1 Test Levels
-| Level | Approach |
-|-------|----------|
-| Functional | ... |
-| Integration | ... |
-| Regression | ... |
-
-### 4.2 Test Types
-| Type | Coverage |
-|------|----------|
-| GUI Testing | ... |
-| API Testing | ... |
-| End-to-End | ... |
-
-### 4.3 Test Approach
-- **Verification Perspective:** Hybrid (Web GUI + API + ...)
-- **Test Environment:** [environment requirement; specific tenant in `config/`]
-- **Feature Flag:** `<flag-name>` (if applicable)
-- **Visual Baseline:** [path to wireframes / live captures]
-
-### 4.4 Test Data Setup
-| Item | Value |
-|------|-------|
-| Tenant | [capability requirement; specifics in `config/`] |
-| Networks | ... |
-| ... | ... |
-
-### 4.5 Hybrid Depth Strategy
-
-**Deep (representative case):** TS-XX — [reason it's the deep test]
-
-**Wide (variant scenarios):** TS-YY — [what makes them variants]
-
-### 4.6 Entry/Exit Criteria
-
-**Entry Criteria:**
-- [ ] [Prerequisites]
-
-**Exit Criteria:**
-- [ ] 100% P0 pass, ≥90% P1 pass
-- [ ] All P0/P1 defects resolved or deferred
-
-### 4.7 Companion Artifacts
-
-Per ISO/IEC/IEEE 29119-3, the following live as separate artifacts in `test_design/`:
-
-| Artifact | Location | Contents |
-|---|---|---|
-| Scenario specifications | [`test_design/scenarios/`](../test_design/scenarios/) | One file per TS-XX with focus, est. cases, activities |
-| Requirements Traceability Matrix | [`test_design/traceability_matrix.md`](../test_design/traceability_matrix.md) | Requirement → scenario mapping; coverage gaps |
-| Risk Register | [`test_design/risk_register.md`](../test_design/risk_register.md) | Per-scenario risk level, likelihood/impact, mitigation |
-
-**Total Test Coverage:** [N] Test Scenarios — [N] estimated test cases (see scenario index).
-```
-
-### test_design/scenarios/README.md
-
-```markdown
-# Scenario Specifications — [PROJECT_ID]
-
-Per ISO/IEC/IEEE 29119-3, scenarios live separate from the test plan. The plan in `test_plan/sections/04_Test_Strategy.md` describes the strategy, scope, and gates; this directory holds the detailed scenarios.
-
-[One-paragraph note about journey order or organizing principle.]
-
-## Admin Flow
-
-\`\`\`mermaid
-flowchart LR
-    A[step] --> B[step]
-\`\`\`
-
-## End-User Flow
-
-\`\`\`mermaid
-flowchart LR
-    A[step] --> B[step]
-\`\`\`
-
-## Scenario Index
-
-| ID | Scenario | Focus | Est. Cases |
-|---|---|---|---|
-| [TS-01](TS-01_<Slug>.md) | [Name] | [GUI / API / E2E] | [N] |
-| [TS-02](TS-02_<Slug>.md) | [Name] | [Focus] | [N] |
-
-**Total:** [N] estimated test cases.
-```
-
-### test_design/scenarios/TS-XX_<Slug>.md
-
-Each scenario file follows the uniform metadata header, an optional `## Scenario Preconditions` block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in the test cases, not the scenarios. See `skills/planning-tests/references/scenario-conventions.md` for the full template.
-
-```markdown
-# TS-XX: <name>
-
-**Focus:** <GUI / API / E2E / Config / hybrid>
-
-**Estimated test cases:** N
-
-**Test plan reference:** [`test_plan/sections/04_Test_Strategy.md`](../../sections/04_Test_Strategy.md)
-
----
-
-<intro paragraph — what this scenario owns, what it doesn't, key cross-references. Split into 2-3 short paragraphs at conceptual seams when it crosses 3+ ideas — see `skills/reviewing-typography/references/typography-principles.md` anti-pattern A2.>
-
-## Scenario Preconditions
-
-- <setup that applies to every case>
-
-## Test Cases
-
-### Case 1: <Short imperative title>
-
-- **Objective:** <one sentence — what the case proves>
-- **Checkpoints:**
-  - <Observable 1>
-  - <Observable 2>
-
-### Case 2: <Short imperative title>
-
-- **Objective:** ...
-- **Preconditions:** <case-specific, optional>
-- **Checkpoints:**
-  - ...
-- **Notes:** <HLD-silent flags, TKT cross-refs, sequencing hints — optional>
-```
-
-### test_plan/sections/05_References_Resources.md
-
-```markdown
-## 5. References & Resources
-### 5.1 Design & Documentation
-```
-
-### test_plan/sections/06_Revision_History.md
-
-```markdown
-## 6. Document Revision History
-
-| Version | Date | Author | Changes |
-|---------|------|--------|---------|
-| 1.0 | YYYY-MM-DD | [Name] | Initial test plan |
-```
+- `test_plan/README.md` — index with metadata + linked TOC
+- `test_plan/sections/01_Project_Business_Context.md` — § 1.1-1.3
+- `test_plan/sections/02_Feature_Definition.md` — § 2.1-2.3
+- `test_plan/sections/03_Scope_Boundaries.md` — § 3.1-3.2
+- `test_plan/sections/04_Test_Strategy.md` — § 4.1-4.7 (lean strategy, entry/exit, companion-artifacts pointer)
+- `test_plan/sections/05_References_Resources.md` — § 5
+- `test_plan/sections/06_Revision_History.md` — § 6
+- `test_design/scenarios/README.md` — scenario index + Mermaid flow diagrams
+- `test_design/scenarios/TS-XX_<Slug>.md` — one file per scenario (see also `scenario-conventions.md`)
+- `test_design/traceability_matrix.md` — requirements → scenarios mapping
+- `test_design/risk_register.md` — per-scenario risk level
 
 ---
 

--- a/commands/testlink/tl-sync.md
+++ b/commands/testlink/tl-sync.md
@@ -123,30 +123,9 @@ Provide structured summary:
 - Author login should be your TestLink username for new test cases
 - Project ID should match your TestLink project (use list_projects to find it)
 
-## TestLink Format Guidelines
+## TestLink Format
 
-### Preconditions:
-```html
-<ul>
-	<li>First precondition item</li>
-	<li>Second precondition item</li>
-</ul>
-```
-
-### Step Actions:
-```html
-<p>Main action with <strong>Button Name</strong> and <code>code values</code></p>
-```
-
-### Expected Results:
-```html
-<p>Expected result description</p>
-```
-
-### Summary:
-```html
-<p>Validate that feature <strong>performs action</strong> successfully.</p>
-```
+See `/tl-format` for HTML formatting rules (preconditions, step actions, expected results, summaries, and entity encoding).
 
 ## Error Handling
 

--- a/commands/utility/compare.md
+++ b/commands/utility/compare.md
@@ -8,8 +8,8 @@ Arguments: {{input}}
   - <remote-repo-path> --issue        Also create GitHub issues in the remote repo for backport items
 
 Examples:
-  /compare /home/jack/src/ollama37
-  /compare /home/jack/src/test-framework-template --issue
+  /compare /home/user/src/ollama37
+  /compare /home/user/src/test-framework-template --issue
 
 ## Important Rules
 

--- a/commands/utility/robot-log-analyzer.md
+++ b/commands/utility/robot-log-analyzer.md
@@ -19,11 +19,11 @@ Process:
 11. Present results with clear headings and bullet points
 
 Key Tools:
-- TodoWrite: Track progress through complex multi-step analysis
+- TaskCreate / TaskUpdate: Track progress through complex multi-step analysis
 - Grep: Search for specific patterns in large files
 - Read: Examine file contents with offset/limit for large files
-- Task: Delegate complex analysis to specialized agents when needed
-- LS: Verify directory structure and file availability
+- Agent: Delegate complex analysis to specialized agents when needed
+- Glob: Verify directory structure and file availability
 
 Key XML Extraction Patterns (for output.xml):
 - <test name="..."> - Test case boundary

--- a/commands/utility/sync.md
+++ b/commands/utility/sync.md
@@ -8,8 +8,8 @@ Arguments: {{input}}
   - <remote-repo-path> --dry-run        Show what would be synced without applying
 
 Examples:
-  /sync /home/jack/src/ollama37
-  /sync /home/jack/src/test-framework-template --dry-run
+  /sync /home/user/src/ollama37
+  /sync /home/user/src/test-framework-template --dry-run
 
 ## Important Rules
 

--- a/docs/references/confluence-format.md
+++ b/docs/references/confluence-format.md
@@ -1,0 +1,507 @@
+# Confluence Storage Format — HTML Reference
+
+HTML storage format reference for direct Confluence page authoring. Used when `content_format: "storage"` is required — see [Path A gotchas and Path B/C in `cf-format-guide.md`](../../commands/confluence/cf-format-guide.md) for when storage is required instead of markdown.
+
+This file contains the full HTML element reference: lists, tables, code blocks, headers, links, text formatting, and special characters.
+
+---
+
+## 1. Lists
+
+### 1.1 Bullet Lists (Unordered Lists)
+
+**Correct Format (Storage/HTML):**
+```html
+<ul>
+  <li><p>First item</p></li>
+  <li><p>Second item</p></li>
+  <li><p>Third item</p></li>
+</ul>
+```
+
+**Incorrect (Markdown converted):**
+```html
+<p> * First item * Second item * Third item</p>
+```
+
+**Example:**
+```html
+<ul>
+  <li><p>First feature requirement with <strong>important detail</strong></p></li>
+  <li><p>Second feature requirement with additional information</p></li>
+</ul>
+```
+
+**Key Points:**
+- Each list item (`<li>`) must contain a paragraph (`<p>`) tag
+- Use `<ul>` for unordered/bullet lists
+- Nested lists: Place nested `<ul>` or `<ol>` inside the parent `<li>` element
+
+### 1.2 Numbered Lists (Ordered Lists)
+
+**Correct Format (Storage/HTML):**
+```html
+<ol start="1">
+  <li><p>First step</p></li>
+  <li><p>Second step</p></li>
+  <li><p>Third step</p></li>
+</ol>
+```
+
+**Incorrect (Markdown converted):**
+```html
+<p> 1. First step 2. Second step 3. Third step</p>
+```
+
+**Example:**
+```html
+<ol start="1">
+  <li><p><strong>Precondition:</strong> Set up test environment</p></li>
+  <li><p>Navigate to the feature page</p></li>
+  <li><p><strong>Test Execution:</strong> Perform the test steps</p></li>
+</ol>
+```
+
+**Key Points:**
+- Use `<ol>` for ordered/numbered lists
+- Include `start="1"` attribute (or appropriate start number)
+- Each list item (`<li>`) must contain a paragraph (`<p>`) tag
+
+### 1.3 Nested Lists
+
+**Correct Format:**
+```html
+<ul>
+  <li><p>Parent item</p>
+    <ul>
+      <li><p>Nested item 1</p></li>
+      <li><p>Nested item 2</p></li>
+    </ul>
+  </li>
+  <li><p>Another parent item</p></li>
+</ul>
+```
+
+**Key Points:**
+- Nested list goes inside the parent `<li>` element, after the `<p>` tag
+- Can mix `<ul>` and `<ol>` for nested lists
+- **Markdown cannot express nesting reliably** — the MCP converter flattens 2-space-indented sub-bullets. For any page with nested lists, use `content_format: "storage"` with the structure above.
+
+### 1.4 Task Lists (Native Confluence Checkboxes)
+
+When the page needs **interactive checkboxes** (Entry/Exit criteria, sign-off checklists, definition-of-done lists), use Confluence's native task-list macro. The markdown `- [ ]` shortcut converts unreliably — write storage format directly.
+
+**Correct Format (Storage):**
+```html
+<ac:task-list>
+  <ac:task>
+    <ac:task-id>1</ac:task-id>
+    <ac:task-status>incomplete</ac:task-status>
+    <ac:task-body>First criterion to verify</ac:task-body>
+  </ac:task>
+  <ac:task>
+    <ac:task-id>2</ac:task-id>
+    <ac:task-status>incomplete</ac:task-status>
+    <ac:task-body>Second criterion — inline <code>code</code> and <strong>bold</strong> are fine inside <code>ac:task-body</code></ac:task-body>
+  </ac:task>
+</ac:task-list>
+```
+
+**Key Points:**
+- Each task needs a unique `<ac:task-id>` (any integer; just keep them unique within the page).
+- `<ac:task-status>` is `incomplete` or `complete`.
+- `<ac:task-body>` accepts inline HTML (`<code>`, `<strong>`, `<a>`, etc.) but not block-level elements.
+- The rendered output is a checkbox the reader can tick directly in Confluence — much better than a bullet list with `[ ]` placeholder text.
+- Reference example: a Test Strategy page § 4.5 with 16 task-list items split across Entry Criteria (9) and Exit Criteria (7).
+
+---
+
+## 2. Tables
+
+### 2.1 Basic Table Structure
+
+**Correct Format (Storage/HTML):**
+```html
+<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
+  <tbody>
+    <tr>
+      <th><p>Header 1</p></th>
+      <th><p>Header 2</p></th>
+    </tr>
+    <tr>
+      <td><p>Cell 1</p></td>
+      <td><p>Cell 2</p></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+**Incorrect (Markdown converted):**
+```html
+<p>|| Header 1 || Header 2 || | Cell 1 | Cell 2 |</p>
+```
+
+**Example:**
+```html
+<table ac:local-id="unique-id-here" data-layout="center" data-table-width="1800">
+  <tbody>
+    <tr>
+      <th><p>Category</p></th>
+      <th><p>Description</p></th>
+    </tr>
+    <tr>
+      <td><p>Feature A</p></td>
+      <td><p>Description of feature A</p></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+**Key Points:**
+- Use `<table>` with Confluence attributes:
+  - `ac:local-id`: Unique identifier (can be generated UUID)
+  - `data-layout="center"`: Center alignment
+  - `data-table-width="1800"`: Table width in pixels
+- Table structure: `<table>` → `<tbody>` → `<tr>` → `<th>` or `<td>`
+- Each cell content should be wrapped in `<p>` tags
+- Use `<th>` for header cells, `<td>` for data cells
+
+### 2.2 Tables with Bullet Points in Cells
+
+**Correct Format:**
+```html
+<table>
+  <tbody>
+    <tr>
+      <td><p>• First bullet point<br/>• Second bullet point<br/>• Third bullet point</p></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+**Key Points:**
+- Use bullet character `•` (not asterisk `*`)
+- Use `<br/>` for line breaks between bullet points
+- All bullet points in one `<p>` tag
+
+**Example:**
+```html
+<td><p>• First feature requirement<br/>• Second feature requirement<br/>• Third feature requirement</p></td>
+```
+
+### 2.3 Tables with Multiple Columns
+
+**Correct Format:**
+```html
+<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
+  <colgroup>
+    <col style="width: 124.0px;"/>
+    <col style="width: 155.0px;"/>
+    <col style="width: 1350.0px;"/>
+  </colgroup>
+  <tbody>
+    <tr>
+      <th><p>Column 1</p></th>
+      <th><p>Column 2</p></th>
+      <th><p>Column 3</p></th>
+    </tr>
+    <tr>
+      <td><p>Data 1</p></td>
+      <td><p>Data 2</p></td>
+      <td><p>Data 3</p></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+**Key Points:**
+- Use `<colgroup>` with `<col>` elements to define column widths
+- Column widths can be specified in pixels (e.g., `width: 124.0px`)
+
+---
+
+## 3. Code Blocks
+
+### 3.1 Inline Code
+
+**Correct Format:**
+```html
+<code>feature-flag-name</code>
+```
+
+### 3.2 Code Blocks
+
+**Correct Format (Using Confluence Code Macro):**
+```html
+<ac:structured-macro ac:name="code" ac:schema-version="1">
+  <ac:parameter ac:name="language">json</ac:parameter>
+  <ac:plain-text-body><![CDATA[{
+  "name": "example-config",
+  "type": "EXAMPLE"
+}]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+**Or Simple Code Block:**
+```html
+<ac:structured-macro ac:name="code" ac:schema-version="1">
+  <ac:plain-text-body><![CDATA[POST /api/v1.1/example-endpoint]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+**Key Points:**
+- Use `<ac:structured-macro>` with `ac:name="code"`
+- Wrap code content in `<![CDATA[...]]>` to preserve formatting
+- Optional: Add `ac:parameter` with `ac:name="language"` for syntax highlighting
+
+---
+
+## 4. Headers
+
+### 4.1 Header Levels
+
+**Correct Format:**
+```html
+<h1>Main Title</h1>
+<h2>Section Title</h2>
+<h3>Subsection Title</h3>
+<h4>Sub-subsection Title</h4>
+<h5>Operation Title</h5>
+```
+
+**Key Points:**
+- Use appropriate header levels for document hierarchy
+- H1 for main title, H2 for major sections, H3 for subsections, etc.
+
+---
+
+## 5. Links
+
+### 5.1 External Links
+
+**Correct Format:**
+```html
+<a href="https://example.atlassian.net/browse/PROJ-123">PROJ-123</a>
+```
+
+### 5.2 Confluence Page Links
+
+**Correct Format:**
+```html
+<ac:link>
+  <ri:page ri:content-title="Page Title" ri:space-key="SPACE"></ri:page>
+  <ac:link-body>Page Title</ac:link-body>
+</ac:link>
+```
+
+**Or Simple Link Format:**
+```html
+<a href="https://example.atlassian.net/wiki/spaces/SPACE/pages/123456789">Confluence Page Title</a>
+```
+
+**Key Points:**
+- Replace `SPACE` with your Confluence space key
+- Replace `123456789` with the actual page ID
+- Replace `example.atlassian.net` with your Confluence instance URL
+
+---
+
+## 6. Text Formatting
+
+### 6.1 Bold Text
+
+**Correct Format:**
+```html
+<strong>Bold Text</strong>
+```
+
+### 6.2 Italic Text
+
+**Correct Format:**
+```html
+<em>Italic Text</em>
+```
+
+### 6.3 Paragraphs
+
+**Correct Format:**
+```html
+<p>Paragraph text here.</p>
+```
+
+**Key Points:**
+- Always wrap text content in `<p>` tags
+- Use `<br/>` for line breaks within paragraphs
+
+---
+
+## 7. Horizontal Rules
+
+**Correct Format:**
+```html
+<hr/>
+```
+
+---
+
+## 8. Special Characters
+
+### 8.1 Bullet Character in Tables
+
+**Use:** `•` (bullet character, Unicode U+2022)
+
+**Not:** `*` (asterisk)
+
+### 8.2 HTML Entities
+
+- Less than: `&lt;` or `<`
+- Greater than: `&gt;` or `>`
+- Ampersand: `&amp;` or `&`
+- Quotes: `&quot;` or `"`
+
+---
+
+## 9. Complete Example Structure
+
+### 9.1 Section with Lists and Tables
+
+```html
+<h2>1. Project &amp; Business Context</h2>
+<h3>1.1 Product Overview</h3>
+<p><strong>Product:</strong> Product Name<br/> <strong>Feature:</strong> Feature Name<br/> <strong>Release Version:</strong> Version Number</p>
+
+<h3>1.2 Business Value</h3>
+<p>Description text here.</p>
+<p><strong>User Benefits:</strong></p>
+<table ac:local-id="unique-id" data-layout="center" data-table-width="1800">
+  <tbody>
+    <tr>
+      <th><p>Benefit</p></th>
+      <th><p>Description</p></th>
+    </tr>
+    <tr>
+      <td><p>Benefit Name</p></td>
+      <td><p>Description of the benefit</p></td>
+    </tr>
+  </tbody>
+</table>
+
+<p><strong>Business Impact:</strong></p>
+<ul>
+  <li><p>Addresses customer feature request</p></li>
+  <li><p>Prioritized feature for upcoming release</p></li>
+</ul>
+```
+
+### 9.2 Section with Numbered List
+
+```html
+<h4>Workflow Steps</h4>
+<ol start="1">
+  <li><p>First step with configuration (e.g., <code>example.com</code>, port 8080)</p></li>
+  <li><p>Second step in the workflow</p></li>
+  <li><p>Third step to complete the process</p></li>
+</ol>
+```
+
+---
+
+## 10. Common Mistakes to Avoid
+
+### Mistake 1: Using Markdown Format
+
+**Problem:** Markdown format doesn't convert lists and tables properly
+```javascript
+// DON'T DO THIS
+content_format: "markdown"
+```
+
+**Solution:** Use storage format
+```javascript
+// DO THIS
+content_format: "storage"
+```
+
+### Mistake 2: Lists Without Paragraph Tags
+
+**Problem:**
+```html
+<ul>
+  <li>Item without paragraph</li>
+</ul>
+```
+
+**Solution:**
+```html
+<ul>
+  <li><p>Item with paragraph</p></li>
+</ul>
+```
+
+### Mistake 3: Tables as Plain Text
+
+**Problem:**
+```html
+<p>|| Header || | Cell |</p>
+```
+
+**Solution:**
+```html
+<table>
+  <tbody>
+    <tr>
+      <th><p>Header</p></th>
+    </tr>
+    <tr>
+      <td><p>Cell</p></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Mistake 4: Numbered Lists as Plain Text
+
+**Problem:**
+```html
+<p>1. First step 2. Second step</p>
+```
+
+**Solution:**
+```html
+<ol start="1">
+  <li><p>First step</p></li>
+  <li><p>Second step</p></li>
+</ol>
+```
+
+---
+
+## 11. Best Practices
+
+1. **Always use `storage` format** when creating pages programmatically
+2. **Wrap all text content in `<p>` tags** - even inside list items and table cells
+3. **Use proper HTML structure** - `<ul>`, `<ol>`, `<table>`, etc.
+4. **Include Confluence attributes** for tables (`ac:local-id`, `data-layout`, `data-table-width`)
+5. **Use bullet character `•`** (not asterisk `*`) in table cells
+6. **Use `<br/>` for line breaks** within paragraphs or table cells
+7. **Test the page** after creation to verify formatting
+8. **Reference existing well-formatted pages** in your Confluence instance as examples
+
+---
+
+## 12. Format Conversion Checklist
+
+When converting markdown to Confluence storage format:
+
+- [ ] Convert `*` bullet lists to `<ul><li><p>...</p></li></ul>`
+- [ ] Convert numbered lists to `<ol start="1"><li><p>...</p></li></ol>`
+- [ ] Convert `||` tables to proper `<table>` HTML
+- [ ] Wrap all text in `<p>` tags
+- [ ] Convert inline code `` `code` `` to `<code>code</code>`
+- [ ] Convert code blocks to `<ac:structured-macro ac:name="code">`
+- [ ] Convert markdown links `[text](url)` to `<a href="url">text</a>`
+- [ ] Convert `**bold**` to `<strong>bold</strong>`
+- [ ] Convert `*italic*` to `<em>italic</em>`
+- [ ] Add Confluence table attributes (`ac:local-id`, `data-layout`, `data-table-width`)
+- [ ] Use `•` character (not `*`) for bullets in table cells
+- [ ] Use `<br/>` for line breaks in table cells

--- a/skills/planning-tests/references/file-templates.md
+++ b/skills/planning-tests/references/file-templates.md
@@ -1,0 +1,289 @@
+# Test Plan File Templates
+
+Markdown templates for the `test_plan/` and `test_design/` files produced by `/tw-plan-feature`, `/tw-plan-enhance`, and `/tw-plan-bugfix`.
+
+See [`file-layout.md`](file-layout.md) for the directory structure rationale. See [`scenario-conventions.md`](scenario-conventions.md) for the TS-XX scenario file template.
+
+---
+
+## `test_plan/README.md`
+
+```markdown
+# Test Plan: [Feature Name] ([Epic ID])
+
+**Test Plan Type:** New Feature Validation
+**Test Plan Version:** 1.0
+**Created:** [Date]
+**Last Updated:** [Date]
+**QA Engineer:** [Name]
+**Epic:** [Link]
+**Feature Request:** [Link]
+**Target Release:** [Date]
+**Feature Flag:** `[flag-name]` (if applicable)
+
+---
+
+## Test Plan Sections
+
+1. [Project & Business Context](sections/01_Project_Business_Context.md)
+2. [Feature Definition](sections/02_Feature_Definition.md)
+3. [Scope & Boundaries](sections/03_Scope_Boundaries.md)
+4. [Test Strategy](sections/04_Test_Strategy.md)
+5. [References & Resources](sections/05_References_Resources.md)
+6. [Revision History](sections/06_Revision_History.md)
+
+---
+
+## Quick Reference
+
+- **Total Test Scenarios:** [N]
+- **Estimated Test Cases:** [N]
+```
+
+---
+
+## `test_plan/sections/01_Project_Business_Context.md`
+
+```markdown
+## 1. Project & Business Context
+### 1.1 Product Overview
+### 1.2 Business Value
+### 1.3 Stakeholders
+```
+
+---
+
+## `test_plan/sections/02_Feature_Definition.md`
+
+```markdown
+## 2. Feature Definition
+### 2.1 Core Functionality
+### 2.2 Feature Control
+### 2.3 Non-Functional Requirements
+```
+
+---
+
+## `test_plan/sections/03_Scope_Boundaries.md`
+
+```markdown
+## 3. Scope & Boundaries
+### 3.1 In-Scope Testing
+### 3.2 Out of Scope
+```
+
+---
+
+## `test_plan/sections/04_Test_Strategy.md` (lean)
+
+```markdown
+## 4. Test Strategy
+
+### 4.1 Test Levels
+| Level | Approach |
+|-------|----------|
+| Functional | ... |
+| Integration | ... |
+| Regression | ... |
+
+### 4.2 Test Types
+| Type | Coverage |
+|------|----------|
+| GUI Testing | ... |
+| API Testing | ... |
+| End-to-End | ... |
+
+### 4.3 Test Approach
+- **Verification Perspective:** Hybrid (Web GUI + API + ...)
+- **Test Environment:** [environment requirement; specific tenant in `config/`]
+- **Feature Flag:** `<flag-name>` (if applicable)
+- **Visual Baseline:** [path to wireframes / live captures]
+
+### 4.4 Test Data Setup
+| Item | Value |
+|------|-------|
+| Tenant | [capability requirement; specifics in `config/`] |
+| Networks | ... |
+| ... | ... |
+
+### 4.5 Hybrid Depth Strategy
+
+**Deep (representative case):** TS-XX — [reason it's the deep test]
+
+**Wide (variant scenarios):** TS-YY — [what makes them variants]
+
+### 4.6 Entry/Exit Criteria
+
+**Entry Criteria:**
+- [ ] Build deployed to test environment
+- [ ] Test data provisioned
+- [ ] Dependencies available (list specific dependencies)
+- [ ] Feature flag enabled (if applicable)
+
+**Exit Criteria:**
+- [ ] 100% P0 test cases pass
+- [ ] ≥90% P1 test cases pass
+- [ ] All P0/P1 defects resolved or deferred with approval
+- [ ] Sign-off from QA lead
+
+### 4.7 Companion Artifacts
+
+Per ISO/IEC/IEEE 29119-3, the following live as separate artifacts in `test_design/`:
+
+| Artifact | Location | Contents |
+|---|---|---|
+| Scenario specifications | [`test_design/scenarios/`](../test_design/scenarios/) | One file per TS-XX with focus, est. cases, activities |
+| Requirements Traceability Matrix | [`test_design/traceability_matrix.md`](../test_design/traceability_matrix.md) | Requirement → scenario mapping; coverage gaps |
+| Risk Register | [`test_design/risk_register.md`](../test_design/risk_register.md) | Per-scenario risk level, likelihood/impact, mitigation |
+
+**Total Test Coverage:** [N] Test Scenarios — [N] estimated test cases (see scenario index).
+```
+
+---
+
+## `test_plan/sections/05_References_Resources.md`
+
+```markdown
+## 5. References & Resources
+### 5.1 Design & Documentation
+```
+
+---
+
+## `test_plan/sections/06_Revision_History.md`
+
+```markdown
+## 6. Document Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | YYYY-MM-DD | [Name] | Initial test plan |
+```
+
+---
+
+## `test_design/scenarios/README.md`
+
+```markdown
+# Scenario Specifications — [PROJECT_ID]
+
+Per ISO/IEC/IEEE 29119-3, scenarios live separate from the test plan. The plan in `test_plan/sections/04_Test_Strategy.md` describes the strategy, scope, and gates; this directory holds the detailed scenarios.
+
+[One-paragraph note about journey order or organizing principle.]
+
+## Admin Flow
+
+\`\`\`mermaid
+flowchart LR
+    A[step] --> B[step]
+\`\`\`
+
+## End-User Flow
+
+\`\`\`mermaid
+flowchart LR
+    A[step] --> B[step]
+\`\`\`
+
+## Scenario Index
+
+| ID | Scenario | Focus | Est. Cases |
+|---|---|---|---|
+| [TS-01](TS-01_<Slug>.md) | [Name] | [GUI / API / E2E] | [N] |
+| [TS-02](TS-02_<Slug>.md) | [Name] | [Focus] | [N] |
+
+**Total:** [N] estimated test cases.
+```
+
+---
+
+## `test_design/scenarios/TS-XX_<Slug>.md`
+
+Each scenario file follows the uniform metadata header, an optional `## Scenario Preconditions` block, and a `### Case N:` block per case (Objective + Checkpoints mandatory; Preconditions + Notes optional). Click-by-click steps belong in the test cases, not the scenarios. See [`scenario-conventions.md`](scenario-conventions.md) for the full authoring guide.
+
+```markdown
+# TS-XX: <name>
+
+**Focus:** <GUI / API / E2E / Config / hybrid>
+
+**Estimated test cases:** N
+
+**Test plan reference:** [`test_plan/sections/04_Test_Strategy.md`](../../sections/04_Test_Strategy.md)
+
+---
+
+<intro paragraph — what this scenario owns, what it doesn't, key cross-references. Split into 2-3 short paragraphs at conceptual seams when it crosses 3+ ideas — see `skills/reviewing-typography/references/typography-principles.md` anti-pattern A2.>
+
+## Scenario Preconditions
+
+- <setup that applies to every case>
+
+## Test Cases
+
+### Case 1: <Short imperative title>
+
+- **Objective:** <one sentence — what the case proves>
+- **Checkpoints:**
+  - <Observable 1>
+  - <Observable 2>
+
+### Case 2: <Short imperative title>
+
+- **Objective:** ...
+- **Preconditions:** <case-specific, optional>
+- **Checkpoints:**
+  - ...
+- **Notes:** <HLD-silent flags, TKT cross-refs, sequencing hints — optional>
+```
+
+---
+
+## `test_design/traceability_matrix.md`
+
+```markdown
+# Requirements Traceability Matrix — [PROJECT_ID]
+
+Maps each requirement to the scenario(s) that cover it. Source documents:
+[list source HLDs, FRs, review transcripts].
+
+## Coverage
+
+| Requirement | Source | Covered By |
+|-------------|--------|------------|
+| [Req 1] | HLD § X.X | [TS-01](scenarios/TS-01_<Slug>.md), [TS-02](scenarios/TS-02_<Slug>.md) |
+| [Req 2] | Jira AC #3 | [TS-03](scenarios/TS-03_<Slug>.md) |
+
+## Coverage Gaps
+
+- **[Gap description]** — the HLD does not specify [X]. Tested as observed
+  (TS-XX); the actual behavior will be captured live for the test plan review.
+```
+
+Cross-link from scenario → matrix uses `../traceability_matrix.md` if you want to add reverse references; matrix → scenario uses `scenarios/TS-XX_<Slug>.md` (relative within `test_design/`).
+
+---
+
+## `test_design/risk_register.md`
+
+```markdown
+# Risk Register — [PROJECT_ID]
+
+Per-scenario risk assessment. Risk level reflects the joint judgment of
+likelihood × impact; mitigation describes the action QA takes during
+execution.
+
+| Scenario | Risk Level | Likelihood | Impact | Mitigation |
+|----------|-----------|------------|--------|------------|
+| [TS-01](scenarios/TS-01_<Slug>.md) | Medium | Moderate | User-facing | Deep testing |
+| [TS-02](scenarios/TS-02_<Slug>.md) | Low | Low | Internal | Standard coverage |
+```
+
+Risk-level criteria:
+
+| Risk Level | Criteria |
+|------------|----------|
+| **High** | New technology, complex integration, user-facing with no rollback |
+| **Medium** | Modified existing flow, partial rollback, affects subset of users |
+| **Low** | Well-understood path, easy rollback, internal-only impact |
+
+Cross-link to scenarios uses `scenarios/TS-XX_<Slug>.md` (relative within `test_design/`).

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -51,14 +51,14 @@ These MCP servers must be configured:
 
 **GitHub (gh-*):** `/gh-init`, `/gh-track`, `/gh-status`, `/gh-close`
 
-**Jira (jr-*):** `/jr-trace`, `/jr-trace-fetch`, `/jr-trace-structure`, `/jr-trace-docs`, `/jr-trace-verify`, `/jr-issue-summary`, `/jr-to-markdown`
+**Jira (jr-*):** `/jr-trace`, `/jr-trace-fetch`, `/jr-trace-structure`, `/jr-trace-docs`, `/jr-trace-verify`
 
-**Confluence (cf-*):** `/cf-create-page`, `/cf-update-page`, `/cf-review-page`, `/cf-page-summary`, `/cf-to-markdown`, `/cf-format-guide`
+**Confluence (cf-*):** `/cf-create-page`, `/cf-update-page`, `/cf-review-page`, `/cf-format-guide`
 
 **Test Workflow (tw-*):** `/tw-plan-init`, `/tw-plan-feature`, `/tw-plan-enhance`, `/tw-plan-bugfix`, `/tw-plan-review`, `/tw-diagrams`, `/tw-case-init`, `/tw-case-feature`, `/tw-case-enhance`, `/tw-case-bugfix`, `/tw-case-review`, `/tw-templates`, `/tw-script-review`
 
 **TestLink (tl-*):** `/tl-list-projects`, `/tl-create-suite`, `/tl-list-suites`, `/tl-update-suite`, `/tl-create-case`, `/tl-get-case`, `/tl-list-cases`, `/tl-update-case`, `/tl-identify-type`, `/tl-create-plan`, `/tl-get-cases-for-plan`, `/tl-add-case-to-plan`, `/tl-execute-case`, `/tl-read-execution`, `/tl-create-execution`, `/tl-format`, `/tl-sync`, `/tl-list-requirements`
 
-**Project (pm-*):** `/pm-init`, `/pm-demo-content`, `/pm-demo-review`, `/pm-demo-ppt`, `/pm-demo-email`, `/pm-meeting-invite`, `/pm-bug-report`, `/pm-scrum-task`
+**Project (pm-*):** `/pm-init`, `/pm-demo-content`, `/pm-demo-review`, `/pm-demo-ppt`, `/pm-demo-email`, `/pm-meeting-invite`, `/pm-bug-report`
 
 **Utility:** `/rewrite-text`, `/robot-log-analyzer`


### PR DESCRIPTION
## Summary

- Two-axis audit (Format/Purpose for internal artifacts, Typography/Phrasing for the README) applied across commands/, skills/, CLAUDE.md, and README.md
- Adds two project-local audit skills (`.claude/skills/auditing-artifacts/`, `.claude/skills/auditing-readme/`) that codify the audit methodology used here
- Documents the three-tier route (CLAUDE.md → Skills → Commands) explicitly in CLAUDE.md so the minimal-command-routed-from-skills pattern is an intentional design choice, not an inferred one

## What changed

**Internal artifacts (Phase 1-3):**
- 76 → 71 commands (5 orphan stubs removed: cf-page-summary, cf-to-markdown, jr-issue-summary, jr-to-markdown, pm-scrum-task)
- 4 broken cross-references fixed
- 2 privacy leaks fixed (/home/jack/... → /home/user/...)
- Stale tool names updated in robot-log-analyzer (TodoWrite → TaskCreate, etc.)
- 480+ lines of inline reference content extracted to docs/references/confluence-format.md and skills/planning-tests/references/file-templates.md
- 1 of 2 size violations resolved (tw-plan-feature 779 → 495; tw-case-review 537 deferred)

**README (Phase 4):**
- Notable Features promoted from line 209 to line 16 — first-screen value prop
- Test Lifecycle updated to 7 phases (adds Baseline) to match CLAUDE.md
- Dev Workflow command list synced (adds dw-tasks, dw-test-design)
- Integrations grouped into Required / Optional / Related — honest signal about wpa-mcp and radius-sql
- Headings cleaned ("Issue-Driven Development" / "Self-Improvement Loop")
- After Installation list split into actions + facts

## Test plan

- [ ] Confirm CLAUDE.md still loads cleanly and the three-tier doc reads well
- [ ] Spot-check that command cross-references all resolve (no /cf-confluence-format-guidelines etc.)
- [ ] Confirm tw-plan-feature.md is under 500 lines and still produces working test plans
- [ ] Confirm README renders correctly on GitHub (ASCII diagrams, tables, anchors)
- [ ] Try running the two new audit skills on a sample to confirm they self-execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)