### PR TITLE
Reframe README around two-workflow story; expand MCP menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI QA Workflow provides two slash-command products for AI coding agents, both living in `.claude/commands/`: **dev-workflow** (a GitHub-driven development lifecycle) and **qa-workflow** (test-doc authoring).
+agent-workflows provides two slash-command products for AI coding agents, both living in `.claude/commands/`: **dev-workflow** (a GitHub-driven development lifecycle) and **qa-workflow** (test-doc authoring).
 
 ## Git Workflow
 
@@ -162,12 +162,9 @@ docs/
 └── tests/         # Test-doc format contract (qa-workflow output)
 ```
 
-### MCP Dependencies
+### MCP servers (optional)
 
-The commands require no MCP servers — the dev-workflow and qa-workflow commands use the `gh` CLI. The following MCP integration is configured but no longer used by any command in this repo:
-- **playwright-mcp** (microsoft/playwright-mcp) - Browser automation
-
-Additional integrations documented in `docs/integrations/` but not currently used by any command: `wpa-mcp` (WPA supplicant control), `radius-sql` (RADIUS database queries).
+The commands require no MCP servers — dev-workflow and qa-workflow run on the `gh` CLI. MCP servers are **optional**: wire any up to extend what an agent can *do* (browser, WiFi, RADIUS, TestLink, Jira/Confluence). See [`docs/integrations/`](docs/integrations/) for the list and setup.
 
 ## Adding New Commands
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# AI QA Workflow
+# agent-workflows
 
-A toolkit of slash commands for AI coding agents: a GitHub-driven development lifecycle (**dev-workflow**) and test-doc authoring (**qa-workflow**), both in `.claude/commands/`.
+Slash commands that make an AI coding agent follow an **exact, documented order** — driven by GitHub issues and a repo's file structure. Two workflows live in `.claude/commands/`:
 
-## Project Goal
+- **dev-workflow** (`dw-*`) — turn a need into shipped work through an ordered lifecycle: story → plan → tasks → implement → PR → merge. Each step is paired with a review; nothing skips ahead. The lifecycle is general — it disciplines any ordered action, not just code.
+- **qa-workflow** (`qw-*`) — author test **docs** kept *separate* from the test scripts, each mapped to the story it verifies (test ↔ script ↔ story). Splitting the doc from the script means coverage isn't silently lost as the code changes across cycles.
 
-Enable **issue-driven development** where every change flows from a GitHub issue through implementation, PR, review, and merge. AI coding agents:
+## Why two workflows
 
-1. **Plan** work as GitHub issues
-2. **Implement** on feature branches with story-aware context
-3. **Ship** through PRs with automated review and merge
+**dev-workflow is the discipline.** An agent that follows the order instead of improvising. Every change flows from a GitHub issue through implementation, review, PR, and merge — the issue is the single source of truth, and each producer (`dw-story`, `dw-plan`, `dw-tasks`, `dw-implement`) is paired with a review so nothing ships ungated.
 
-> **Note:** This repo now ships two products — **dev-workflow** (the issue-driven lifecycle below) and **qa-workflow** (test-doc authoring, `qw-*`). Binding test docs to a runner and executing them is the consuming project's own layer.
+**qa-workflow is the anti-drift layer.** A test is a markdown **doc** (what to verify, mapped to a story); the **script** that runs it lives in the runner repo. The doc records a `story` + `story_hash`, so when the story changes the hash no longer matches and the test is flagged stale — drift is caught instead of quietly accumulating. Authoring is self-contained (markdown + GitHub); executing the scripts is the runner's job — see the [agent-* family](#the-agent-family) below.
 
 ## Notable Features
 
@@ -49,7 +48,7 @@ The agent will:
 **Activate:**
 
 1. Restart your IDE to load new commands
-2. Configure MCP integrations (see [docs/integrations/](docs/integrations/))
+2. (Optional) Wire up MCP servers to extend what your agents can do (see [docs/integrations/](docs/integrations/))
 
 **What's now available:**
 
@@ -142,17 +141,23 @@ Self-improvement and session recording. These live at the home tier (`~/.claude/
 
 ## Documentation
 
-### Integrations
+### Optional MCP servers
 
-**Optional** — documented but not currently called by any command:
+The workflows themselves need no MCP servers — they run on the `gh` CLI. These are **optional**: wire any of them up to extend what your agents can *do* (drive a browser, control WiFi, query a database, work a Jira ticket). The first three ship a full config cheat-sheet; the rest link to their own repos for setup.
 
