### PR TITLE
Scrub ai-qa-workflow self-references; record agent-* family

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Commands and skills are organized in two tiers to reduce maintenance across mult
 
 ### First-Time Home Setup
 
-When adopting ai-qa-workflow across multiple projects for the first time:
+When adopting agent-workflows across multiple projects for the first time:
 
 1. **Create `~/.claude/CLAUDE.md`** — Define your identity (roles, project types), universal git workflow rules, information leak prevention rules, and the command hierarchy (what's at home vs project level)
 2. **Install home-level commands** — Install the universal commands at `~/.claude/commands/`:

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Enable **issue-driven development** where every change flows from a GitHub issue
 Installation is agent-driven — no installer script, no build step. Your AI agent reads `CLAUDE.md` and does the work.
 
 ```
-git clone https://github.com/dogkeeper886/ai-qa-workflow
+git clone https://github.com/dogkeeper886/agent-workflows
 ```
 
 Then tell your AI agent:
 
-> "Read /path/to/ai-qa-workflow/CLAUDE.md and install the commands I need"
+> "Read /path/to/agent-workflows/CLAUDE.md and install the commands I need"
 
 The agent will:
 1. Detect your project context and configured MCP servers
@@ -165,14 +165,17 @@ Self-improvement and session recording. These live at the home tier (`~/.claude/
 
 ## Related Projects
 
-| Project | Purpose | Repository |
-|---------|---------|------------|
-| **Test Framework Template** | Dual-judge test execution | [dogkeeper886/test-framework-template](https://github.com/dogkeeper886/test-framework-template) |
+This repo is **`agent-workflows`**, part of the `agent-*` family:
+
+| Project | Role | Repository |
+|---------|------|------------|
+| **agent-workflows-runner** | Executes the test scripts the qa-workflow docs map to (rename planned) | [dogkeeper886/test-framework-template](https://github.com/dogkeeper886/test-framework-template) |
+| **agent-studio** | Product layer over the workflows + runner (rename planned) | currently `ai-qa-studio` |
 
 ## Project Structure
 
 ```
-ai-qa-workflow/
+agent-workflows/
 ├── .claude/
 │   ├── commands/
 │   │   ├── dev-workflow/   # Dev lifecycle commands (dw-*)

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -29,7 +29,7 @@ docs/tests/
 ---
 id: TS-01                       # scenario id, unique within the namespace
 title: Login succeeds with valid credentials
-namespace: ai-qa-workflow       # which repo/tenant this test belongs to
+namespace: agent-workflows      # which repo/tenant this test belongs to
 story: STORY-003                # the need this scenario verifies (→ docs/stories/STORY-003.md)
 story_hash: 7474d8b6…           # sha256 of the linked story file at last sync (drift anchor)
 plan: 28                        # the [STORY-XXX] Test Plan issue it was authored from (qw-cases sets it)


### PR DESCRIPTION
## Summary
- Update clone URL, install path, structure tree, CLAUDE.md adoption note, and the test-doc namespace example from `ai-qa-workflow` to `agent-workflows`
- Record the `agent-*` family (agent-workflows / agent-workflows-runner / agent-studio) in Related Projects, honest about the sibling renames still pending

Fixes #73
Part of STORY-002 · plan #71

## Test plan
- [ ] `grep -rn "ai-qa-workflow" --include="*.md" .` returns only STORY-001/STORY-002 history
- [ ] `test-framework-template` link in Related Projects still resolves
- [ ] README/CLAUDE.md read correctly with the new name

> Note: the README's title and QA-only framing are intentionally left for #74 (full reframe).

Generated with [Claude Code](https://claude.com/claude-code)