### PR TITLE
Give every gate report one shape (#105-#108)

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -60,11 +60,10 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │   - Skip silently if no story link or docs/stories/ doesn't exist
         │
         └─► Step 6: Report
-            - Show the PR URL to the user
-            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
-              review and test it. Merge with /dw-merge <PR> only once a human is
-              satisfied. (The change's substance was already gated locally by
-              /dw-review-implement before the PR.)
+            - Report per .claude/rules/agent-report.md; Trace carries the PR URL
+            - Next is the HUMAN review + test — stop here, don't auto-advance. Merge
+              with /dw-merge <PR> only once a human is satisfied. (The change's
+              substance was already gated locally by /dw-review-implement.)
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -111,6 +111,13 @@ history — start, failures, fixes, and resolution.
 
 ---
 
+## OUTPUT
+
+The implementation state, against what the issue asked for. Trace carries the branch, the issue, and the commits. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Uses `gh` CLI for issue operations

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -113,7 +113,8 @@ history — start, failures, fixes, and resolution.
 
 ## OUTPUT
 
-The implementation state, against what the issue asked for. Trace carries the branch, the issue, and the commits. Reported per `.claude/rules/agent-report.md` — the verdict
+The implementation state, against what the issue asked for. Trace carries the branch,
+the issue, and the commits. Reported per `.claude/rules/agent-report.md` — the verdict
 first, and a section with nothing to report says so.
 
 ---

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -53,11 +53,10 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: git branch -d <branch-name>
         │
         └─► Step 7: Report
-            - Confirm merge to the user
-            - Show the merged PR URL
-            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
-            - If story is complete, mention it
-            - Mention any follow-up issues if applicable
+            - Report per .claude/rules/agent-report.md; Trace carries the merged PR URL
+            - Next: /dw-implement <next-issue> if the story has open tasks left,
+              otherwise say the story is complete
+            - Unresolved carries any follow-up the merge leaves behind
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -56,7 +56,8 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
             - Report per .claude/rules/agent-report.md; Trace carries the merged PR URL
             - Next: /dw-implement <next-issue> if the story has open tasks left,
               otherwise say the story is complete
-            - Unresolved carries any follow-up the merge leaves behind
+            - A follow-up the merge deliberately leaves behind is Not done (a choice);
+              Unresolved is for what the merge left genuinely uncertain
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -124,6 +124,13 @@ This command produces the plan only. It does NOT create task issues — that is 
 
 ---
 
+## OUTPUT
+
+The plan issue. Trace carries its URL; Next is the human gate on that issue, never /dw-tasks. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Uses `gh` CLI — must be authenticated (`gh auth status`)

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -119,15 +119,21 @@ This command produces the plan only. It does NOT create task issues — that is 
 
 **Output:**
 
-    Plan issue #28 created: https://github.com/owner/repo/issues/28
-    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
+    PASS — plan #28 written; the approach covers STORY-003.
+
+    Checked     the story's Success Looks Like; repo conventions; no existing plan
+    Not done    task issues — /dw-tasks opens those, after the gate
+    Unresolved  2 open questions, recorded on the issue
+    Trace       https://github.com/owner/repo/issues/28 · docs/stories/STORY-003.md
+    Next        a human reads and approves #28 on GitHub
 
 ---
 
 ## OUTPUT
 
-The plan issue. Trace carries its URL; Next is the human gate on that issue, never /dw-tasks. Reported per `.claude/rules/agent-report.md` — the verdict
-first, and a section with nothing to report says so.
+The plan issue. Reported per `.claude/rules/agent-report.md` — the verdict first, and a
+section with nothing to report says so. Trace carries the issue URL; Next is the human
+reading it on GitHub, never `/dw-tasks` — that comes after the gate, not from here.
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -66,9 +66,10 @@ Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
         │     comment the issue and route back to /dw-implement
         │
         └─► Step 6: Report
-            - Per finding: the exact file:line + the smallest fix
-            - A delivery verdict against the issue's "Done When"
-            - The issue link + suggested next step
+            - Report per .claude/rules/agent-report.md
+            - The verdict is the delivery state against the issue's "Done When";
+              every finding gives the exact file:line and the smallest fix
+            - Trace carries the issue link and the branch
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -54,8 +54,7 @@ hands it back to `/dw-story` if the need itself is unclear.
         │     wording), stop and route to /dw-story to re-capture it with the user
         │
         └─► Step 5: Report
