### PR TITLE
Close the customization-seam holes (#99, #100, #101)

### DIFF
--- a/.claude/commands/doc-workflow/doc-gen-readme.md
+++ b/.claude/commands/doc-workflow/doc-gen-readme.md
@@ -83,7 +83,7 @@ This writes the README only. It does NOT open a PR.
     1. WebSearch "README best practices <year> structure badges diagrams"
     2. Study repo → key ideas: <A>, <B>, <C>
     3. Draft structure; recommend 3 diagrams
-    4. Author docs/images/<idea>.svg → render PNG (a reproducible render step)
+    4. Author <idea>.svg in the project's diagrams dir → render PNG (a reproducible step)
     5. Write README.md; verify tool names / env vars / links against the code
     6. Hand off → /doc-review-readme
 
@@ -91,7 +91,7 @@ This writes the README only. It does NOT open a PR.
 
 ## API Notes
 
-- Reads the repo + the web; writes README.md (+ docs/images/* if diagrams). No PR.
+- Reads the repo + the web; writes README.md (+ the diagrams dir if diagrams). No PR.
 - The WebSearch step is mandatory — it is what keeps this command from going stale.
 - Diagrams are optional; when used, SVG is the source of truth and the PNG is rendered.
 - Producer paired with the review `/doc-review-readme` (see .claude/rules/doc-workflow.md).

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -32,7 +32,7 @@ Fits in the qa-workflow:
         │
         ├─► Step 2: One file per scenario
         │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
-        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       id, title, namespace, story (+ the drift anchor the profile declares),
         │       plan: <plan> (the test-plan issue number — omit when there is none),
         │       issue, status: green
         │   - (Format and field meanings: docs/tests/README.md.)
@@ -55,7 +55,9 @@ Fits in the qa-workflow:
 
 - Reuse is optional: if the project has a reuse index, query it for a vetted case or
   step before authoring a near-duplicate, so coverage converges instead of duplicating.
-- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- Drift anchor: record whatever the profile declares, so a later gate can tell the story
+  has moved (default: `story_hash`, the `sha256sum` of the story file). A project that
+  detects drift another way declares that instead — don't assume hashing.
 - `plan`: the `[STORY-XXX] Test Plan` issue number — the scenario source and the trace
   back (see docs/tests/README.md). Absent for ad-hoc tests written without a plan.
 - Producer paired with `/qw-review-cases`.

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -25,7 +25,7 @@ Fits in the qa-workflow:
         ├─► Step 1: Each doc
         │   - [ ] One scenario, one job; cases are coherent slices of it.
         │   - [ ] Front-matter complete and resolvable: story file exists,
-        │         story_hash matches it, namespace set, status present.
+        │         the profile's drift anchor holds, namespace set, status present.
         │   - [ ] Each step's Expected Result is observable — checkable, not vague.
         │   - [ ] Conforms to the format contract (docs/tests/README.md).
         │

--- a/.claude/rules/doc-workflow.md
+++ b/.claude/rules/doc-workflow.md
@@ -20,7 +20,7 @@ in current best practice, leading with the few ideas worth a diagram, and true t
         │                    └─ reuses reviewing-phrasing + reviewing-typography,
         │                       then verifies every claim against the code
         ▼
-   README.md (+ docs/images/* when diagrams help)
+   README.md (+ the project's diagrams dir when diagrams help)
 ```
 
 `doc-gen-readme` opens with a mandatory **WebSearch** step so the structure tracks current
@@ -45,7 +45,7 @@ No producer ships without a review covering its output.
 
 ## Project-specific values
 
-The images dir, the diagram policy (SVG source → PNG), and the README output path are
+The diagrams dir, the diagram policy (SVG source → PNG), and the README output path are
 **not** owned by the `doc-*` commands — they resolve from
 `.claude/rules/project-profile.md`. The values a command shows are the defaults; change
 them in the profile, not the command.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -17,6 +17,20 @@ project-profile → Labels"). The values below are the **defaults**: they reprod
 repo's current behaviour, so a project that changes nothing behaves exactly as it does
 now. Adoption is opt-in — change a line here and every unit follows.
 
+**Two wiring styles, and when each applies.** A **skill** points at this file at each point
+of use — it is read on its own, with no rule loaded beside it. A **command** may show a
+value inline as an illustrated default; its group rule (`.claude/rules/*.md`) carries the
+"these resolve from the profile" statement for the whole group, so the pointer is not
+repeated line by line. Both are correct. Which one applies is decided by whether the unit
+is read together with its rule — not by preference.
+
+**What a unit must never bake in is a *mechanism*.** A value this file can restate — a
+path, a label, an id — is safe to show inline. A *procedure* is not: how drift is detected,
+how files are laid out. No value can override a procedure, so a project that does it another
+way is forced to edit the shipped unit, and its repo then reads as drifted when it was only
+working around us. State the goal; let this file or the project's own layer name the
+mechanism.
+
 **What belongs here vs. not.** This file is for **declarative** customization — a value
 or a list. A whole **procedure** (e.g. how to publish to Confluence and review the
 render) is *not* a value; it belongs in its own project-owned skill, never crammed into
@@ -29,7 +43,7 @@ a general unit. Lists → here; procedures → a project skill. This is the rule
 
 - stories dir: `docs/stories/`
 - tests dir: `docs/tests/`
-- images dir: `docs/images/`
+- diagrams dir: `docs/diagrams/` (SVG source) + `docs/diagrams/png/` (rendered)
 - story format contract: `docs/stories/README.md`
 - test format contract: `docs/tests/README.md`
 
@@ -67,14 +81,17 @@ project's choice.
 
 - test-doc filename: `TS-NN-<slug>.md` in the tests dir
 - front-matter fields: `id, title, namespace, story, story_hash, plan, issue, status`
-- story hash: `sha256` of the story file (`sha256sum`)
+- drift anchor: `story_hash` — the `sha256` of the story file (`sha256sum`), recorded so a
+  later gate can tell the story has moved. A project that detects drift another way (a
+  derived link check, say) names that here instead, or `none`. The `qw-*` commands record
+  whatever this declares; they do not assume hashing.
 - default status: `green`
 
 ## Docs & diagrams
 
 - README output: `README.md`
 - diagram policy: SVG source committed + rendered to PNG (no Mermaid / inline diagram blocks)
-- images dir: `docs/images/` (also under Paths)
+- diagrams dir: `docs/diagrams/` (SVG source) + `docs/diagrams/png/` (rendered) — also under Paths
 
 ## Review semantics
 

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -24,18 +24,17 @@ value inline as an illustrated default; its group rule (`.claude/rules/*.md`) ca
 repeated line by line. Both are correct. Which one applies is decided by whether the unit
 is read together with its rule — not by preference.
 
-**What a unit must never bake in is a *mechanism*.** A value this file can restate — a
-path, a label, an id — is safe to show inline. A *procedure* is not: how drift is detected,
-how files are laid out. No value can override a procedure, so a project that does it another
-way is forced to edit the shipped unit, and its repo then reads as drifted when it was only
-working around us. State the goal; let this file or the project's own layer name the
-mechanism.
-
 **What belongs here vs. not.** This file is for **declarative** customization — a value
 or a list. A whole **procedure** (e.g. how to publish to Confluence and review the
 render) is *not* a value; it belongs in its own project-owned skill, never crammed into
 a general unit. Lists → here; procedures → a project skill. This is the rules files'
 "what this owns vs. what it hands off" boundary, made concrete.
+
+The same line binds the **units**. A value this file can restate is safe for a unit to show
+inline; a *procedure* never is — how drift is detected, how files are laid out. No value can
+override a procedure, so a project that does it another way is forced to edit the shipped
+unit, and its repo then reads as drifted when it was only working around us. State the goal;
+let this file or the project's own layer name the mechanism.
 
 ---
 
@@ -80,7 +79,8 @@ project's choice.
 ## Front-matter & format contract (test docs)
 
 - test-doc filename: `TS-NN-<slug>.md` in the tests dir
-- front-matter fields: `id, title, namespace, story, story_hash, plan, issue, status`
+- front-matter fields: `id, title, namespace, story, story_hash, plan, issue, status` — the
+  anchor field tracks the drift anchor below; drop it when that is `none`
 - drift anchor: `story_hash` — the `sha256` of the story file (`sha256sum`), recorded so a
   later gate can tell the story has moved. A project that detects drift another way (a
   derived link check, say) names that here instead, or `none`. The `qw-*` commands record

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -39,6 +39,12 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
    filenames, magic values that should be derived, rigid step-by-step where a principle
    would do, and references to tools or layouts that have moved.
+   **Bakes in a mechanism?** Hardest bite of this question. A value `project-profile.md`
+   owns may appear inline as a default (see its "Two wiring styles"), but a *procedure* —
+   how drift is detected, how files are laid out — cannot be overridden by any value, so a
+   project that does it differently must edit the shipped unit. Flag every "compute X this
+   way" or "write it at this path" that the profile cannot redirect; the fix is to state
+   the goal and let the profile or the project's layer name the mechanism.
 4. **Fits the project.** Does it match the project's conventions as declared in
    `project-profile.md` — the **canonical format** (its source of truth) and the **live
    integrations** listed there — rather than a stack it has moved past? Flag coupling to

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -1,0 +1,73 @@
+# STORY-006: Close the holes in the customization seam
+
+## User Story
+
+As a downstream consumer of this template repo (e.g. test-framework-template, android-wifi-mcp),
+I want every project-specific value to actually resolve from `project-profile.md` — and to be
+   told when one doesn't,
+So that I never have to edit a shipped unit to get the behaviour I declared, and upstream
+   improvements still reach me without a merge conflict over my own customizations.
+
+## The Need
+
+STORY-005 shipped the customization seam and it works. Nine `dw-*` commands are byte-identical
+across two downstreams that have never coordinated; the runner absorbs all of its differences in
+its profile without touching a single command. The rule — *edit the profile, not the units* — is
+sound and is holding.
+
+But the seam has holes. A few values never made it out of the command text, and where a unit
+names its own value, the profile is inert: a project can set the value, nothing follows, and the
+only way to get the behaviour it declared is to edit the shipped file. That edit then looks like
+the downstream drifting when it is really working around us.
+
+Two downstreams have now paid for this, independently:
+
+| Value | Where it's still named inside a unit | Who tripped over it | What they had to do |
+|---|---|---|---|
+| images dir | `doc-gen-readme.md`, `rules/doc-workflow.md` | test-framework-template | rewrote the command to point at its own diagrams dir |
+| drift anchor (`story_hash`) | `qw-cases.md`, `qw-review-cases.md` | android-wifi-mcp | replaced hash drift with a derived chain check, then edited both commands |
+
+One of those values is also simply **wrong**. The profile declares an images dir this repo does
+not have; the six diagrams it actually ships live somewhere else entirely, and the README links
+them from there. So `doc-gen-readme` run here today writes into a directory the repo doesn't use.
+That breaks the profile's own promise — that its defaults "reproduce this repo's current
+behaviour" — and it is the promise the whole seam rests on, because it is what makes adoption a
+no-op until a project opts in.
+
+Underneath both is the same gap: **nothing checks that a unit doesn't name a value the profile
+owns.** STORY-005 swept 18 units by hand and got most of them; there is no pass that would catch
+the ones it missed, or the next one someone writes. So a leak stays invisible until a downstream
+trips over it — which is the expensive place to find it, because by then the workaround is
+already committed in someone else's repo and reads as their mistake.
+
+## Success Looks Like
+
+- A downstream changes the images dir or the drift anchor in its profile, and the commands
+  follow — with no unit edited.
+- No shipped command, skill, or rule names a value the profile owns.
+- Every default the profile declares matches what this repo actually does, and that agreement is
+  something anyone can check rather than take on trust.
+- The workarounds in `test-framework-template` and `android-wifi-mcp` become unnecessary: those
+  files can match upstream again without either project losing the behaviour it chose.
+- A new leak is caught when it is introduced, not when a downstream trips over it months later.
+- We know the known leaks are the whole list — not just the ones a downstream happened to hit.
+
+## Open Questions
+
+- How is "no unit names a profile-owned value" actually checked — a question added to
+  `reviewing-artifacts`, a line in the rules, or something runnable in CI? (decided in `dw-plan`)
+- The drift anchor is a *mechanism*, not just a field name — android-wifi-mcp swapped hashing for
+  a derived link check. Does the profile declare the mechanism, or only the front-matter fields,
+  with the mechanism left to the project's own layer?
+- Do the three known leaks represent the whole problem, or does a re-audit of all 18 units from
+  STORY-005 turn up more?
+- For the images dir: does the corrected default become this repo's real diagrams layout, or does
+  the declared default stay as-is with this repo setting its own value like any other project?
+- Is the profile's "defaults reproduce this repo's behaviour" promise worth enforcing generally,
+  or is the images dir a one-off to fix and move on?
+
+## Status
+
+- Created: 2026-08-03
+- Plan: #98
+- Issues: #99, #100, #101

--- a/docs/stories/STORY-006.md
+++ b/docs/stories/STORY-006.md
@@ -70,4 +70,4 @@ already committed in someone else's repo and reads as their mistake.
 
 - Created: 2026-08-03
 - Plan: #98
-- Issues: #99, #100, #101
+- Issues: #99, #100, #101 (PR #102, open)


### PR DESCRIPTION
## Summary

- **#99** — `project-profile.md` declared `images dir: docs/images/`, a directory that does not exist; this repo's six diagrams live in `docs/diagrams/` + `docs/diagrams/png/`. The profile now says so, and `doc-gen-readme` + the doc-workflow rule defer the location instead of naming one.
- **#100** — `qw-cases` / `qw-review-cases` baked in "sha256 the story file, compare it". No profile value can express *"no hash — derive the chain instead"*, which is what `android-wifi-mcp` moved to, so it had to edit both commands. They now record whatever anchor the profile declares; the profile declares it as a mechanism, `none` included.
- **#101** — The seam had two undocumented wiring styles: `b0a9de4` ("wire dev/qa/doc command groups to project-profile") changed four rule files and **zero** commands, while the skills were edited directly. The profile now states both styles and when each applies, and `reviewing-artifacts` Q3 bites on baked-in mechanisms so the next leak is caught here rather than downstream.

The shipped defaults still reproduce today's behaviour — a project that changes nothing behaves exactly as before.

Closes #99
Closes #100
Closes #101

Part of STORY-006 · plan #98

## Test plan

- [ ] `grep -rn 'docs/images' .claude/` returns nothing
- [ ] `grep -rn 'sha256' .claude/commands/` returns only the declared default, framed as overridable
- [ ] The profile's diagrams dir matches what `docs/diagrams/` actually contains
- [ ] `test-framework-template`'s local `doc-gen-readme` rewrite is no longer needed
- [ ] `android-wifi-mcp`'s local `qw-cases` / `qw-review-cases` edits are no longer needed

Generated with [Claude Code](https://claude.com/claude-code)