### PR TITLE
feat(#87): add project-profile.md customization seam + pilot on reviewing-artifacts

### DIFF
--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -1,0 +1,82 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# project-profile
+
+The one place a downstream project declares its specifics. The shipped commands and
+skills state their *intent* and resolve any project-specific value — a path, an ID
+scheme, a label, an integration, a format, an audience — **from this file**, instead of
+hardcoding it. Customize a workflow by editing this file, not the units.
+
+**How a unit uses it.** Where a command or skill would otherwise bake in a value, it
+points at the matching section here (e.g. "create the *plan* label — see
+project-profile → Labels"). The values below are the **defaults**: they reproduce this
+repo's current behaviour, so a project that changes nothing behaves exactly as it does
+now. Adoption is opt-in — change a line here and every unit follows.
+
+**What belongs here vs. not.** This file is for **declarative** customization — a value
+or a list. A whole **procedure** (e.g. how to publish to Confluence and review the
+render) is *not* a value; it belongs in its own project-owned skill, never crammed into
+a general unit. Lists → here; procedures → a project skill. This is the rules files'
+"what this owns vs. what it hands off" boundary, made concrete.
+
+---
+
+## Paths
+
+- stories dir: `docs/stories/`
+- tests dir: `docs/tests/`
+- images dir: `docs/images/`
+- story format contract: `docs/stories/README.md`
+- test format contract: `docs/tests/README.md`
+
+## ID schemes
+
+- story id: `STORY-XXX` (zero-padded sequential, e.g. `STORY-001`)
+- scenario id: `TS-NN`
+- case id: `TC-NN`
+- title prefixes: `[STORY-XXX] Plan` · `[STORY-XXX] Test Plan` · `[STORY-XXX] <task>`
+
+## Labels
+
+Names the workflow uses; colours where the workflow pins one (`#hex`), otherwise the
+project's choice.
+
+- plan: `plan` (`#5319e7`)
+- test plan: `test-plan` (`#006b75`)
+- priority: `priority:high` · `priority:medium` · `priority:low`
+- type: `feature` · `enhancement` · `bug` · `docs`
+- status: `status:in-progress` · `status:needs-review` · `status:blocked`
+
+## Linking & branch
+
+- story back-reference (in titles/bodies): `[STORY-XXX]`
+- plan back-reference (task → plan): `Part of #<plan>`
+- issue closure (PR → issue): `Fixes #N` / `Closes #N`
+- feature branch name: `issue-<N>-<slug>`
+
+## Git
+
+- default branch: *derive it* (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`), don't assume `main`
+- merge strategy: `--merge` (preserve history; switch to `--squash` only if the project requires)
+
+## Front-matter & format contract (test docs)
+
+- test-doc filename: `TS-NN-<slug>.md` in the tests dir
+- front-matter fields: `id, title, namespace, story, story_hash, plan, issue, status`
+- story hash: `sha256` of the story file (`sha256sum`)
+- default status: `green`
+
+## Review semantics
+
+- canonical format (source of truth): `markdown`
+- live integrations: `GitHub` — tools the project genuinely uses; coupling to one
+  listed here is correct, not drift. (A downstream adds its own, e.g. Jira, Confluence,
+  TestLink.)
+- deliverable (triggers a paired review): a unit that *produces or changes* an output —
+  by name (`create-`/`sync-`/`publish-`/`draft-`/`init-`) or as a producing gerund skill
+  (`planning-…`, `drafting-…`)
+- audience (human-read docs): engineers and newcomers

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -39,19 +39,20 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
    filenames, magic values that should be derived, rigid step-by-step where a principle
    would do, and references to tools or layouts that have moved.
-4. **Fits the project.** Does it match the conventions this project actually uses —
-   markdown as the source of truth, plus the tools and layout the repo relies on now —
-   rather than a stack it has moved past? Flag coupling to a tool or layout the project
-   has genuinely retired or relocated; an integration the project still uses, or a
-   deliberate adapter, is not a violation. Cross-references resolve to files that exist.
-   Skills must be flat under `.claude/skills/<name>/` — a foldered skill is undiscoverable;
-   a unit that needs folders to group is a command, not a skill.
+4. **Fits the project.** Does it match the project's conventions as declared in
+   `project-profile.md` — the **canonical format** (its source of truth) and the **live
+   integrations** listed there — rather than a stack it has moved past? Flag coupling to
+   a tool the profile does not list as live (one genuinely retired or relocated); an
+   integration the profile lists as live, or a deliberate adapter, is not a violation.
+   Cross-references resolve to files that exist. Skills must be flat under
+   `.claude/skills/<name>/` — a foldered skill is undiscoverable; a unit that needs
+   folders to group is a command, not a skill.
 5. **Right for its reader.** Agent-facing (commands, skills): unambiguous instructions
    the agent can follow. Human-facing (README, story): reads like a person wrote it for
    a person — clear, concrete, scannable.
-6. **Paired (producers only).** If this artifact *produces or changes* a deliverable —
-   a `create-`/`sync-`/`publish-`/`draft-`/`init-` step, or a producing gerund skill
-   (`planning-…`, `drafting-…`) — does a review cover its output? Every producer needs a
+6. **Paired (producers only).** If this artifact *produces or changes* a **deliverable**
+   (as `project-profile.md` → Review semantics defines one), does a review cover its
+   output? Every producer needs a
    paired review — a standing rule (the `## Producer → review pairing` tables in
    `.claude/rules/*.md`). A producer with no
    review is a gap to flag, not an exception; one that yields no outward deliverable


### PR DESCRIPTION
## Summary
First task of STORY-005 — the customization seam.
- **New `.claude/rules/project-profile.md`** — the single place a downstream declares its specifics (paths, ID schemes, labels, linking/branch, git, front-matter/format contract, review semantics). Seeded with defaults equal to current behaviour, so adoption is opt-in and changing nothing is a no-op.
- Header documents the **read-from-profile convention** and the **declarative (→ profile) vs procedural (→ a project skill)** boundary.
- Auto-loads alongside any command/skill via `paths:` frontmatter.
- **Pilots the convention on `reviewing-artifacts`**: Q4 resolves canonical format + live integrations from the profile (no more hardcoded "markdown as the source of truth"); Q6 resolves the deliverable definition from the profile. Establishes the pattern #88/#89/#90 will apply.

Fixes #87
Part of STORY-005 · plan #86

## Test plan
- [x] `project-profile.md` holds all 7 value-kinds, seeded to current defaults
- [x] reviewing-artifacts Q4/Q6 reference the profile; no behaviour change with defaults
- [x] dw-review-implement: PASS (surgical — only the new file + the pilot's two questions)

## Note
Review surfaced a **pre-existing** dangling reference (not introduced here): three commands (`dw-story`, `dw-review-story`, `dw-review-tasks`) point at `docs/stories/README.md`, which doesn't exist. Tracked separately as a follow-up (story-format contract, mirroring `docs/tests/README.md`).

Generated with [Claude Code](https://claude.com/claude-code)