### PR TITLE
docs: register doc-workflow alongside dev/qa workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## 5. Dev & QA workflow discipline
+## 5. Workflow discipline
 
 Substantial work flows through a pipeline; each step is a gate that stops for a
 human decision (commands suggest the next, they never auto-run it):
@@ -82,6 +82,15 @@ qw-plan → qw-review-plan → qw-cases → qw-review-cases
 ```
 
 The full flow + pairing lives in `.claude/rules/qa-workflow.md`.
+
+**doc-workflow** is the sibling that turns a codebase into its README — same gated
+discipline:
+
+```
+doc-gen-readme → doc-review-readme → [human reviews] → PR
+```
+
+The full flow + pairing lives in `.claude/rules/doc-workflow.md`.
 
 Two review gates are external skills this toolkit does not own — invoke them by hand:
 - `code-review` (bundled): adversarial diff review. Run after `dw-implement`,

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ git clone https://github.com/dogkeeper886/agent-workflows
 # copy the commands, review skills, and workflow rules into your repo
 cp -r agent-workflows/.claude/commands/dev-workflow  your-repo/.claude/commands/
 cp -r agent-workflows/.claude/commands/qa-workflow   your-repo/.claude/commands/
+cp -r agent-workflows/.claude/commands/doc-workflow  your-repo/.claude/commands/
 cp -r agent-workflows/.claude/skills/*               your-repo/.claude/skills/
 cp -r agent-workflows/.claude/rules/*                your-repo/.claude/rules/
 ```
 
 Restart your IDE to load the new commands. The `dw-*` / `qw-*` commands run on the `gh` CLI — make sure [`gh`](https://cli.github.com/) is installed and authenticated (`gh auth status`).
 
-> The `rules/` files (`dev-workflow.md`, `qa-workflow.md`) carry the full pipeline and the producer→review pairing. Copy them alongside the commands, or the commands' references to them will dangle.
+> The `rules/` files (`dev-workflow.md`, `qa-workflow.md`, `doc-workflow.md`) carry the full pipeline and the producer→review pairing. Copy them alongside the commands, or the commands' references to them will dangle.
 
 ## Usage
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -60,7 +60,7 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## 5. Dev & QA workflow discipline
+## 5. Workflow discipline
 
 Substantial work flows through a pipeline; each step is a gate that stops for a
 human decision (commands suggest the next, they never auto-run it):
@@ -82,6 +82,15 @@ qw-plan → qw-review-plan → qw-cases → qw-review-cases
 ```
 
 The full flow + pairing lives in `.claude/rules/qa-workflow.md`.
+
+**doc-workflow** is the sibling that turns a codebase into its README — same gated
+discipline:
+
+```
+doc-gen-readme → doc-review-readme → [human reviews] → PR
+```
+
+The full flow + pairing lives in `.claude/rules/doc-workflow.md`.
 
 Two review gates are external skills this toolkit does not own — invoke them by hand:
 - `code-review` (bundled): adversarial diff review. Run after `dw-implement`,


### PR DESCRIPTION
## Summary
- `doc-workflow` landed in the recent backport (`592ae41`) but was never wired into the project's own docs. This registers it as a first-class sibling of `dev-workflow` and `qa-workflow`.
- **CLAUDE.md** (+ synced `templates/CLAUDE.md`): broadened §5 title to "Workflow discipline" and added the `doc-gen-readme → doc-review-readme` sibling paragraph pointing at `.claude/rules/doc-workflow.md`.
- **README.md**: install block now copies the `doc-workflow` commands (the `rules/*` glob already copied the rule, leaving a dangling pointer to commands that weren't installed); rules-file note now lists `doc-workflow.md`.

## Scope
Minimal "consistent ship" — makes doc-workflow installable and removes the dangling-pointer risk. Deliberately **not** included: README agent-family section, structure tree, and the "two workflows" diagram still describe only dev + qa. Those are a larger editorial pass for a follow-up.

## Test plan
- [ ] `doc-workflow` referenced in `CLAUDE.md`, `templates/CLAUDE.md`, and `README.md`
- [ ] README install steps copy `doc-workflow` commands so installed repos have the commands the rule references

Generated with [Claude Code](https://claude.com/claude-code)