### PR TITLE
Add the qa-workflow authoring (A) — the qw pair for dev-workflow (#66)

### DIFF
--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "commands/qa-workflow/**/*.md"
+---
+
+# qa-workflow
+
+A sibling to `dev-workflow`. Where dev-workflow turns a need into shipped code, qa-workflow
+turns a story into **trustworthy test docs** — readable markdown in `docs/tests/`, authored
+from a reviewed test plan. This repo owns the **authoring** half (markdown + GitHub); binding
+those docs to a runner and running them is the project's own layer.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md   ──or──  "write a test for X"   (on request)
+            │
+            ▼
+   qw-plan ───────► qw-review-plan      what to test — scenarios persisted as the
+            │                            [STORY-XXX] Test Plan issue
+            ▼
+   qw-cases ──────► qw-review-cases     write docs/tests/TS-*.md (the format contract)
+            │
+            ▼
+   → hand off to the project's binding + run layer
+```
+
+## The test-plan issue
+
+`qw-plan`'s scenarios persist as a **GitHub issue**, titled `[STORY-XXX] Test Plan`, labelled
+`test-plan` (distinct from dev's `[STORY-XXX] Plan`). `qw-review-plan` reviews it; `qw-cases`
+reads it and records the issue number in each `TS-*.md` `plan:` field.
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `qw-plan`  | `qw-review-plan`  | does the plan cover the story? |
+| `qw-cases` | `qw-review-cases` | each doc: one job, observable, traces back |
+
+No producer ships without a review covering its output.
+
+## What this owns — and what it hands off
+
+- **Owns:** the authoring flow + the `docs/tests/` test-doc format (the contract). Self-contained
+  — markdown + GitHub only.
+- **Hands off:** binding each case to an executable and running it is the **project's binding +
+  run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
+
+The format a test doc must follow is `docs/tests/README.md`.

--- a/commands/qa-workflow/qw-cases.md
+++ b/commands/qa-workflow/qw-cases.md
@@ -1,0 +1,62 @@
+# Write the Test Docs
+
+```
+Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
+steps where a reuse index is available, instead of re-inventing them.
+
+Target: the reviewed `[STORY-XXX] Test Plan` issue from `/qw-review-plan` (its scenarios).
+
+## PURPOSE
+
+The authoring producer of the qa-workflow — the test analogue of `dw-implement`.
+Writes each planned scenario as a `docs/tests/TS-*.md` doc in the format contract
+(docs/tests/README.md): front-matter + cases, each case a Steps table of
+Action / Expected Result rows.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
+
+---
+
+## WORKFLOW
+
+    /qw-cases STORY-003
+        │
+        ├─► Step 1: Read the test-plan issue
+        │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     Read its scenarios; note its number <plan>. (No plan issue → the scenarios
+        │     came from /qw-plan in chat; <plan> is absent.)
+        │
+        ├─► Step 2: One file per scenario
+        │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
+        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       plan: <plan> (the test-plan issue number — omit when there is none),
+        │       issue, status: green
+        │   - (Format and field meanings: docs/tests/README.md.)
+        │
+        ├─► Step 3: Write each case (TC) — reuse before re-inventing
+        │   - If the project has a reuse index, query it before writing: is the case's
+        │     objective already covered? is there a vetted step for the action you mean?
+        │     Reuse or extend a close match instead of coining a near-duplicate (optional).
+        │   - Fill the Steps table: each row one Action + its Expected Result.
+        │
+        └─► Step 4: Hand off
+            - Run `/qw-review-cases` to gate the docs.
+            - Reviewed docs then hand to the project's binding + run layer — bind each case
+              to its executable and run it. (If a reuse index exists, the new docs get
+              indexed there.)
+
+---
+
+## API Notes
+
+- Reuse is optional: if the project has a reuse index, query it for a vetted case or
+  step before authoring a near-duplicate, so coverage converges instead of duplicating.
+- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- `plan`: the `[STORY-XXX] Test Plan` issue number — the scenario source and the trace
+  back (see docs/tests/README.md). Absent for ad-hoc tests written without a plan.
+- Producer paired with `/qw-review-cases`.
+```

--- a/commands/qa-workflow/qw-plan.md
+++ b/commands/qa-workflow/qw-plan.md
@@ -1,0 +1,82 @@
+# Plan What to Test
+
+```
+Derive the scenarios that verify a story (or an on-request target) — the "what
+to test", before any test doc is written.
+
+Target: a STORY-XXX, or an ad-hoc request ("write a test for X").
+
+## PURPOSE
+
+The front of the qa-workflow — the test analogue of reading a story before
+implementing. It produces a short list of **scenarios** (each a TS-to-be) that together
+cover the need, and **persists them as a `[STORY-XXX] Test Plan` GitHub issue** so the plan
+survives the session and `qw-review-plan` reviews a real artifact (not a chat message);
+`qw-cases` then writes against it. See `.claude/rules/qa-workflow.md`.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
+
+---
+
+## WORKFLOW
+
+    /qw-plan STORY-003
+        │
+        ├─► Step 1: Read the need
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If an on-request target: restate what behaviour is to be verified.
+        │
+        ├─► Step 2: Check what already exists
+        │   - List the docs/tests/ scenarios already linked to this story:
+        │       grep -l 'story: STORY-XXX' docs/tests/
+        │   - If the project has a reuse index, query it for cases already covering this
+        │     behaviour, so the plan reuses vetted coverage instead of duplicating it (optional).
+        │   - Check for an existing test-plan issue (extend it, don't duplicate):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     (`test-plan` is qa's own label — distinct from dev's `plan`)
+        │
+        ├─► Step 3: Propose scenarios
+        │   - Break the need into scenarios (TS-to-be), each:
+        │     • one coherent slice of behaviour, • independently runnable,
+        │     • mappable to one or more of the project's executables (bound later, project layer).
+        │   - For each, name the cases (TC-to-be) it will hold, at a sentence each.
+        │
+        ├─► Step 4: Open the test-plan issue
+        │   - Ensure the label (idempotent):
+        │       gh label create "test-plan" --color "006b75" --description "The qa test plan for a story (what to test)" --force
+        │   - Write the scenarios into a GitHub issue so they outlive the session
+        │     (the template below). Title: [STORY-XXX] Test Plan
+        │     (ad-hoc target → "Test Plan: <subject>", no story prefix). Label: test-plan.
+        │       gh issue create --label "test-plan" --title "[STORY-XXX] Test Plan" --body "…"
+        │
+        └─► Step 5: Hand off — stop for review
+            - Show the test-plan issue URL for `/qw-review-plan`, then `/qw-cases`.
+            - STOP. Do NOT write TS docs — that is `/qw-cases`.
+
+---
+
+## TEST-PLAN ISSUE BODY
+
+    ## Scenarios
+    ### TS-01 (to-be): <scenario title>
+    - Objective: <the slice of behaviour it verifies>
+    - Cases: TC-01 <one line>, TC-02 <one line>
+
+    ### TS-02 (to-be): …
+
+    Part of STORY-XXX
+
+---
+
+## API Notes
+
+- A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.
+- The scenarios persist as a `[STORY-XXX] Test Plan` issue (label `test-plan`; ad-hoc →
+  `Test Plan: <subject>`) — the same plan-as-issue form `dev-workflow` uses, with its own
+  `test-plan` label so it never collides with dev's `[STORY-XXX] Plan` (label `plan`).
+- The story is the goal; keep the plan to coverage, not step detail.
+- Producer paired with `/qw-review-plan`, which reviews the issue.
+```

--- a/commands/qa-workflow/qw-review-cases.md
+++ b/commands/qa-workflow/qw-review-cases.md
@@ -1,0 +1,48 @@
+# Review the Test Docs
+
+```
+Check each test doc does one clear job, has observable steps, and traces back to
+its story — before it is bound and run.
+
+Target: the docs/tests/TS-*.md docs written by /qw-cases for a STORY-XXX.
+
+## PURPOSE
+
+The paired review for `/qw-cases`. The test-doc analogue of `dw-review-implement`:
+gates the written docs for quality and traceability.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
+
+---
+
+## WORKFLOW
+
+    /qw-review-cases STORY-003
+        │
+        ├─► Step 1: Each doc
+        │   - [ ] One scenario, one job; cases are coherent slices of it.
+        │   - [ ] Front-matter complete and resolvable: story file exists,
+        │         story_hash matches it, namespace set, status present.
+        │   - [ ] Each step's Expected Result is observable — checkable, not vague.
+        │   - [ ] Conforms to the format contract (docs/tests/README.md).
+        │
+        ├─► Step 2: Traceability
+        │   - [ ] story → doc resolves both ways (→ executable once bound, project layer).
+        │   - [ ] No duplicate of an existing scenario for the same story.
+        │
+        └─► Step 3: Decision
+            - PASS: docs do their job and trace back → hand off to the project's binding
+              + run layer (bind each case to its executable, then run it).
+            - REVISE: fix the named doc — smallest change first — and re-check.
+
+---
+
+## API Notes
+
+- This reviews the *doc* (intent); `/qw-review-bind` reviews the doc↔script binding.
+- Published-deliverable phrasing/typography is out of scope here.
+- Review paired with the producer `/qw-cases`.
+```

--- a/commands/qa-workflow/qw-review-plan.md
+++ b/commands/qa-workflow/qw-review-plan.md
@@ -1,0 +1,54 @@
+# Review the Test Plan
+
+```
+Check the proposed scenarios cover the story — and stay coverage, not a frozen
+step-by-step spec.
+
+Target: the `[STORY-XXX] Test Plan` issue written by `/qw-plan` (label `test-plan`).
+
+## PURPOSE
+
+The paired review for `/qw-plan`. Gates the persisted **test-plan issue** before
+`qw-cases` writes any docs, so coverage gaps are caught cheaply. See
+`.claude/rules/qa-workflow.md`.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases   (the authoring half)
+    → hand off to the project's binding + run layer
+
+---
+
+## WORKFLOW
+
+    /qw-review-plan STORY-003
+        │
+        ├─► Step 1: Read the test-plan issue
+        │   - Find it (`test-plan` is qa's own label — distinct from dev's `plan`):
+        │       gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
+        │     (ad-hoc target: search "Test Plan: <subject>"). Read its scenarios.
+        │   - If none exists, report and stop (run `/qw-plan` first).
+        │
+        ├─► Step 2: Coverage vs the story
+        │   - [ ] Every item in the story's "Success Looks Like" maps to a scenario.
+        │   - [ ] Nothing essential to verifying the story is missing.
+        │   - [ ] No scenario goes beyond the story's need.
+        │
+        ├─► Step 3: Each scenario
+        │   - [ ] One coherent slice; independently runnable.
+        │   - [ ] Maps to at least one of the project's executables (or names the gap).
+        │   - [ ] No duplication of a scenario already in docs/tests/ (grep the story link).
+        │
+        └─► Step 4: Decision (recorded on the issue)
+            - PASS: covers the story → comment "Reviewed — covers the story" on the issue;
+              proceed to `/qw-cases`.
+            - REVISE: comment the missing or excess scenario on the issue; back to `/qw-plan`.
+
+---
+
+## API Notes
+
+- Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.
+- Review paired with the producer `/qw-plan`; it gates the persisted
+  `[STORY-XXX] Test Plan` issue, recording PASS/REVISE as a comment on it.
+```

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,74 @@
+# `docs/tests/` — the test-doc format
+
+Each test is a **readable markdown document** that lives here, close to the story it verifies.
+The markdown is the *canonical* artifact — humans read and review it, and it is the source of
+truth for **why** a test exists and **what** it checks. `qw-cases` writes these; `qw-review-cases`
+reviews them.
+
+Binding a doc to an executable and running it is the **project's binding + run layer** — out of
+scope for this format. This doc defines only the readable artifact.
+
+## One file = one scenario (TS), many cases (TC)
+
+A **scenario** groups related **cases**, each case a sequence of **steps**.
+
+```
+docs/tests/
+  TS-01-<slug>.md     # a scenario: TC-01, TC-02, … each with a Steps table
+  TS-02-….md
+```
+
+- **TS** (scenario) — the file. Holds the front-matter and a `## Why this scenario exists`.
+- **TC** (case) — a `### TC-NN:` section. Has an objective, an optional **`Script:`** line (the
+  binding the project's run layer fills in), and a **Steps** table.
+- **Step** — one row of a case's Steps table: an **Action** and its **Expected Result**.
+
+## Front-matter (scenario level)
+
+```yaml
+---
+id: TS-01                       # scenario id, unique within the namespace
+title: Login succeeds with valid credentials
+namespace: ai-qa-workflow       # which repo/tenant this test belongs to
+story: STORY-003                # the need this scenario verifies (→ docs/stories/STORY-003.md)
+story_hash: 7474d8b6…           # sha256 of the linked story file at last sync (drift anchor)
+plan: 28                        # the [STORY-XXX] Test Plan issue it was authored from (qw-cases sets it)
+status: green                   # green | stale | unbound  (maintained by the project's drift gate)
+---
+```
+
+- `story` + `story_hash` are the drift anchor: when the story changes, its hash no longer matches.
+- `plan` traces the scenario back to the `[STORY-XXX] Test Plan` issue. Optional — absent when a
+  test was written without a plan.
+- `Script:` is **per-TC, not in front-matter** — and is filled by the project's binding layer.
+
+## Case (TC) structure
+
+```markdown
+### TC-01: Valid login
+
+- **Objective:** a known-good user can sign in.
+- **Script:** <filled by the project's binding layer>
+- **Preconditions:** the app is running.
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Enter valid username + password | the form accepts them |
+| 2 | Submit | redirected to the dashboard |
+```
+
+The Steps table is **machine-extractable** on purpose: one row = one `Action → Expected Result`.
+
+## Traceability
+
+- **story → tests:** `grep -l 'story: STORY-XXX' docs/tests/`
+- **test → story:** the front-matter `story:` line.
+- **test → plan:** the front-matter `plan:` line (the Test Plan issue number).
+
+No hand-maintained index — the links live in the files and resolve by `grep`/path.
+
+## Beyond authoring (the project's layer)
+
+`status` values (`green` | `stale` | `unbound`), the `Script:` binding, drift detection, and any
+step-reuse index are the **project's** concern, not this format's. This repo authors the readable
+docs; a consuming project binds + runs + maintains them.


### PR DESCRIPTION
## Summary
Bring the general qa-workflow **authoring** half into this repo, beside `commands/dev-workflow/`, from ai-qa-step-graph's STORY-010 factoring:
- **`commands/qa-workflow/`** — `qw-plan` · `qw-review-plan` · `qw-cases` · `qw-review-cases` (the decoupled, self-contained authoring set: markdown + gh only).
- **`docs/tests/README.md`** — the test-doc format (the A *contract*); `Script:` binding, drift, and step-reuse are noted as the **project's** layers, not here.
- **`.claude/rules/qa-workflow.md`** — the authoring flow + producer→review pairing, paired with `dev-workflow` (`paths:` → `commands/qa-workflow/`).

Purely additive (+370, 0 deletions). The 4 commands are byte-identical to the decoupled source. No `step-store`/`cicd`/runner references — self-contained.

Fixes #66

## Note on concurrency / placement
This repo is mid-restructure (the `issue-61-62-resolve-groups` branch is moving `commands/` → `.claude/`). I branched from `main` and placed qa-workflow in **`commands/qa-workflow/`** to match where `dev-workflow` currently lives — so the in-flight migration relocates both halves together. If you'd prefer `.claude/commands/`, say so.

## Test plan
- [ ] `commands/qa-workflow/` has the 4 authoring commands
- [ ] `docs/tests/README.md` + `.claude/rules/qa-workflow.md` present; references resolve
- [ ] No `step-store`/`cicd`/runner refs
- [ ] Passed `dw-review-implement`

Generated with [Claude Code](https://claude.com/claude-code)