-            - Report per .claude/rules/agent-report.md — the verdict vocabulary is
-              project-profile → Reports, not a set this command names
+            - Report per .claude/rules/agent-report.md
             - Checked carries both checklists; Trace carries the story path
 
 ---
@@ -83,8 +82,12 @@ hands it back to `/dw-story` if the need itself is unclear.
 **Output:**
 
     PASS — STORY-001 is complete and stays a goal.
-    docs/stories/STORY-001.md
-    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+    Checked     both checklists above — completeness, and goal-not-spec
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-001.md
+    Next        /dw-tasks STORY-001 — the issue is where the "how" gets decided
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -54,8 +54,9 @@ hands it back to `/dw-story` if the need itself is unclear.
         │     wording), stop and route to /dw-story to re-capture it with the user
         │
         └─► Step 5: Report
-            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
-            - Print the path to the story and the suggested next step
+            - Report per .claude/rules/agent-report.md — the verdict vocabulary is
+              project-profile → Reports, not a set this command names
+            - Checked carries both checklists; Trace carries the story path
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -62,9 +62,10 @@ Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
         │     → back to /dw-tasks to re-decompose
         │
         └─► Step 6: Report
-            - Per issue: verdict + findings
-            - A coverage verdict against the story
-            - The story path + issue links + suggested next step
+            - Report per .claude/rules/agent-report.md
+            - The verdict covers the breakdown as a whole; Checked carries the
+              coverage of the story's "Success Looks Like" and the per-issue passes
+            - Trace carries the story path and the issue links
 
 ---
 

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -89,7 +89,12 @@ Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
 **Output:**
 
     PASS — the breakdown covers STORY-007 and each issue stays a goal.
