### PR TITLE
chore(reviewing-artifacts): backport frontmatter-hygiene, flat-skills rule, fold pairing into a question

### DIFF
--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -2,11 +2,11 @@
 name: reviewing-artifacts
 description: |
   Reviews any workflow artifact — the commands, skills, and project docs that are the
-  tooling (READMEs, stories, CLAUDE.md, and the like) — against five goal questions:
+  tooling (READMEs, stories, CLAUDE.md, and the like) — against a few goal questions:
   one clear job, complete, a goal not a frozen spec, fits the project, right for its
-  reader. Also runs a producer→review pairing coverage pass that flags any producer
-  shipped without a paired review. It judges whether an artifact does its job; how a
-  human-read doc (the README, docs/ prose) looks and reads goes to the typography +
+  reader, and (for producers) paired with a review. Its pairing question flags any
+  producer shipped without a paired review. It judges whether an artifact does its job;
+  how a human-read doc (the README, docs/ prose) looks and reads goes to the typography +
   phrasing review. Floor, not ceiling.
 ---
 
@@ -26,7 +26,7 @@ fine-grained **look and words** of a human-read doc — the README, the prose in
 go to `reviewing-typography` (the look) + `reviewing-phrasing` (the words); this skill
 judges whether the artifact does its job (Q5 still asks whether a doc serves its reader).
 
-## The five questions
+## The questions
 
 Ask these of any artifact. The artifact's type shifts which ones bite hardest.
 
@@ -44,59 +44,42 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    rather than a stack it has moved past? Flag coupling to a tool or layout the project
    has genuinely retired or relocated; an integration the project still uses, or a
    deliberate adapter, is not a violation. Cross-references resolve to files that exist.
+   Skills must be flat under `.claude/skills/<name>/` — a foldered skill is undiscoverable;
+   a unit that needs folders to group is a command, not a skill.
 5. **Right for its reader.** Agent-facing (commands, skills): unambiguous instructions
    the agent can follow. Human-facing (README, story): reads like a person wrote it for
    a person — clear, concrete, scannable.
+6. **Paired (producers only).** If this artifact *produces or changes* a deliverable —
+   a `create-`/`sync-`/`publish-`/`draft-`/`init-` step, or a producing gerund skill
+   (`planning-…`, `drafting-…`) — does a review cover its output? Every producer needs a
+   paired review — a standing rule (the `## Producer → review pairing` tables in
+   `.claude/rules/*.md`). A producer with no
+   review is a gap to flag, not an exception; one that yields no outward deliverable
+   (internal scaffolding, an authoring input) is exempt, not a gap. This skill is the
+   enforcement arm. Bites only on producers.
 
 Where each type leans:
 
 | Artifact | Leans on |
 |----------|----------|
-| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it) |
+| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it), Q6 if it produces |
 | README / user doc | Q5 (reads for a human), Q1 (one clear job) |
 | Story | Q3 (goal, not spec) — this is what `dw-review-story` checks at the story stage |
 | CLAUDE.md | Q2/Q4 (matches the repo as it actually is — no orphaned references) |
-
-## Producer→review pairing (coverage pass)
-
-A standing rule (CLAUDE.md → "Review pairing"): every **producer** has a **paired
-review**. When the scope is the whole workflow — or any change that adds/edits a
-producer — run this coverage pass on top of the five questions.
-
-It is a **method, not a fixed list** — derive the producers and reviews from whatever
-units exist now; don't hardcode an inventory that will drift.
-
-1. **List the producers.** A producer is any unit that *creates, syncs, publishes, or
-   drafts a deliverable* — by name (`create-`, `sync-`, `publish-`, `draft-`, `init-`)
-   or by what it does (a producing gerund skill — a name like `planning-…`, `drafting-…`).
-2. **List the reviews.** Any unit whose job is to *check a result* — `*-review`,
-   `*-verify`, the `reviewing-*` skills, a typography/format audit.
-3. **Match each producer to the review that covers its output.** A pairing is real only
-   if some review actually inspects what that producer makes.
-4. **Flag the gaps.** Name every producer with **no** review covering its output — that
-   is a pairing violation. Note the missing review and where it would live.
-5. **Mark the exempt.** A producer that yields no outward deliverable to review —
-   internal scaffolding, a visual folded into an already-reviewed doc, an authoring
-   input, tooling logs — is **exempt**, not a gap. List it as exempt and say why.
-
-Report pairings as a small table and list the unpaired producers as findings:
-
-```
-Producer → Review
-<producer>           → <review>            ✓
-<producer>           → (none)              ✗  needs: <proposed review + home>
-<producer>           → (exempt)            —  <why it has no outward deliverable>
-```
 
 ## Steps
 
 1. **Scope.** A single file, a folder, or "the files I just changed." Find where the
    artifacts actually live in *this* repo — don't assume a fixed layout.
 2. **Read** the target(s).
-3. **Ask the five questions** of each. Checklists are a floor — note anything else that
+3. **Ask the questions** of each. Checklists are a floor — note anything else that
    weakens the artifact.
-4. **Pairing coverage pass** (when reviewing the workflow or a producer change) — run
-   the section above and report unpaired producers.
+4. **Frontmatter hygiene (commands/skills).** Flag and recommend removing:
+   - `disable-model-invocation: true` — a unit's user-only nature comes from living in
+     `.claude/commands/`, not a flag. On a skill the flag just makes it dormant (Claude
+     can't auto-invoke it); a genuinely user-only entry point belongs in `.claude/commands/`.
+   - a `tools:` / `allowed-tools:` allow-list — legacy baggage that pins the unit to
+     specific tools/servers. Drop it so the unit inherits the session's tools.
 5. **Report** (below).
 6. **Fix (if asked).** Smallest blast radius first: remove leaked hardcoding, fill gaps,
    tighten wording. Structural changes — merging, splitting, or removing an artifact —


### PR DESCRIPTION
## Summary
Backports three **generic** improvements to `reviewing-artifacts` from downstream (`r1-test-cases`), keeping our wording and leaving the r1-specific content (Jira/Confluence/TestLink, "studio") behind.

- **Frontmatter hygiene** (new step): flag `disable-model-invocation: true` and `tools:`/`allowed-tools:` allow-lists for removal.
- **Flat-skills rule** (added to Q4): a foldered skill is undiscoverable; a unit that needs folders to group is a command, not a skill.
- **Fold the pairing pass into a question** (new Q6): replaces the ~30-line standalone "Producer→review pairing (coverage pass)" section with one question; updates the leans-table and steps accordingly.

## Note
Downstream's Q6 referenced a CLAUDE.md "Review pairing" section — valid downstream, but it **dangles upstream** (we have no such section). Repointed it at the `## Producer → review pairing` tables in `.claude/rules/*.md`, which is where the rule actually lives here. This also clears a pre-existing orphan in the removed section.

## Test plan
- [x] `reviewing-artifacts` run on the change → PASS (no leftover "five questions", no orphaned refs, no r1 content leaked)
- [x] Q6 cross-reference resolves to real files

Generated with [Claude Code](https://claude.com/claude-code)