### PR TITLE
Name the drift anchor, not 'the hash algorithm', in the qa-workflow rule

### DIFF
--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -52,6 +52,6 @@ The format a test doc must follow is `docs/tests/README.md`.
 ## Project-specific values
 
 The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
-test-doc front-matter fields, the hash algorithm, and the default status are **not** owned
+test-doc front-matter fields, the drift anchor, and the default status are **not** owned
 by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
 a command shows are the defaults; change them in the profile, not the command.


### PR DESCRIPTION
Follow-up to #102, caught reviewing the downstream sync PRs.

`rules/qa-workflow.md` still told the reader that "the hash algorithm" resolves from the profile. After #100 the profile has no such key — it declares a `drift anchor`, which may be `none`. The old wording both dangled and implied the only choice was *which* hash.

One line. No behaviour change.

Generated with [Claude Code](https://claude.com/claude-code)