### PR TITLE
qa-workflow: close the Test Plan tracking loop

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -32,6 +32,10 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         ├─► Step 3: Create PR
         │   - Title: short, imperative, under 70 characters
         │   - Body must include "Fixes #N" or "Closes #N"
+        │   - If the issue's story has a `[STORY-XXX] Test Plan` (label `test-plan`) and the
+        │     story's docs/tests/TS-*.md are verified green, add `Closes #<test-plan>` to the
+        │     body so merging closes the Test Plan (qa-workflow terminal step). Find it:
+        │     gh issue list --search "[STORY-XXX] Test Plan" --label test-plan --state all
         │   - Use this template:
         │
         │       gh pr create --title "<title>" --body "$(cat <<'EOF'
@@ -40,6 +44,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │
         │       Fixes #<issue-number>
         │       (if linked to story: "Part of STORY-XXX")
+        │       (if the story's tests are verified green: "Closes #<test-plan>")
         │
         │       ## Test plan
         │       - [ ] ...

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -47,6 +47,19 @@ No producer ships without a review covering its output.
 - **Hands off:** binding each case to an executable and running it is the **project's binding +
   run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
 
+## Closing the loop — when a Test Plan is done
+
+The authoring flow leaves the `[STORY-XXX] Test Plan` issue **open**; it is the live record of
+outstanding coverage. It reaches its terminal state when the story is implemented and its
+`docs/tests/TS-*.md` are **verified green** — run by hand until the binding + run layer exists:
+
+- As you verify each TS doc, set its front-matter `status` (`green` pass / `red` fail) and
+  `issue:` (the implementation issue it verified).
+- When all of a story's TS docs are green, **close** the `[STORY-XXX] Test Plan` issue. This is
+  wired through the dev side: the implementation PR that completes the story puts
+  `Closes #<test-plan>` in its description (see `dw-create-pr`), so merging it closes the Test
+  Plan. A `red` doc leaves the Test Plan open.
+
 The format a test doc must follow is `docs/tests/README.md`.
 
 ## Project-specific values


### PR DESCRIPTION
## Summary

`[STORY-XXX] Test Plan` issues currently have no terminal state: `qw-plan` opens them and the authoring flow (`qw-review-plan` → `qw-cases` → `qw-review-cases`) never closes them. This adds the close step, without requiring the binding + run layer.

- **qa-workflow.md** — new "Closing the loop" section: a Test Plan reaches its terminal state when its story is implemented and its `docs/tests/TS-*.md` are verified green (by hand until a run layer exists); set each TS `status` (green/red) + `issue` on verification.
- **dw-create-pr.md** — when a story's tests are green, the implementation PR adds `Closes #<test-plan>` so merging closes the Test Plan.

Surfaced while running the workflow on a downstream project — the Test Plan issues stayed open forever. Minimal by design; the full binding/runner remains the project's deferred run layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)