### PR TITLE
feat: wire all units to project-profile (#90, #88, #89) + surface it in README (#91)

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -69,3 +69,11 @@ review passes plus a plan issue on a typo is ritual, not rigor.
 - **GitHub issues** already hold the work; the plan is one too (the parent), so the
   approach, its review, and its history live where the tasks do — no separate plan store.
 - **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.
+
+## Project-specific values
+
+Story paths, the `STORY-XXX` id scheme, label names + colours, the `[STORY-XXX]` /
+`Part of #<plan>` linking patterns, the `issue-<N>-<slug>` branch name, and the merge
+strategy are **not** owned by the `dw-*` commands — they resolve from
+`.claude/rules/project-profile.md`. The values a command shows are the defaults; change
+them in the profile, not the command.

--- a/.claude/rules/doc-workflow.md
+++ b/.claude/rules/doc-workflow.md
@@ -42,3 +42,10 @@ No producer ships without a review covering its output.
 - **Reuses:** the human-read doc review — `reviewing-phrasing` (the words) and
   `reviewing-typography` (the look). `doc-review-readme` calls them rather than re-judging
   prose itself.
+
+## Project-specific values
+
+The images dir, the diagram policy (SVG source → PNG), and the README output path are
+**not** owned by the `doc-*` commands — they resolve from
+`.claude/rules/project-profile.md`. The values a command shows are the defaults; change
+them in the profile, not the command.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -70,6 +70,12 @@ project's choice.
 - story hash: `sha256` of the story file (`sha256sum`)
 - default status: `green`
 
+## Docs & diagrams
+
+- README output: `README.md`
+- diagram policy: SVG source committed + rendered to PNG (no Mermaid / inline diagram blocks)
+- images dir: `docs/images/` (also under Paths)
+
 ## Review semantics
 
 - canonical format (source of truth): `markdown`

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -48,3 +48,10 @@ No producer ships without a review covering its output.
   run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
 
 The format a test doc must follow is `docs/tests/README.md`.
+
+## Project-specific values
+
+The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
+test-doc front-matter fields, the hash algorithm, and the default status are **not** owned
+by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
+a command shows are the defaults; change them in the profile, not the command.

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -33,7 +33,8 @@ These are **lenses, not steps** — they interact, and which bites hardest depen
 doc in hand. Weigh them together, and flag anything that weakens the writing even if it
 isn't named here.
 
-- **Reader.** Who actually reads this, and what do they already know? The phrasing meets
+- **Reader.** Who actually reads this, and what do they already know? Default to the
+  project's audience in `project-profile.md` when the doc doesn't say. The phrasing meets
   them there — no unexplained jargon for a newcomer, no over-explaining to a peer.
 - **Lead with the point.** The reader should hit what matters first, not after a runway of
   setup. Context that arrives before the point reads as not knowing the priority — or as
@@ -57,8 +58,8 @@ redundant, buried, or missing a hook. That spot is the finding.
 
 ## Steps
 
-1. **Scope.** Which doc(s), and who the reader is. If the reader isn't clear from the doc
-   or its context, ask before reviewing.
+1. **Scope.** Which doc(s), and who the reader is — default to the audience in
+   `project-profile.md` when the doc and its context don't say. If still unclear, ask.
 2. **Read it as that reader would** — once, straight through, for whether it lands.
 3. **Weigh the lenses** above by judgment; note anything else that hurts the phrasing.
 4. **Report** (below).

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -2,7 +2,7 @@
 name: reviewing-typography
 description: |
   Reviews how a human-read document looks — the README, the prose and tables in docs/, or
-  any markdown written for a person — for visual hierarchy, Gestalt proximity, restraint,
+  any human-read document — for visual hierarchy, Gestalt proximity, restraint,
   and walls of text, so a reader can find the point at a glance. The look half of the
   human-read doc review (reviewing-phrasing handles the words). Use when such a doc is
   written or restructured. Judgment over checklist; floor, not ceiling.
@@ -14,15 +14,17 @@ One reviewer for how a human-read document **looks**. Its partner `reviewing-phr
 judges how a doc *reads*; this judges how it *scans*. Together they are the human-read doc
 review.
 
-This skill's job is **human-read** markdown — the README, the prose, tables, and lists in
+This skill's job is **human-read** documents in the project's canonical format
+(`project-profile.md` — markdown by default) — the README, the prose, tables, and lists in
 `docs/`, and any doc aimed at a person. The **agent-read** workflow tooling — commands,
 skills, rules, CLAUDE.md, stories — is **not** this skill's job; whether those do their job
 goes to `reviewing-artifacts`.
 
-A markdown doc has no fonts to set, but it has the same levers UI typography uses, and the
-same principles decide whether it works: **heading levels** are size/weight, **blank lines
-and grouping** are spacing, **bold/italic** are weight, and **paragraph and list length**
-decide whether the page reads as structure or as soup.
+The principles are medium-agnostic; each format expresses them through its own levers. In
+markdown (the default) a doc has no fonts to set, but it has the same levers UI typography
+uses: **heading levels** are size/weight, **blank lines and grouping** are spacing,
+**bold/italic** are weight, and **paragraph and list length** decide whether the page reads
+as structure or as soup.
 
 ## Why this is a judgment skill, not a checklist
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ cp -r agent-workflows/.claude/rules/*                your-repo/.claude/rules/
 
 Restart your IDE to load the new commands. The `dw-*` / `qw-*` commands run on the `gh` CLI — make sure [`gh`](https://cli.github.com/) is installed and authenticated (`gh auth status`).
 
-> The `rules/` files (`dev-workflow.md`, `qa-workflow.md`, `doc-workflow.md`) carry the full pipeline and the producer→review pairing. Copy them alongside the commands, or the commands' references to them will dangle.
+> The `rules/` files (`dev-workflow.md`, `qa-workflow.md`, `doc-workflow.md`) carry the full pipeline and the producer→review pairing; `project-profile.md` holds your project's paths, IDs, labels, and conventions. Copy them alongside the commands, or the commands' references to them will dangle.
+
+**Customize for your repo:** edit `.claude/rules/project-profile.md` — the one place for paths, ID schemes, labels, branch/merge conventions, front-matter, and review semantics (live integrations, canonical format, audience). The commands and skills read their values from it, so you adapt the workflow there instead of editing the units. The shipped defaults match this repo's behaviour, so changing nothing is safe.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Completes STORY-005 (plan #86) on top of the seam from #87. Every command and skill now resolves its project-specific values from `.claude/rules/project-profile.md`; defaults are unchanged, so this is behaviour-preserving.

- **#90 — reviewing skills:** `reviewing-phrasing` reads the default audience from the profile (Reader lens + Scope); `reviewing-typography` reads the canonical format (markdown by default) and notes the principles are medium-agnostic. (`reviewing-artifacts` was piloted in #87.)
- **#88 / #89 — command groups:** each group rule (`dev-/qa-/doc-workflow.md`, auto-loaded with its commands) names the profile as the authoritative source for that group's paths, IDs, labels, linking/branch, git, front-matter, and diagram values. Commands keep readable defaults; the profile is the one place to change them. Added a **Docs & diagrams** section to the profile so doc-workflow's references resolve.
- **#91 — README:** names `project-profile.md` in the rules-copy note and adds a "Customize for your repo" callout. (The `rules/*` glob already installs the profile.)

**Design note:** for the command groups I wired the **group rule** (3 edits) rather than stripping values from 15 step-by-step commands — DRY, fits the repo's rule/command layering, keeps commands readable. Per-command inline references remain an easy follow-up if preferred.

Fixes #90
Fixes #88
Fixes #89
Fixes #91
Part of STORY-005 · plan #86

## Test plan
- [x] Every rule/skill profile reference resolves to a profile section
- [x] Defaults preserved (markdown, GitHub, current paths/labels) — no behaviour change
- [x] Substance gate (dw-review-implement): surgical, 7 files, each change traces to its task

Generated with [Claude Code](https://claude.com/claude-code)