### PR TITLE
Port the dev-workflow plan-stage into commands/dev-workflow/

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "commands/dev-workflow/**/*.md"
+---
+
+# dev-workflow
+
+Turns a need into shipped code. A story states the **need** (a goal, not a spec); a
+**plan issue** states the agreed **approach**; task issues carry the *how* as it's worked
+out. Each producer is paired with a review — no producer ships without one.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md
+            │
+   dw-story ───────► dw-review-story    the need — complete, and a goal not a spec
+            │
+            ▼
+   dw-plan ────────► [human reviews the plan issue]   research → ONE plan issue: the approach
+            │                                           (skip for trivial / single-task work)
+            ▼
+   dw-tasks ───────► dw-review-tasks    plan issue → task issues, each "Part of #<plan>"
+            │
+            ▼
+   dw-implement ───► dw-review-implement   build the issue; the plan issue is the
+            │                               checkpoint a fresh session resumes from
+            ▼
+   dw-create-pr ───► [human review + /review]   open the PR
+            │
+            ▼
+   dw-merge          green CI + human review → merge
+```
+
+## The plan issue
+
+The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-XXX] Plan`.
+Its body holds the researched approach, acceptance criteria, and the commands/files it
+expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
+with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+
+Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
+before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the
+`[human review + /review]` gate before a merge).
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `dw-story`     | `dw-review-story`     | the need: complete, and a goal not a spec |
+| `dw-plan`      | **human review** (the plan issue) | the approach covers the story, before decomposition |
+| `dw-tasks`     | `dw-review-tasks`     | the issues cover the plan; each lean; trace back to the plan |
+| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the studio |
+| `dw-test-design` | *(verified by running the suite)* | tests pass, native to the framework |
+| `dw-create-pr` | *(human review + `/review`)* | the PR overview before merge |
+| `dw-merge`     | *(is the terminal gate)* | green CI + human review |
+
+No producer ships without a review covering its output.
+
+## Right-size it
+
+The plan stage is for non-trivial stories. A one-line doc change or a single-task story
+**skips `dw-plan`** — `dw-story` hands off straight to `dw-tasks` (or a lone issue). Three
+review passes plus a plan issue on a typo is ritual, not rigor.
+
+## What is reused, not rebuilt
+
+- **The story + issues** are the unit of work — a story in `docs/stories/`, its task
+  issues on GitHub.
+- **GitHub issues** already hold the work; the plan is one too (the parent), so the
+  approach, its review, and its history live where the tasks do — no separate plan store.
+- **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -50,7 +50,7 @@ before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirr
 | `dw-story`     | `dw-review-story`     | the need: complete, and a goal not a spec |
 | `dw-plan`      | **human review** (the plan issue) | the approach covers the story, before decomposition |
 | `dw-tasks`     | `dw-review-tasks`     | the issues cover the plan; each lean; trace back to the plan |
-| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the studio |
+| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the project |
 | `dw-test-design` | *(verified by running the suite)* | tests pass, native to the framework |
 | `dw-create-pr` | *(human review + `/review`)* | the PR overview before merge |
 | `dw-merge`     | *(is the terminal gate)* | green CI + human review |

--- a/commands/dev-workflow/dw-create-pr.md
+++ b/commands/dev-workflow/dw-create-pr.md
@@ -19,7 +19,10 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         ├─► Step 1: Verify Readiness
         │   - Confirm you're on the correct branch (issue-<N>-<slug>)
         │   - Run: git status — check for uncommitted changes
-        │   - Run: git log --oneline main..HEAD — review commits
+        │   - Review the branch's commits against the repo's default branch —
+        │     derive it, don't hardcode `main` (gh repo view --json
+        │     defaultBranchRef -q .defaultBranchRef.name):
+        │     git log --oneline <default>..HEAD
         │   - If no argument given, infer issue number from branch name
         │   - Run: gh issue view <N> — check if title contains [STORY-XXX]
         │
@@ -58,7 +61,10 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │
         └─► Step 6: Report
             - Show the PR URL to the user
-            - Suggest next step: /dw-review-pr <PR>
+            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
+              review and test it. Merge with /dw-merge <PR> only once a human is
+              satisfied. (The change's substance was already gated locally by
+              /dw-review-implement before the PR.)
 
 ---
 
@@ -69,7 +75,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
 **Agent verifies, pushes, creates PR:**
 
     $ git status
-    $ git log --oneline main..HEAD
+    $ git log --oneline <default-branch>..HEAD
     $ git push -u origin issue-27-release-notes
     $ gh pr create --title "Add release notes generator command" --body "..."
     $ gh issue edit 27 --remove-label "status:in-progress" --add-label "status:needs-review"
@@ -78,7 +84,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
 **Output:**
 
     PR #30 created: https://github.com/owner/repo/pull/30
-    Next: /dw-review-pr 30
+    A human reviews + tests it; merge with /dw-merge 30 when satisfied.
 
 ---
 

--- a/commands/dev-workflow/dw-implement.md
+++ b/commands/dev-workflow/dw-implement.md
@@ -22,14 +22,20 @@ and prepares for PR creation when done.
         │   - Read acceptance criteria, technical notes, dependencies
         │   - Check labels — type and priority should already be set
         │   - Check for linked/blocking issues
+        │   - If the issue body links a plan ("Part of #<plan>"), read that plan
+        │     issue — its Approach is the agreed checkpoint to build from, so a fresh
+        │     session resumes without re-deriving it: gh issue view <plan>
         │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
-        │     for full context (user story, broader acceptance criteria, related tasks)
+        │     for full context (the user story and the need it serves)
         │   - If anything is unclear, ask the user before starting
         │
         ├─► Step 2: Create Branch
         │   - Branch name: issue-<N>-<short-slug>
         │     Example: issue-27-release-notes