-- [MCP Playwright](docs/integrations/mcp-playwright.md) - Browser automation
-- [MCP WPA](docs/integrations/mcp-wpa.md) - WPA supplicant control
-- [MCP RADIUS SQL](docs/integrations/mcp-radius-sql.md) - RADIUS database queries
+| Server | Wire an agent to… | Setup |
+|--------|-------------------|-------|
+| **Playwright** | drive a browser for end-to-end web testing | [cheat-sheet](docs/integrations/mcp-playwright.md) |
+| **wpa-mcp** | control WiFi via `wpa_supplicant` | [cheat-sheet](docs/integrations/mcp-wpa.md) |
+| **RADIUS SQL** | query RADIUS auth/accounting records | [cheat-sheet](docs/integrations/mcp-radius-sql.md) |
+| **ai-qa-step-graph** | reuse test steps semantically from a pgvector step-store | [repo](https://github.com/dogkeeper886/ai-qa-step-graph) |
+| **android-wifi-mcp** | control WiFi on Android devices via ADB | [repo](https://github.com/dogkeeper886/android-wifi-mcp) |
+| **testlink-mcp** | read/write cases in [TestLink](https://github.com/dogkeeper886/testlink-code) | [repo](https://github.com/dogkeeper886/testlink-mcp) |
+| **Atlassian Rovo MCP** | work Jira / Confluence from the agent | [docs](https://www.atlassian.com/platform/remote-mcp-server) |
 
-**Related framework:**
+### Related framework
 
-- [Test Framework Template](docs/integrations/test-framework-template.md) - Dual-judge execution
+- [Test Framework Template](docs/integrations/test-framework-template.md) — dual-judge execution; the runner that executes qa-workflow's test scripts
 
 ### Design
 
@@ -163,14 +168,22 @@ Self-improvement and session recording. These live at the home tier (`~/.claude/
 - [Command Format](docs/references/command-format.md) - Slash command format specification
 - [Skill Format](docs/references/skill-format.md) - Skill directory and SKILL.md format
 
-## Related Projects
+## The agent family
 
-This repo is **`agent-workflows`**, part of the `agent-*` family:
+This repo is the **`agent-workflows`** layer — the commands and the test docs they author. Two sibling repos complete the picture:
 
-| Project | Role | Repository |
-|---------|------|------------|
-| **agent-workflows-runner** | Executes the test scripts the qa-workflow docs map to (rename planned) | [dogkeeper886/test-framework-template](https://github.com/dogkeeper886/test-framework-template) |
-| **agent-studio** | Product layer over the workflows + runner (rename planned) | currently `ai-qa-studio` |
+```
+agent-workflows   →   agent-workflows-runner   →   agent-studio
+ (this repo)            (executes the scripts)        (product layer)
+ commands +             the qa-workflow docs          over the workflows
+ test docs              map test → script             + runner
+```
+
+| Repo | Role | Status |
+|------|------|--------|
+| **agent-workflows** (this repo) | dev-workflow + qa-workflow commands and the test docs they author | — |
+| **agent-workflows-runner** | executes the test scripts the qa-workflow docs map to | rename planned ([test-framework-template](https://github.com/dogkeeper886/test-framework-template)) |
+| **agent-studio** | product layer over the workflows + runner | rename planned (currently `ai-qa-studio`) |
 
 ## Project Structure
 

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -1,4 +1,4 @@
-# AI QA Workflow Agent - Design Guidelines
+# agent-workflows — Design Guidelines
 
 ## Core Design Principles
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,6 +1,6 @@
 # MCP Server Configuration Cheat Sheet
 
-Quick reference for configuring MCP servers used by AI QA Workflow commands.
+Quick reference for the **optional** MCP servers you can wire up to extend what agent-workflows agents can do. The workflows need none of these — they run on the `gh` CLI.
 
 ## Configuration Formats
 
@@ -11,11 +11,17 @@ Each MCP server can be configured in two ways:
 
 ## MCP Servers
 
-| Server | Purpose | Runtime Options |
-|--------|---------|-----------------|
+The first three have full config cheat-sheets here; the rest link to their own repos for setup.
+
+| Server | Purpose | Setup |
+|--------|---------|-------|
 | [mcp-playwright](mcp-playwright.md) | Browser automation | NPX, Docker |
-| [mcp-wpa](mcp-wpa.md) | WPA supplicant control | HTTP, Docker |
+| [mcp-wpa](mcp-wpa.md) | WiFi via `wpa_supplicant` | HTTP, Docker |
 | [mcp-radius-sql](mcp-radius-sql.md) | RADIUS database queries | HTTP |
+| [ai-qa-step-graph](https://github.com/dogkeeper886/ai-qa-step-graph) | Semantic test-step reuse (pgvector step-store) | see repo |
+| [android-wifi-mcp](https://github.com/dogkeeper886/android-wifi-mcp) | WiFi control on Android via ADB | see repo |
+| [testlink-mcp](https://github.com/dogkeeper886/testlink-mcp) | TestLink case management | see repo |
+| [Atlassian Rovo MCP](https://www.atlassian.com/platform/remote-mcp-server) | Jira / Confluence | HTTP (remote) |
 | [test-framework-template](test-framework-template.md) | Dual-judge test framework | N/A (not an MCP server) |
 
 ## Prerequisites

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,4 +1,4 @@
-## AI QA Workflow
+## agent-workflows
 
 This section provides AI coding agents with command guidance.
 


### PR DESCRIPTION
## Summary
- Reframe the README around the ordered-discipline / two-workflow story: new `agent-workflows` title, a "Why two workflows" section, and an explanation of qa-workflow's test/script split + `story_hash` drift anchor
- Add an "agent family" ecosystem section (agent-workflows → runner → studio)
- Reframe MCP integrations from "unused debris" into an **optional capability menu**; add ai-qa-step-graph, android-wifi-mcp, testlink-mcp (+ testlink-code), and Atlassian Rovo MCP as list+link; keep the playwright/wpa/radius cheat-sheets; exclude the Ruckus servers
- Sweep the remaining "AI QA Workflow" display-name leftovers (CLAUDE.md, design principles, integrations index, template) that #73's slug-only scrub missed

Fixes #74
Part of STORY-002 · plan #71

## Test plan
- [ ] `grep -rn "AI QA Workflow\|ai-qa-workflow" --include="*.md" .` returns only STORY-001/STORY-002 history
- [ ] All local doc links resolve; the `#the-agent-family` anchor jumps to the ecosystem section
- [ ] Added MCP repo links + the Atlassian Rovo MCP link open correctly
- [ ] README reads as a two-workflow toolkit, not QA-only

> Scope note: spans 5 files because it also finishes the display-name rebrand #73 missed (slug vs spaced name).

Generated with [Claude Code](https://claude.com/claude-code)