-    Next: /dw-implement 21
+
+    Checked     every Success Looks Like item maps to an issue; each issue one job
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-007.md · #21 #22
+    Next        /dw-implement 21
 
 (Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
 

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -80,5 +80,7 @@ Show the user the created story and suggest next steps:
 
 ## OUTPUT
 
-The path to the created story file.
+The story captured, and whether it is ready to be gated. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so. Trace carries the story file's path.
 ```

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -112,10 +112,18 @@ Fits in the dev-workflow:
 
 **Output:**
 
+    PASS — STORY-003 broken into 2 issues; together they cover the plan.
+
     | Issue | Title                              | Type        | Priority |
     |-------|------------------------------------|-------------|----------|
     | #15   | [STORY-003] Add input validation   | enhancement | high     |
     | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Checked     every Acceptance Criterion in plan #28 maps to an issue
+    Not done    none
+    Unresolved  none
+    Trace       docs/stories/STORY-003.md · plan #28 · #15 #16
+    Next        /dw-review-tasks STORY-003 to gate the breakdown
 
     Suggested order: #15 → #16
     Start: /dw-implement 15

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -81,11 +81,10 @@ Fits in the dev-workflow:
         │     - Issues: #1, #2, #3
         │
         └─► Step 7: Report
-            - Show table of created issues:
-              | Issue | Title | Type | Priority |
-            - Suggest implementation order based on dependencies
-            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
-              /dw-implement <N> to start on the first task
+            - Report per .claude/rules/agent-report.md; the created issues are a
+              table (| Issue | Title | Type | Priority |) plus the build order
+            - Trace carries the story path, the plan issue, and the issue links
+            - Next: /dw-review-tasks STORY-XXX to gate the breakdown
 
 ---
 

--- a/.claude/commands/doc-workflow/doc-gen-readme.md
+++ b/.claude/commands/doc-workflow/doc-gen-readme.md
@@ -91,8 +91,9 @@ This writes the README only. It does NOT open a PR.
 
 ## OUTPUT
 
-The README, and any diagrams authored with it. Trace carries their paths. Reported per `.claude/rules/agent-report.md` — the verdict
-first, and a section with nothing to report says so.
+The README, and any diagrams authored with it. Trace carries their paths. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
 
 ---
 

--- a/.claude/commands/doc-workflow/doc-gen-readme.md
+++ b/.claude/commands/doc-workflow/doc-gen-readme.md
@@ -89,6 +89,13 @@ This writes the README only. It does NOT open a PR.
 
 ---
 
+## OUTPUT
+
+The README, and any diagrams authored with it. Trace carries their paths. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Reads the repo + the web; writes README.md (+ the diagrams dir if diagrams). No PR.

--- a/.claude/commands/doc-workflow/doc-review-readme.md
+++ b/.claude/commands/doc-workflow/doc-review-readme.md
@@ -53,6 +53,14 @@ Fits in the doc-workflow:
 
 ---
 
+## OUTPUT
+
+The decision from Step 4, printed — with the findings behind it. Trace carries the
+README and any diagrams reviewed. Reported per `.claude/rules/agent-report.md` —
+the verdict first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Reuses `reviewing-phrasing` + `reviewing-typography` (the human-read doc review) and

--- a/.claude/commands/doc-workflow/doc-review-readme.md
+++ b/.claude/commands/doc-workflow/doc-review-readme.md
@@ -56,8 +56,8 @@ Fits in the doc-workflow:
 ## OUTPUT
 
 The decision from Step 4, printed — with the findings behind it. Trace carries the
-README and any diagrams reviewed. Reported per `.claude/rules/agent-report.md` —
-the verdict first, and a section with nothing to report says so.
+README and any diagrams reviewed. Reported per `.claude/rules/agent-report.md` — the
+verdict first, and a section with nothing to report says so.
 
 ---
 

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -53,8 +53,9 @@ Fits in the qa-workflow:
 
 ## OUTPUT
 
-The test docs written. Trace carries each doc's path and the test-plan issue. Reported per `.claude/rules/agent-report.md` — the verdict
-first, and a section with nothing to report says so.
+The test docs written. Trace carries each doc's path and the test-plan issue. Reported
+per `.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
 
 ---
 

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -51,6 +51,13 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The test docs written. Trace carries each doc's path and the test-plan issue. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Reuse is optional: if the project has a reuse index, query it for a vetted case or

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -71,6 +71,13 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The test-plan issue. Trace carries its URL; Next is the paired review. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -73,8 +73,9 @@ Fits in the qa-workflow:
 
 ## OUTPUT
 
-The test-plan issue. Trace carries its URL; Next is the paired review. Reported per `.claude/rules/agent-report.md` — the verdict
-first, and a section with nothing to report says so.
+The test-plan issue. Trace carries its URL; Next is the paired review. Reported per
+`.claude/rules/agent-report.md` — the verdict first, and a section with nothing to
+report says so.
 
 ---
 

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -40,6 +40,13 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The decision from Step 3, printed — with the findings behind it. Trace carries each doc reviewed. Reported per `.claude/rules/agent-report.md` — the verdict
+first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - This reviews the *doc* (intent); the doc↔script binding is reviewed in the project's binding + run layer, not here.

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -42,8 +42,9 @@ Fits in the qa-workflow:
 
 ## OUTPUT
 
-The decision from Step 3, printed — with the findings behind it. Trace carries each doc reviewed. Reported per `.claude/rules/agent-report.md` — the verdict
-first, and a section with nothing to report says so.
+The decision from Step 3, printed — with the findings behind it. Trace carries each doc
+reviewed. Reported per `.claude/rules/agent-report.md` — the verdict first, and a
+section with nothing to report says so.
 
 ---
 

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -48,8 +48,8 @@ Fits in the qa-workflow:
 
 ## OUTPUT
 
-The decision from Step 4 — recorded as a comment on the test-plan issue, and printed
-for the reader. Trace carries the issue URL. Reported per `.claude/rules/agent-report.md` —
+The decision from Step 4 — recorded as a comment on the test-plan issue, and printed for
+the reader. Trace carries the issue URL. Reported per `.claude/rules/agent-report.md` —
 the verdict first, and a section with nothing to report says so.
 
 ---

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -46,6 +46,14 @@ Fits in the qa-workflow:
 
 ---
 
+## OUTPUT
+
+The decision from Step 4 — recorded as a comment on the test-plan issue, and printed
+for the reader. Trace carries the issue URL. Reported per `.claude/rules/agent-report.md` —
+the verdict first, and a section with nothing to report says so.
+
+---
+
 ## API Notes
 
 - Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.

--- a/.claude/rules/agent-report.md
+++ b/.claude/rules/agent-report.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# agent-report
+
+Every unit in this toolkit ends at a **human gate**. What that human reads to decide is
+the **report**. This states what a report owes its reader.
+
+The report is where the workflow's cost actually lands: producing is cheap, judging is
+not. A report that has to be re-read from the top makes the human the slowest part of a
+pipeline built entirely around their judgment.
+
+This file states the **goal**. The words a report uses — the verdicts, the section
+names, the marker for an empty section, what each medium allows — are **values**: see
+`project-profile.md` → Reports. A unit resolves them from there; it does not name its
+own.
+
+## What a report answers
+
+Seven questions, in this order. The reader should find each without hunting.
+
+```
+   1  What am I being asked to decide?   ──► the verdict, first, alone on a line
+   2  What is wrong, and where?          ──► the findings
+   3  What does this verdict cover?      ──► what was actually examined
+   4  What was left out on purpose?      ──► a CHOICE
+   5  What is still uncertain?           ──► a RISK
+   6  Where are the artifacts?           ──► the trace
+   7  What happens next?                 ──► exactly one step
+```
+
+## The rules that make it work
+
+**Lead with the decision.** Question 1 is answerable without reading the report. A
+verdict that arrives after a paragraph of narration has already cost the reader the
+thing the report exists to save.
+
+**4 and 5 are not the same question.** Something skipped on purpose is a *choice*;
+something unresolved is a *risk*. Collapsing them is the failure this contract exists to
+prevent — it is how a workaround and a concern end up reading alike.
+
+**Silence is not an answer.** A section with nothing to report says so. An absent
+section cannot be told apart from a question never asked, and a reader cannot tell
+whether an area was clean or simply never looked at.
+
+**Say what the verdict covers.** A pass is scoped to what was examined (3). Without it a
+reader assumes the scope, and assumes wrong in the direction of comfort.
+
+**Structure before prose.** A verdict is a line; findings are a table; a flow, a
+pipeline, or a shape is a diagram; options compared are a table with a row each. Prose is
+for an argument that has to be *followed* — and then it is short. Rebuilding structure
+out of paragraphs in your head *is* the review cost.
+
+**Be legible where it lands.** A report read in a chat session must work as plain text.
+One that lands in a document or an issue may use whatever renders there. The formats each
+medium allows are a value — see `project-profile.md` → Reports. Do not bake one medium's
+markup into a unit; a project that reports elsewhere would have to edit it.
+
+## Right-size it
+
+Not every answer is a report. A one-line reply, a confirmation, a single fact a reader
+asked for directly — these are the answer, and wrapping them in seven sections is ritual,
+not rigor. The contract binds a unit's **gate output**: what a command or skill prints
+when it finishes and hands a decision to a human. Below that, use judgment.
+
+## Why this is a rule, not a template
+
+A frozen block of headings is a *procedure* — no profile value can override it, so a
+project that reports differently would be forced to edit a shipped unit and its repo
+would then read as drifted when it was only working around us (see
+`project-profile.md` → what belongs here vs. not). State the questions; let the profile
+name the words.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -93,6 +93,22 @@ project's choice.
 - diagram policy: SVG source committed + rendered to PNG (no Mermaid / inline diagram blocks)
 - diagrams dir: `docs/diagrams/` (SVG source) + `docs/diagrams/png/` (rendered) — also under Paths
 
+## Reports
+
+The words a gate report uses. The contract itself — the questions a report answers and
+why — is `.claude/rules/agent-report.md`; a unit resolves the wording from here.
+
+- verdict vocabulary: `PASS` · `REVISE` · `HAND BACK`
+- extra verdict (artifact review only): `CUT` — the artifact duplicates another or does
+  nothing useful; propose removal
+- section names: `Verdict` · `Findings` · `Checked` · `Not done` · `Unresolved` ·
+  `Trace` · `Next`
+- empty-section marker: `none` (a section with nothing to report says so; it is not dropped)
+- finding columns: `# · severity · location · what's wrong · smallest fix`
+- formats by medium: chat session → plain text, tables, ASCII diagrams · document or
+  issue → whatever renders there. For a *published* human-read doc the diagram policy
+  under Docs & diagrams applies instead.
+
 ## Review semantics
 
 - canonical format (source of truth): `markdown`

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -35,6 +35,12 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    another artifact (could it merge, or go away?).
 2. **Complete.** Does it deliver that job end to end — no missing steps, placeholder
    text, or dead instructions that produce nothing? A reader/agent should be able to act.
+   **Says what it reports?** A unit that ends at a human gate is not complete until it
+   says what it hands that human. Flag one that finishes silently, one that defines a
+   decision it never prints, one that restates the sections of
+   `.claude/rules/agent-report.md` inline instead of resolving to it, and one that
+   invents verdict words outside `project-profile.md` → Reports. A unit deliberately
+   exempt (its output is not a gate) says so — silence is not an exemption.
 3. **Goal, not frozen spec — and no hardcoding.** Does it state intent and leave room
    where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
    filenames, magic values that should be derived, rigid step-by-step where a principle
@@ -95,16 +101,14 @@ Where each type leans:
 
 ## Report
 
-Per artifact, a short verdict and the specific findings — no numeric score.
-
-```
-<artifact path> — PASS | REVISE | CUT
-
-- [Q#] <finding, with line reference> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score. This review also uses
+**CUT**, declared there as the artifact review's own.
 
 - **PASS** — does its job, fits the project, nothing leaked.
 - **REVISE** — specific, fixable findings (gaps, hardcoding, drift, readability).
 - **CUT** — duplicates another artifact or does nothing useful; propose removal (with approval).
 
-End with the path(s) reviewed and the suggested next step.
+Each finding names the question it came from (`[Q#]`), the line, and the smallest fix.
+Trace carries the path(s) reviewed.

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -104,7 +104,7 @@ Where each type leans:
 Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
 and a section with nothing to report saying so. The verdict vocabulary is
 `project-profile.md` → Reports. No numeric score. This review also uses
-**CUT**, declared there as the artifact review's own.
+**CUT**, declared there as the artifact review's own. In this review they mean:
 
 - **PASS** — does its job, fits the project, nothing leaked.
 - **REVISE** — specific, fixable findings (gaps, hardcoding, drift, readability).

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -69,15 +69,12 @@ redundant, buried, or missing a hook. That spot is the finding.
 
 ## Report
 
-Per doc, a short verdict and specific findings — no numeric score.
-
-```
-<doc> — PASS | REVISE
-
-- <what hurts the phrasing, quoted> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score.
 
 - **PASS** — fits its reader, leads with the point, says the right thing.
 - **REVISE** — specific, fixable findings (buried point, padding, wrong register, missing fact).
 
-End with what was reviewed and the suggested next step.
+Each finding quotes what hurts the phrasing and gives the smallest fix. Trace carries
+the doc(s) reviewed.

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -71,7 +71,7 @@ redundant, buried, or missing a hook. That spot is the finding.
 
 Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
 and a section with nothing to report saying so. The verdict vocabulary is
-`project-profile.md` → Reports. No numeric score.
+`project-profile.md` → Reports. No numeric score. In this review they mean:
 
 - **PASS** — fits its reader, leads with the point, says the right thing.
 - **REVISE** — specific, fixable findings (buried point, padding, wrong register, missing fact).

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -83,7 +83,7 @@ and watch where their eye snags or stalls; that spot is the finding.
 
 Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
 and a section with nothing to report saying so. The verdict vocabulary is
-`project-profile.md` → Reports. No numeric score.
+`project-profile.md` → Reports. No numeric score. In this review they mean:
 
 - **PASS** — the eye finds the point; hierarchy and grouping hold.
 - **REVISE** — specific, fixable findings (no hierarchy, fused groups, bold inflation, wall of text).

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -81,15 +81,12 @@ and watch where their eye snags or stalls; that spot is the finding.
 
 ## Report
 
-Per doc, a short verdict and specific findings — no numeric score.
-
-```
-<doc> — PASS | REVISE
-
-- <what hurts the look, with the location> → <smallest fix>
-```
+Report per `.claude/rules/agent-report.md` — the verdict first, findings as a table,
+and a section with nothing to report saying so. The verdict vocabulary is
+`project-profile.md` → Reports. No numeric score.
 
 - **PASS** — the eye finds the point; hierarchy and grouping hold.
 - **REVISE** — specific, fixable findings (no hierarchy, fused groups, bold inflation, wall of text).
 
-End with what was reviewed and the suggested next step.
+Each finding names the location of what hurts the look and gives the smallest fix. Trace
+carries the doc(s) reviewed.

--- a/docs/stories/STORY-007.md
+++ b/docs/stories/STORY-007.md
@@ -1,0 +1,97 @@
+# STORY-007: A standard report format for every agent gate
+
+## User Story
+
+As the human who gates every step of these workflows,
+I want each command to report back in the same, scannable shape,
+So that judging a step costs a glance instead of a re-read, and I can tell what was
+checked, what was skipped, and what is still uncertain without reconstructing it myself.
+
+## The Need
+
+Every workflow this repo ships is a chain of human gates. Nine `dw-*` steps, four
+`qw-*`, two `doc-*` — each one stops and asks a person to decide. The markdown and the
+GitHub issues hold up well; they are versioned, greppable, and the story → plan → task
+chain traces cleanly. The bottleneck is not the artifacts. It is **reading the agent's
+report at the gate.**
+
+Those reports have no agreed shape. Nothing in the commands defines one:
+
+- Fourteen of the fifteen commands say nothing at all about what to print when they finish.
+- The ones that do each name different things in different words — one asks for a
+  verdict, findings, a path and a next step; another asks for findings with line
+  numbers, a delivery verdict, and an issue link; a third defines a decision but never
+  says to report it.
+- Even the verdict vocabulary drifts between neighbouring commands.
+
+With nothing specified, the shape is improvised fresh each run. The cost lands on the
+reader in three ways:
+
+**Categories collapse into one another.** A single block of prose carries the problem,
+the concern, what was completed, what was already known, what was skipped, what was
+worked around, the summary, and the status — all mixed together. The two that matter
+most are the two that blur worst: something *deliberately skipped* and something
+*genuinely unresolved* read identically, though one is a choice and the other is a risk.
+
+**Silence is ambiguous.** When a report doesn't mention an area, there is no way to tell
+whether it didn't apply or the agent never looked. A confident verdict can quietly cover
+less than the reader assumes.
+
+**The form fights the reader.** Findings that are a table arrive as paragraphs; a
+sequence of gates arrives as prose describing arrows; a comparison arrives as
+alternating blocks of text. The reader ends up rebuilding the structure in their head,
+and that rebuilding *is* the review cost.
+
+This compounds with how the workflows are actually used. Work runs in parallel sessions,
+and returning to one means recalling what was already decided, what passed, and what is
+still open. A report that has to be re-read from the top every time makes the human the
+slowest part of a pipeline built entirely around their judgment.
+
+There is also no check on any of this. A newly written command can ship without saying
+what it reports, and nothing notices — the same shape of gap this repo is already
+addressing elsewhere, where a value goes unspecified and only surfaces when someone
+downstream trips over it.
+
+## Success Looks Like
+
+- Reports from two different commands are recognizably the same shape — a reader who
+  has seen one knows where to look in the other.
+- The decision a report is asking for is apparent without reading the report.
+- What was deliberately left out and what is genuinely uncertain are never confusable,
+  and an area with nothing to report says so rather than going silent.
+- A reader can tell what a passing verdict actually covers.
+- Reports lead with structure — the shape of the content is visible before the words
+  are read — and prose appears only where an argument genuinely has to be followed.
+- A report is legible in the place it lands: readable as plain text in a chat session,
+  and free to use whatever renders when it lands in a document or a GitHub issue.
+- A command that doesn't say what it reports is caught when it is written, not months
+  later by a reader who noticed the reports feel inconsistent.
+- A project adopting these workflows can put the reports into its own house style
+  without editing anything this repo ships.
+
+## Open Questions
+
+- Does one report shape cover every unit, or do producers and reviews need different
+  weight — a review leads with findings, a producer with what it made? (decided in
+  `dw-plan`)
+- Are the verdict wording and the section names fixed by this repo, or declared by the
+  adopting project like its other specifics? The second is consistent with the
+  customization seam, but it makes every report shape project-dependent.
+- Is this the same body of work as the story that closed the customization seam? Both
+  want a pass that checks "this unit declares what it owes its reader," and building
+  that check twice would be waste.
+- How is that check actually made — a question added to the artifact review, a line in
+  the rules, or something runnable? (shared with the story above)
+- The repo already has a stated position on diagrams in its published docs. Does a
+  per-medium rule for reports sit alongside it or contradict it?
+- A GitHub board was raised alongside this as a way to see which work is next. It
+  answers a different question than a report does, and may not belong to this story at
+  all — decide whether it is in scope or its own thread.
+- Right-sizing: a full report on a trivial, one-line answer would be ritual rather than
+  rigor. Where is the floor below which the shape doesn't apply?
+
+## Status
+
+- Created: 2026-08-03
+- Plan: #104
+- Issues: #105, #106, #107, #108


### PR DESCRIPTION
Closes #105
Closes #106
Closes #107
Closes #108

Part of [STORY-007](../docs/stories/STORY-007.md) · plan #104

## Why

Every unit in this toolkit ends at a **human gate**, but nothing said what to print there. 14 of 15 commands had no `## OUTPUT` section; six producers finished silently; the units that did report each named a different subset of fields. With nothing specified the shape was improvised each run — so a skipped step and an unresolved risk read alike, and a PASS never said what it covered.

## What changed

| # | Change |
|---|---|
| #105 | `.claude/rules/agent-report.md` — the seven questions a report answers, and the rules that make it work. `project-profile.md` → Reports holds the *words* (verdicts, section names, per-medium formats) |
| #106 | All 15 commands resolve to it: eight gained an `## OUTPUT` section, six Report steps stopped enumerating partial field lists, and the `REVISED` verdict outlier is gone |
| #107 | The three `reviewing-*` skills resolve too, pointing per use as the skill wiring style requires; `CUT` is declared in the profile as the artifact review's own |
| #108 | `reviewing-artifacts` Q2 now bites on a unit that never says what it reports, restates the sections inline, or invents verdict words |

## Design note

The contract is stated as **goals, not a heading template**. A frozen block of headings is a *mechanism* no profile value could override — the exact trap STORY-006 (#99–#101) just finished closing. The rule states the questions; the profile names the words, so a downstream restyles reports without editing a shipped unit.

## Review history

`/code-review medium` found nine findings on the first commit; `8337cdb` fixes six. Two were real defects:

- **`dw-merge` routed a deliberate follow-up into `Unresolved`** — a *choice* filed as a *risk*, the one collapse the contract exists to prevent, committed by the first command to use the vocabulary.
- **Four worked examples still taught the pre-contract shape.** Agents copy the concrete example over the prose above it, so those commands would have kept emitting the old shape and the story's "same shape across commands" criterion would have failed on first run.

One finding was rejected (group-rule coverage already exists via `agent-report.md`'s `paths:`); two naming/layout calls were left as-is by the author's decision.

## Known limits

- Commands name section names inline (`Trace carries…`). Allowed by the profile's "two wiring styles", but a project renaming `Trace` leaves that prose stale.
- The contract is untested by a fresh session — every report written so far came from an author who already knew it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)