-        │   - Run: git checkout -b issue-<N>-<slug> main
+        │   - Branch from the repo's default branch — derive it, don't hardcode
+        │     `main` (e.g. gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name); check it out and pull, then:
+        │     git checkout -b issue-<N>-<slug>
         │   - Comment on issue:
         │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"
         │   - Add status label:
@@ -44,9 +50,9 @@ and prepares for PR creation when done.
         ├─► Step 4a: On Success
         │   - Comment on issue:
         │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
-        │   - If linked to STORY-XXX, update docs/stories/STORY-XXX.md:
-        │     check off completed acceptance criteria for this task
-        │   - Proceed to /dw-create-pr
+        │   - Progress is recorded on the issue, not the story — the story stays the
+        │     stable statement of the need
+        │   - Proceed to /dw-review-implement to gate the changes before the PR
         │
         ├─► Step 4b: On Failure
         │   - Do NOT silently retry — update the issue:
@@ -61,7 +67,8 @@ and prepares for PR creation when done.
         │
         └─► Step 4c: On Partial Fix
             - Comment: what was fixed, what remains, blockers
-            - Proceed to /dw-create-pr if the partial fix is independently useful
+            - If the partial fix is independently useful: run /dw-review-implement,
+              then a human reviews + tests before a PR is opened (/dw-create-pr)
             - Create follow-up issues for remaining work
 
 ---
@@ -84,7 +91,7 @@ GitHub auto-creates backlinks when issues reference each other.
 **Agent reads issue #27, creates branch, implements:**
 
     $ gh issue view 27
-    $ git checkout -b issue-27-release-notes main
+    $ git checkout -b issue-27-release-notes   # from the repo's default branch
     $ gh issue comment 27 --body "Starting work on branch `issue-27-release-notes`"
     $ gh issue edit 27 --add-label "status:in-progress"
 
@@ -92,7 +99,8 @@ GitHub auto-creates backlinks when issues reference each other.
 
     $ gh issue comment 27 --body "Implementation complete, tests passing. Ready for PR."
 
-**Next step:** /dw-create-pr 27
+**Next step:** /dw-review-implement 27 (local gate). Then a human reviews + tests
+before a PR is opened (/dw-create-pr 27) — the workflow doesn't auto-advance to a PR.
 
 ---
 
@@ -109,4 +117,7 @@ history — start, failures, fixes, and resolution.
 - Branch naming convention: `issue-<number>-<short-slug>`
 - Always comment on the issue before and after implementation
 - Label management: `status:in-progress` while working, `status:blocked` if stuck
+- For a planned task, the linked plan issue (`Part of #<plan>`) holds the agreed
+  approach — the checkpoint a fresh session resumes from (see
+  `.claude/rules/dev-workflow.md`)
 ```

--- a/commands/dev-workflow/dw-merge.md
+++ b/commands/dev-workflow/dw-merge.md
@@ -16,11 +16,15 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
 
     /dw-merge 30
         │
-        ├─► Step 1: Verify PR is Ready
-        │   - Run: gh pr view <PR> --json reviewDecision,mergeStateStatus,headRefName
-        │   - Must be approved and mergeable
-        │   - Run: gh pr checks <PR>
-        │   - CI checks must pass (if applicable)
+        ├─► Step 1: Verify Ready to Merge
+        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,reviewDecision
+        │   - Must be mergeable (no conflicts)
+        │   - Run: gh pr checks <PR> — any CI checks must pass (if applicable)
+        │   - The merge gate is HUMAN review + test, not a GitHub approval. On a
+        │     solo repo GitHub blocks self-approval, so do NOT require
+        │     reviewDecision=APPROVED. Before merging, confirm a human has reviewed
+        │     and tested the change (its substance was gated by /dw-review-implement
+        │     before the PR). If not yet reviewed/tested, stop and say so.
         │
         ├─► Step 2: Identify Linked Issue and Story
         │   - Read PR body for "Fixes #N" or "Closes #N"
@@ -43,7 +47,9 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Skip silently if no story link or docs/stories/ doesn't exist
         │
         ├─► Step 6: Clean Up Local Branch
-        │   - Run: git checkout main && git pull
+        │   - Switch to the repo's default branch and pull — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git checkout <default> && git pull
         │   - Run: git branch -d <branch-name>
         │
         └─► Step 7: Report
@@ -61,11 +67,11 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
 
 **Agent verifies, merges, cleans up:**
 
-    $ gh pr view 30 --json reviewDecision,mergeStateStatus,headRefName
+    $ gh pr view 30 --json mergeStateStatus,headRefName,reviewDecision  # mergeable? (don't gate on self-approval)
     $ gh pr checks 30
     $ gh pr merge 30 --merge --delete-branch
     $ gh issue edit 27 --remove-label "status:needs-review"
-    $ git checkout main && git pull
+    $ git checkout <default-branch> && git pull
     $ git branch -d issue-27-release-notes
 
 **Output:**

--- a/commands/dev-workflow/dw-plan.md
+++ b/commands/dev-workflow/dw-plan.md
@@ -1,129 +1,135 @@
-# Plan Development Work into GitHub Issues
+# Plan Development Work into a Plan Issue
 
 ```
-Break down a user request into GitHub Issues with labels and priorities.
+Research a story and write the plan — the agreed approach — as ONE GitHub plan
+issue, then stop for human review.
 
-Request: {{input}}
+Target: a STORY-XXX (or a raw request).
 
 ## PURPOSE
 
-Analyzes a feature request, enhancement, or bug report and creates well-structured
-GitHub Issues with proper labels and priorities. Checks for duplicates, breaks down
-multi-part requests, and waits for user approval before implementation begins.
+The front of the dev-workflow's build half: turn a story's *need* into an agreed
+*approach*, captured as a durable, reviewable **plan issue** before any task issue is
+opened. It researches against the repo (conventions, prior issues) so the plan is
+grounded, writes one plan issue, and **stops** — a human reviews the plan on GitHub,
+then `/dw-tasks` decomposes it. The plan issue is the parent of the task issues and the
+checkpoint a fresh session resumes from. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+This command produces the plan only. It does NOT create task issues — that is `/dw-tasks`.
 
 ---
 
 ## WORKFLOW
 
-    /dw-plan Add cross-repo sync commands
+    /dw-plan STORY-003
         │
-        ├─► Step 1: Check Existing Issues
-        │   - Run: gh issue list --state all --limit 50
-        │   - Scan for duplicates or related issues
-        │   - If duplicate found, report and ask user how to proceed
+        ├─► Step 1: Read the need (and right-size)
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If a raw request: restate the need in a sentence.
+        │   - RIGHT-SIZE: if the work is trivial — a one-line change or a single,
+        │     obvious task — skip planning. Say so and hand off straight to
+        │     /dw-tasks (or a lone issue). The plan stage is for non-trivial stories.
         │
-        ├─► Step 2: Classify the Request
-        │   - Determine type: feature / enhancement / bug / docs
-        │   - Determine priority: high / medium / low
-        │   - Break down into individual issues if request covers multiple items
+        ├─► Step 2: Research (ground the approach)
+        │   - Investigate the repo so the plan reflects it, not generic advice:
+        │     • conventions — CLAUDE.md, .claude/rules/, neighbouring code patterns
+        │     • prior art — gh issue list --state all --limit 50 ; related stories
+        │   - Note the approach, the commands/files it will touch, and open questions.
         │
-        ├─► Step 3: Create Labels (idempotent)
-        │   - Ensure type labels exist:
-        │     • feature        (color: #0e8a16) — New capability
-        │     • enhancement    (color: #1d76db) — Improve existing
-        │     • bug            (color: #d93f0b) — Bug report
-        │     • docs           (color: #c5def5) — Documentation
-        │   - Ensure priority labels exist:
-        │     • priority:high   (color: #b60205) — Important, fix soon
-        │     • priority:medium (color: #fbca04) — Normal priority
-        │     • priority:low    (color: #0e8a16) — Nice to have
-        │   - Ensure status labels exist:
-        │     • status:in-progress  (color: #1d76db) — Work started
-        │     • status:needs-review (color: #e4e669) — PR open, awaiting review
-        │     • status:blocked      (color: #d93f0b) — Blocked by dependency
+        ├─► Step 3: Check for an existing plan
+        │   - Run: gh issue list --search "[STORY-XXX] Plan" --state all
+        │   - If a plan issue already exists, report and ask how to proceed (extend it,
+        │     not duplicate).
+        │
+        ├─► Step 4: Ensure labels (idempotent)
+        │   - plan           (color: #5319e7) — The approach for a story, before tasks
+        │   - priority:high / priority:medium / priority:low (as in /dw-tasks)
         │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
         │
-        ├─► Step 4: Create Issues
-        │   - One issue per distinct work item
-        │   - Use the appropriate body template (see below)
-        │   - Apply type + priority labels
-        │   - Link related issues: "Depends on #N", "Related to #N"
+        ├─► Step 5: Write ONE plan issue
+        │   - Title: [STORY-XXX] Plan   (raw request: "Plan: <short need>")
+        │   - Body: the template below — approach, acceptance criteria, the
+        │     commands/files it expects to touch, open questions.
+        │   - Labels: plan + priority. Link the story: "Part of STORY-XXX".
         │
-        ├─► Step 5: Summarize
-        │   - Output a table of created issues:
-        │     | Issue | Title | Type | Priority | URL |
-        │   - Wait for user approval before proceeding
+        ├─► Step 6: Record on the story (if a STORY-XXX)
+        │   - Update docs/stories/STORY-XXX.md Status with the plan issue number:
+        │     - Plan: #<plan>
         │
-        └─► Step 6: User Approval Gate
-            - Ask: "Want me to start on #N?"
-            - Do NOT proceed to /dw-implement until user explicitly approves
+        └─► Step 7: Hand off — stop for human review
+            - Show the plan issue URL.
+            - STOP. The plan now waits for a HUMAN to read, comment, and approve it on
+              GitHub. Do NOT create task issues and do NOT auto-advance.
+            - Once a human is satisfied: /dw-tasks STORY-XXX breaks the plan into tasks.
 
 ---
 
-## ISSUE BODY TEMPLATES
+## PLAN ISSUE BODY TEMPLATE
 
-### Feature / Enhancement
+    ## Context
+    Part of [STORY-XXX](../docs/stories/STORY-XXX.md) — <the need, one line>.
 
-    ## User Story
-    As a [role], I want [capability], so that [benefit].
+    ## Approach
+    <How we'll meet the need — the agreed shape of the work, grounded in the repo.>
 
     ## Acceptance Criteria
-    1. ...
+    - [ ] <observable outcome that means the story is delivered>
 
-    ## Technical Notes
-    - ...
+    ## Touches
+    - <commands / files / areas the work is expected to change>
 
-    ## Dependencies
-    - None | Depends on #N
-
-### Bug
-
-    ## Description
-    ...
-
-    ## Expected Behavior
-    ...
-
-    ## Steps to Reproduce
-    1. ...
+    ## Open Questions
+    - <what's still unresolved — settled as the tasks are worked>
 
 ---
 
 ## EXAMPLE
 
-    /dw-plan Add command to generate release notes from git history
+    /dw-plan STORY-003
 
-**Agent creates:**
+**Agent reads the story, researches, writes one plan issue:**
 
-    gh issue create \
-      --label "feature" --label "priority:medium" \
-      --title "Add release notes generator command" \
-      --body "## User Story
-    As a developer, I want to generate release notes from git history,
-    so that I can quickly summarize changes for each release.
-
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --state all --limit 50
+    $ gh issue list --search "[STORY-003] Plan" --state all
+    $ gh label create "plan" --color "5319e7" --description "The approach for a story, before tasks" --force
+    $ gh issue create --label "plan" --label "priority:high" \
+        --title "[STORY-003] Plan" \
+        --body "## Context
+    Part of STORY-003 — validate inbound payloads.
+    ## Approach
+    ...
     ## Acceptance Criteria
-    1. Command reads git log between two tags
-    2. Groups commits by type (feature, fix, docs)
-    3. Outputs formatted markdown
+    - [ ] ...
+    ## Touches
+    - ...
+    ## Open Questions
+    - ..."
 
-    ## Dependencies
-    - None"
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Plan: #28
 
 **Output:**
 
-    | Issue | Title                              | Type    | Priority | URL                    |
-    |-------|------------------------------------|---------|----------|------------------------|
-    | #27   | Add release notes generator command | feature | medium   | https://github.com/... |
-
-    Want me to start on #27?
+    Plan issue #28 created: https://github.com/owner/repo/issues/28
+    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
 
 ---
 
 ## API Notes
 
 - Uses `gh` CLI — must be authenticated (`gh auth status`)
-- Labels use `--force` flag so existing labels are updated, not duplicated
-- Always check for duplicates before creating new issues
-- The issue body is the single source of truth for the work item
+- Labels use `--force` so existing labels are updated, not duplicated
+- One plan issue per story — check for duplicates before creating
+- The plan issue is the parent of the task issues; the story records the need, the plan
+  records the approach, the task issues carry the how (see .claude/rules/dev-workflow.md)
+- Trivial work skips this command — go straight to /dw-tasks
 ```

--- a/commands/dev-workflow/dw-review-implement.md
+++ b/commands/dev-workflow/dw-review-implement.md
@@ -1,0 +1,115 @@
+# Review an Implementation
+
+```
+Review the changes an issue was implemented with — do they deliver the issue, and
+do they stay surgical rather than sprawling beyond it?
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Quality-gates the work done by `/dw-implement` before it becomes a PR. Checks that
+the changes on the branch **deliver the issue** (every "Done When" is actually
+satisfied) and stay **surgical** (every changed line traces to the issue — no scope
+creep, dead code, or debug leftovers) while **fitting the studio**. Fixes small
+findings on the branch in place, or hands back to `/dw-implement` if the approach is
+wrong.
+
+Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
+
+    … → dw-implement → dw-review-implement → dw-create-pr → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-implement 27
+        │
+        ├─► Step 1: Gather
+        │   - Run: gh issue view <N> (the Goal + "Done When")
+        │   - If the title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for the need behind the issue
+        │   - See what changed on the branch, against the repo's default branch:
+        │     git diff <default>...HEAD   (derive <default>, don't hardcode `main`)
+        │   - If there are no changes, report and stop (run /dw-implement first)
+        │
+        ├─► Step 2: Delivers the issue
+        │   - [ ] Every "Done When" box is actually satisfied by the changes —
+        │         observable, not asserted. Confirm by running the project's
+        │         standard tooling (build / test / render — whatever /dw-implement
+        │         used), not by reading the diff alone
+        │   - [ ] Nothing the issue asked for is missing or stubbed out
+        │   - [ ] The changes match the issue's Goal, not a different problem
+        │
+        ├─► Step 3: Surgical
+        │   - [ ] Every changed line traces to this issue — no unrelated refactors,
+        │         "improvements", or reformatting of adjacent code
+        │   - [ ] No scope creep beyond the issue's Goal (extra features, speculative
+        │         abstractions, config nobody asked for)
+        │   - [ ] No dead code, commented-out blocks, debug prints, or leftover TODOs
+        │   - [ ] Now-unused imports/vars/files the change created are removed
+        │
+        ├─► Step 4: Fits the studio
+        │   - [ ] Matches the project's conventions and existing patterns/style
+        │   - [ ] Core stays target-agnostic — no vendor names/coupling leaked in
+        │         (vendor specifics belong in a profile)
+        │   - [ ] Markdown stays the source of truth; cross-references resolve to
+        │         files that exist
+        │   - [ ] The issue records the work (start / fixes / result) per /dw-implement
+        │
+        ├─► Step 5: Decision
+        │   - PASS: delivers the issue, surgical, fits → ready for a HUMAN to
+        │     review + test, then open a PR (/dw-create-pr <N>) — don't auto-advance
+        │   - REVISE: specific findings — fix on the branch, smallest blast radius
+        │     first (remove leaked scope, fill a gap, tighten); commit
+        │   - HAND BACK: the approach is wrong (wrong design, misread the issue) →
+        │     comment the issue and route back to /dw-implement
+        │
+        └─► Step 6: Report
+            - Per finding: the exact file:line + the smallest fix
+            - A delivery verdict against the issue's "Done When"
+            - The issue link + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-implement 6
+
+**Agent reads the issue + the branch diff, runs the checks:**
+
+    Delivers the issue (vs "Done When"):
+    ✓ design/wireframes/ holds tokens + components.css/js + components.html
+    ✓ no RUCKUS/R1 strings; brand neutral + configurable on qa-sidebar
+    ✓ demo content target-agnostic
+    ✓ components.html renders standalone in light + dark
+
+    Surgical:
+    ✓ only design/ added + two pointer lines in code/README.md
+    ✓ no dead code / debug leftovers; no unrelated edits
+
+    Fits the studio:
+    ✓ core stays target-agnostic; markdown source of truth intact
+
+**Output:**
+
+    PASS — #6 delivers the issue and stays surgical.
+    A human reviews + tests; open a PR with /dw-create-pr 6 when ready.
+
+(Illustrative — a clean implementation. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly
+- Reviews the local implementation result before it becomes a PR — pairs with
+  /dw-implement the way /dw-review-tasks pairs /dw-tasks
+- This is the substance gate (delivers + surgical), run on the local diff before
+  the PR — there is no separate PR-review command. PR mechanics (linkage, labels)
+  are handled by /dw-create-pr and /dw-merge, and a human reviews + tests the PR
+  before merge.
+- Surgical-change bar mirrors the project's CLAUDE.md (every changed line traces to
+  the request; clean up only your own orphans)
+- When fixing, change only what a finding points to — don't rewrite sound work
+```

--- a/commands/dev-workflow/dw-review-implement.md
+++ b/commands/dev-workflow/dw-review-implement.md
@@ -11,7 +11,7 @@ Issue number: {{input}}
 Quality-gates the work done by `/dw-implement` before it becomes a PR. Checks that
 the changes on the branch **deliver the issue** (every "Done When" is actually
 satisfied) and stay **surgical** (every changed line traces to the issue — no scope
-creep, dead code, or debug leftovers) while **fitting the studio**. Fixes small
+creep, dead code, or debug leftovers) while **fitting the project**. Fixes small
 findings on the branch in place, or hands back to `/dw-implement` if the approach is
 wrong.
 
@@ -49,7 +49,7 @@ Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
         │   - [ ] No dead code, commented-out blocks, debug prints, or leftover TODOs
         │   - [ ] Now-unused imports/vars/files the change created are removed
         │
-        ├─► Step 4: Fits the studio
+        ├─► Step 4: Fits the project
         │   - [ ] Matches the project's conventions and existing patterns/style
         │   - [ ] Core stays target-agnostic — no vendor names/coupling leaked in
         │         (vendor specifics belong in a profile)

--- a/commands/dev-workflow/dw-review-implement.md
+++ b/commands/dev-workflow/dw-review-implement.md
@@ -72,34 +72,6 @@ Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
 
 ---
 
-## EXAMPLE
-
-    /dw-review-implement 6
-
-**Agent reads the issue + the branch diff, runs the checks:**
-
-    Delivers the issue (vs "Done When"):
-    ✓ design/wireframes/ holds tokens + components.css/js + components.html
-    ✓ no RUCKUS/R1 strings; brand neutral + configurable on qa-sidebar
-    ✓ demo content target-agnostic
-    ✓ components.html renders standalone in light + dark
-
-    Surgical:
-    ✓ only design/ added + two pointer lines in code/README.md
-    ✓ no dead code / debug leftovers; no unrelated edits
-
-    Fits the studio:
-    ✓ core stays target-agnostic; markdown source of truth intact
-
-**Output:**
-
-    PASS — #6 delivers the issue and stays surgical.
-    A human reviews + tests; open a PR with /dw-create-pr 6 when ready.
-
-(Illustrative — a clean implementation. Real reviews often return REVISE.)
-
----
-
 ## API Notes
 
 - Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly

--- a/commands/dev-workflow/dw-review-story.md
+++ b/commands/dev-workflow/dw-review-story.md
@@ -39,7 +39,7 @@ hands it back to `/dw-story` if the need itself is unclear.
         │   - [ ] No implementation detail in the body — no specific files, APIs,
         │         frameworks, data shapes, or step-by-step "how"
         │   - [ ] Success Looks Like describes observable user-facing results, not
-        │         implementation steps ("the studio shows the stories", not "parse
+        │         implementation steps ("the project shows the stories", not "parse
         │         markdown with X and render with Y")
         │   - [ ] The technical / uncertain "how" lives in Open Questions, deferred
         │         to the issue — it is not asserted as decided in the body
@@ -66,10 +66,10 @@ hands it back to `/dw-story` if the need itself is unclear.
 **Agent reads the story, runs both checklists:**
 
     Completeness:
-    ✓ Title specific — "See the project's stories in the studio"
+    ✓ Title specific — "See the project's stories"
     ✓ User Story — role + action + benefit all present
-    ✓ The Need — explains why (studio is the face over the markdown source of truth)
-    ✓ Success Looks Like — observable (studio shows stories, reflects changes)
+    ✓ The Need — explains why (the project is the face over the markdown source of truth)
+    ✓ Success Looks Like — observable (the project shows stories, reflects changes)
     ✓ Open Questions — presentation, status, read strategy all deferred
     ✓ Status — Created date present
 

--- a/commands/dev-workflow/dw-review-story.md
+++ b/commands/dev-workflow/dw-review-story.md
@@ -1,0 +1,96 @@
+# Review a User Story
+
+```
+Review a story for completeness and ensure it stays a goal document, not a spec.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates a story written by `/dw-story` before it becomes work. Checks two
+things: the story is **complete** (every goal section is present and substantive),
+and it is a **goal document, not a spec** (it states the need and the outcome, and
+leaves the *how* to the GitHub issue). Reports findings and revises the story, or
+hands it back to `/dw-story` if the need itself is unclear.
+
+---
+
+## WORKFLOW
+
+    /dw-review-story STORY-001
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Completeness Checklist
+        │   - [ ] Title is specific (not a placeholder like "[Title]")
+        │   - [ ] User Story has a real role, action, AND benefit — the "so that"
+        │         is a genuine benefit, not a restatement of the action
+        │   - [ ] The Need explains the problem behind the request (the why), in the
+        │         user's terms — not how it will be built
+        │   - [ ] Success Looks Like lists outcomes someone could actually observe
+        │   - [ ] Open Questions captures what's genuinely unresolved (or says
+        │         "none known" — empty-because-skipped is a finding)
+        │   - [ ] Status has a Created date
+        │
+        ├─► Step 3: Goal-not-Spec Checklist
+        │   - [ ] No implementation detail in the body — no specific files, APIs,
+        │         frameworks, data shapes, or step-by-step "how"
+        │   - [ ] Success Looks Like describes observable user-facing results, not
+        │         implementation steps ("the studio shows the stories", not "parse
+        │         markdown with X and render with Y")
+        │   - [ ] The technical / uncertain "how" lives in Open Questions, deferred
+        │         to the issue — it is not asserted as decided in the body
+        │   - [ ] No acceptance-criteria checklist acting as a build spec
+        │   - [ ] The whole story is decidable by someone who won't implement it
+        │
+        ├─► Step 4: Decision
+        │   - PASS: both checklists clear → report ✓ and suggest /dw-tasks STORY-XXX
+        │   - REVISE: list each finding with the exact line, then fix in place —
+        │     remove leaked spec, fill missing sections, reword success into outcomes
+        │   - HAND BACK: if the *need* itself is unclear or wrong (not just the
+        │     wording), stop and route to /dw-story to re-capture it with the user
+        │
+        └─► Step 5: Report
+            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
+            - Print the path to the story and the suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-story STORY-001
+
+**Agent reads the story, runs both checklists:**
+
+    Completeness:
+    ✓ Title specific — "See the project's stories in the studio"
+    ✓ User Story — role + action + benefit all present
+    ✓ The Need — explains why (studio is the face over the markdown source of truth)
+    ✓ Success Looks Like — observable (studio shows stories, reflects changes)
+    ✓ Open Questions — presentation, status, read strategy all deferred
+    ✓ Status — Created date present
+
+    Goal-not-Spec:
+    ✓ No files/APIs/frameworks asserted in the body
+    ✓ Success is outcome-based, not implementation steps
+    ✓ The "how" sits in Open Questions
+    ✓ No build-spec checklist
+
+**Output:**
+
+    PASS — STORY-001 is complete and stays a goal.
+    docs/stories/STORY-001.md
+    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+---
+
+## API Notes
+
+- Reads only the story file — no GitHub calls
+- The story is a goal; the issue is where the *how* and its history live (see
+  docs/stories/README.md)
+- When revising, change only what a finding points to — don't rewrite a sound story
+```

--- a/commands/dev-workflow/dw-review-tasks.md
+++ b/commands/dev-workflow/dw-review-tasks.md
@@ -1,0 +1,103 @@
+# Review the Tasks for a Story
+
+```
+Review the GitHub issues a story was broken into — do they cover the story, and does
+each stay a lean goal rather than a frozen spec?
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates the issues created by `/dw-tasks` before implementation starts. Checks
+that **together they cover the story**, and that **each is one small, testable job
+that leaves the *how* to develop on the issue** (not front-loaded as a spec). Fixes
+issue bodies / labels / links in place, or sends the breakdown back to `/dw-tasks` if
+it's wrong.
+
+Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-tasks STORY-001
+        │
+        ├─► Step 1: Gather
+        │   - If no story ID, list docs/stories/ and ask which to review
+        │   - Read docs/stories/STORY-XXX.md (the goal + "Success Looks Like")
+        │   - Find the plan issue (if any): note its number <plan> — none means
+        │     trivial work that skipped the plan stage:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state all
+        │   - List its task issues (the plan issue is the parent, not a task):
+        │     gh issue list --search "[STORY-XXX]" --state all --json number,title,labels,body
+        │   - If no issues exist, report and stop (run /dw-tasks first)
+        │
+        ├─► Step 2: Coverage — the issues vs the story (and plan)
+        │   - [ ] Every item in the story's "Success Looks Like" is covered by an issue
+        │   - [ ] Nothing essential to delivering the story is missing
+        │   - [ ] No issue goes beyond the story's goal — each traces back to the need
+        │   - [ ] When a plan exists: each task links back to it ("Part of #<plan>") —
+        │         flag any task missing the link. No plan → skip (trivial path).
+        │
+        ├─► Step 3: Each issue
+        │   - [ ] One clear job (title + Goal say one thing)
+        │   - [ ] Small enough to finish in a session; independent where it can be
+        │   - [ ] "Done When" is observable — checkable without ambiguity
+        │   - [ ] Body is lean (Context / Goal / Done When); the *how* is NOT frozen in
+        │         — it's left to develop on the issue (research / PoC / comments)
+        │   - [ ] Type + priority labels make sense
+        │
+        ├─► Step 4: Across the set
+        │   - [ ] No two issues substantially duplicate each other
+        │   - [ ] Dependencies/links are sane (no cycles) and the order is buildable
+        │
+        ├─► Step 5: Decision
+        │   - PASS: covers the story + each issue is clean → suggest /dw-implement <first>
+        │   - REVISE: specific fixes — edit the issue body / labels / links in place
+        │     (gh issue edit), or comment what's missing
+        │   - RE-SPLIT: the breakdown itself is wrong (gaps, wrong boundaries, overlap)
+        │     → back to /dw-tasks to re-decompose
+        │
+        └─► Step 6: Report
+            - Per issue: verdict + findings
+            - A coverage verdict against the story
+            - The story path + issue links + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-tasks STORY-007
+
+**Agent reads the story + its issues, runs the checks:**
+
+    Coverage (vs the story's "Success Looks Like"):
+    ✓ <outcome A>  → #21
+    ✓ <outcome B>  → #22
+    ~ nothing essential missing; no issue exceeds the goal
+
+    Each issue:
+    ✓ #21 one job · Done When observable · lean body (Context / Goal / Done When)
+    ✓ #22 one job · Done When observable · lean body
+
+    Across the set: no overlap; deps are sane and the order is buildable
+
+**Output:**
+
+    PASS — the breakdown covers STORY-007 and each issue stays a goal.
+    Next: /dw-implement 21
+
+(Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read (and, on REVISE, edit) the issues — read-mostly
+- The story is the goal; these issues are the agreed work — keep them lean, the how
+  lives in their comments/history (see docs/stories/README.md)
+- When fixing, change only what a finding points to — don't rewrite a sound breakdown
+```

--- a/commands/dev-workflow/dw-story.md
+++ b/commands/dev-workflow/dw-story.md
@@ -7,7 +7,10 @@ Create a user story file from user input.
 
 ## PURPOSE
 
-Transform user input into a structured user story file saved to `docs/stories/`.
+Capture the user's **need** as a story file saved to `docs/stories/`. A story is a
+**goal, not a spec** — it states what the user needs and why, and leaves the *how*
+open. Implementation detail (affected files, APIs, design) is worked out later on the
+GitHub issue, not here. See `docs/stories/README.md`.
 
 ---
 
@@ -19,14 +22,16 @@ Check `docs/stories/` for existing story files. Generate the next sequential ID:
 - Format: `STORY-XXX` (e.g., STORY-001, STORY-002)
 - If no stories exist, start with STORY-001
 
-### Step 2: Clarify Requirements
+### Step 2: Clarify the Need
 
-If the user input is vague, ask clarifying questions:
-- What is the expected behavior?
-- What systems or resources does this affect?
-- Are there any edge cases to consider?
+If the user input is vague, ask questions that sharpen the **need** — not the
+implementation:
+- Who is the user, and what are they trying to achieve?
+- Why does it matter — what's the benefit or the problem behind the request?
+- What would success look like from their point of view?
 
-If the input is clear enough, proceed directly.
+Do **not** ask about affected files, edge cases, or design here — that gets worked
+out on the issue. If the need is clear enough, proceed directly.
 
 ### Step 3: Write Story File
 
@@ -41,33 +46,35 @@ As a [role],
 I want to [action],
 So that [benefit].
 
-## Description
+## The Need
 
-[Expanded description from user input]
+[The problem behind the request — what the user is trying to achieve and why, in
+their terms.]
 
-## Acceptance Criteria
+## Success Looks Like
 
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+[The outcome that means this is done, described as observable user-facing results —
+not implementation steps.]
 
-## Technical Notes
+## Open Questions
 
-- Affected files: [list of files likely to change]
-- Dependencies: [commands, MCP tools, or APIs involved]
+[What still has to be figured out — resolved later on the GitHub issue via research,
+proof of concept, or clarification. The "how" goes here, not above.]
 
 ## Status
 
 - Created: [date]
-- Tasks: none
-- Tests: none
+- Issues: none
 ```
 
 ### Step 4: Confirm
 
 Show the user the created story and suggest next steps:
-- `/dw-plan` to break into GitHub issues
-- `/tw-plan-init` to create a test plan (if QA-related)
+- `/dw-review-story STORY-XXX` to check it's complete and still a goal, not a spec
+- `/dw-plan STORY-XXX` to research the approach and write the plan issue (the agreed
+  *how*), reviewed before it's broken into tasks
+- Trivial / single-task work can skip the plan — `/dw-tasks STORY-XXX` straight away
+- `/qw-plan` to plan what to test (if QA-related)
 
 ---
 

--- a/commands/dev-workflow/dw-tasks.md
+++ b/commands/dev-workflow/dw-tasks.md
@@ -1,19 +1,22 @@
-# Break Story into GitHub Issues
+# Break a Plan into GitHub Task Issues
 
 ```
-Read a user story file and create GitHub issues for each task.
+Break a reviewed plan (or a story) into GitHub task issues, each linked back to it.
 
 Story ID: {{input}}
 
 ## PURPOSE
 
-Reads an existing story file from `docs/stories/STORY-XXX.md` and breaks it into
-implementable GitHub issues. Each issue is linked back to the story via title prefix.
-Updates the story file with created issue numbers.
+Reads the reviewed **plan issue** for a story (`[STORY-XXX] Plan`, written by `/dw-plan`)
+and breaks its approach into implementable GitHub task issues, each linking back to the
+plan. When no plan issue exists — trivial work that skipped the plan stage — it falls
+back to breaking the story directly. Updates the story file with the created issue
+numbers. See `.claude/rules/dev-workflow.md`.
 
-Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue):
+Fits in the dev-workflow:
 
-    dw-story → dw-tasks → dw-implement → dw-create-pr → dw-review-pr → dw-merge
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
 
 ---
 
@@ -21,14 +24,19 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 
     /dw-tasks STORY-003
         │
-        ├─► Step 1: Read the Story
+        ├─► Step 1: Read the plan (or the story)
         │   - If no story ID provided, list files in docs/stories/ and ask user to pick
-        │   - Read docs/stories/STORY-XXX.md
-        │   - Extract: title, acceptance criteria, technical notes
+        │   - Read docs/stories/STORY-XXX.md for the need + "Success Looks Like"
+        │   - Find the reviewed plan issue:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state open
+        │     • If found: read it — its Approach + Acceptance Criteria are what you
+        │       break into tasks (the plan is the agreed how). Note its number <plan>.
+        │     • If none: fall back to breaking the story directly (trivial work that
+        │       skipped the plan stage). <plan> is empty.
         │   - If the story file doesn't exist, report and stop
         │
         ├─► Step 2: Break into Tasks
-        │   - Analyze the story and break it into tasks
+        │   - Break the plan's approach (or the story, when no plan) into tasks
         │   - Each task should be:
         │     • Small — completable in one session
         │     • Independent — minimal dependencies between tasks
@@ -52,30 +60,32 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
         ├─► Step 5: Create GitHub Issues
         │   - One issue per task
         │   - Title: [STORY-XXX] Task description
-        │   - Body:
+        │   - Body — start lean; the issue grows as the *how* is worked out
+        │     (research, PoC, clarification, fixes) and recorded in comments:
         │       ## Context
-        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md)
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md) · plan #<plan>
         │
-        │       ## Acceptance Criteria
-        │       - [ ] [criterion from task breakdown]
+        │       ## Goal
+        │       [what this task achieves, from the plan's approach / the story's need]
         │
-        │       ## Technical Notes
-        │       [relevant notes from the story]
-        │   - Labels: type + priority (infer from story content)
-        │   - Link related issues: "Part of STORY-XXX"
+        │       ## Done When
+        │       - [ ] [observable done condition for this task]
+        │   - Labels: type + priority (infer from the plan / story content)
+        │   - Trace back: "Part of #<plan>" in the body links each task to the plan
+        │     issue (GitHub backlinks it). Omit the plan reference when there is none.
         │
         ├─► Step 6: Update Story File
         │   - Update the Status section in docs/stories/STORY-XXX.md:
         │     ## Status
         │     - Created: [original date]
-        │     - Tasks: #1, #2, #3
-        │     - Tests: none
+        │     - Issues: #1, #2, #3
         │
         └─► Step 7: Report
             - Show table of created issues:
               | Issue | Title | Type | Priority |
             - Suggest implementation order based on dependencies
-            - Suggest: /dw-implement <N> to start on the first task
+            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
+              /dw-implement <N> to start on the first task
 
 ---
 
@@ -83,13 +93,14 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 
     /dw-tasks STORY-003
 
-**Agent reads story, breaks into tasks, creates issues:**
+**Agent reads the plan, breaks it into tasks, creates issues:**
 
     $ cat docs/stories/STORY-003.md
-    $ gh issue list --search "[STORY-003]" --state all
+    $ gh issue list --search "[STORY-003] Plan" --label plan --state open   # → plan #28
+    $ gh issue list --search "[STORY-003]" --state all                      # dup check
     $ gh issue create --title "[STORY-003] Add input validation" \
         --label "enhancement" --label "priority:high" \
-        --body "## Context\nPart of STORY-003\n\n## Acceptance Criteria\n..."
+        --body "## Context\nPart of STORY-003 · plan #28\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
     $ gh issue create --title "[STORY-003] Add error response formatting" \
         --label "enhancement" --label "priority:medium" \
         --body "..."
@@ -98,8 +109,7 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 
     ## Status
     - Created: 2026-04-01
-    - Tasks: #15, #16
-    - Tests: none
+    - Issues: #15, #16
 
 **Output:**
 
@@ -118,5 +128,8 @@ Fits between `/dw-story` (creates story) and `/dw-implement` (works on an issue)
 - Uses `gh` CLI for issue operations
 - Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
 - Issue titles use `[STORY-XXX]` prefix for traceability
-- The story file is the persistent record linking requirements → tasks → tests
+- The reviewed plan issue (`[STORY-XXX] Plan`, from /dw-plan) is the source for the
+  breakdown when present, and each task links back to it; no plan → break the story
+- The story file records the need; the issue is the single source of truth for *how*,
+  growing with research, decisions, and fixes as the work proceeds
 ```

--- a/commands/dev-workflow/dw-test-design.md
+++ b/commands/dev-workflow/dw-test-design.md
@@ -23,8 +23,10 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         ├─► Step 1: Understand What Was Implemented
         │   - Run: gh issue view <N>
         │   - Read the acceptance criteria and technical notes
-        │   - Run: git log --oneline main..HEAD  (see what changed)
-        │   - Run: git diff main --stat  (see which files changed)
+        │   - See what changed vs the repo's default branch — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git log --oneline <default>..HEAD and
+        │     git diff <default> --stat
         │   - Identify what needs test coverage
         │
         ├─► Step 2: Detect Test Infrastructure


### PR DESCRIPTION
## Summary
Bring `commands/dev-workflow/` up to the plan-stage version from `ai-qa-step-graph`:
- **dw-plan** now produces a durable `[STORY-XXX] Plan` GitHub issue (human-reviewed) before **dw-tasks** decomposes it (`Part of #<plan>`); **dw-implement** reads the plan as a checkpoint.
- Adds the review-pairing commands **dw-review-story / dw-review-tasks / dw-review-implement**.
- Adds `.claude/rules/dev-workflow.md`, genericized for this repo (no qa-workflow / `make ci` / `reviewing-artifacts` / CLAUDE.md §5), with `paths:` pointing at `commands/dev-workflow/`.

Overwrote in `commands/dev-workflow/` (this repo's active location) per the agreed plan.

## ⚠️ Deferred to a follow-up story (the folder reconciliation)
This repo keeps commands in `commands/` (not `.claude/commands/`), which is the root cause of the awkwardness here. A dedicated story should:
1. Migrate `commands/` + `skills/` → `.claude/` (the Claude Code convention).
2. Update the install flow + docs that reference the old paths.
3. Update CLAUDE.md's **### Dev Workflow Commands** list (it still shows the old 8-command set incl. `dw-review-pr`, and is missing the new review trio).
4. Resolve **`dw-review-pr`** — left in place (superseded by `/review` + `dw-review-implement`); removing it now would dangle the CLAUDE.md reference.

This PR is just the command overwrite + the rule; it deliberately does **not** touch CLAUDE.md or the install flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)