### PR TITLE
Close the story's plan issues when its last task merges

### DIFF
--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -8,7 +8,9 @@ PR number: {{input}}
 ## PURPOSE
 
 Merges an approved PR, deletes the remote branch, cleans up local branches
-and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body;
+a plan issue never does — no PR targets one — so this command closes the
+story's plans when its last task lands.
 
 ---
 
@@ -40,11 +42,17 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │   - Run: gh issue edit <N> --remove-label "status:needs-review"
         │   - Issue auto-closes via "Fixes #N" — no manual close needed
         │
-        ├─► Step 5: Update Story File (if linked)
+        ├─► Step 5: Close Out the Story (if linked)
         │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
         │     • Check off completed acceptance criteria for this task
         │     • If all story tasks are closed, mark story status as Completed
-        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │   - When that was the story's LAST open task, close its plan issues — no PR
+        │     ever targets a plan, so nothing else will:
+        │       gh issue list --search "[STORY-XXX]" --label plan --state open
+        │       gh issue list --search "[STORY-XXX]" --label test-plan --state open
+        │     Close each, naming the PR that finished the story. Both kinds orphan the
+        │     same way; qa has no terminal gate of its own, so this closes both.
+        │   - Skip silently if no story link, no docs/stories/, or no plan issue is open
         │
         ├─► Step 6: Clean Up Local Branch
         │   - Switch to the repo's default branch and pull — derive it, don't
@@ -54,6 +62,7 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
         │
         └─► Step 7: Report
             - Report per .claude/rules/agent-report.md; Trace carries the merged PR URL
+              and any plan issues closed
             - Next: /dw-implement <next-issue> if the story has open tasks left,
               otherwise say the story is complete
             - A follow-up the merge deliberately leaves behind is Not done (a choice);
@@ -71,13 +80,15 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
     $ gh pr checks 30
     $ gh pr merge 30 --merge --delete-branch
     $ gh issue edit 27 --remove-label "status:needs-review"
+    $ gh issue list --search "[STORY-003]" --label plan --state open   # last task → close it
+    $ gh issue close 28 --comment "Delivered — last task merged in PR #30."
     $ git checkout <default-branch> && git pull
     $ git branch -d issue-27-release-notes
 
 **Output:**
 
     PR #30 merged: https://github.com/owner/repo/pull/30
-    Issue #27 auto-closed.
+    Issue #27 auto-closed. Plan #28 closed — that was STORY-003's last task.
     Branch issue-27-release-notes deleted (local + remote).
 
 ---
@@ -88,4 +99,7 @@ and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
 - `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
 - `--delete-branch` removes the remote branch; `git branch -d` removes the local one
 - If PR is not approved or CI fails, report the blocker instead of merging
+- A plan closes only on the story's LAST open task — it stays open while any remain
+- The close is hooked to this command, so a story finished another way (tasks closed
+  by hand, a PR merged in the UI) still leaves its plan open
 ```

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -46,8 +46,8 @@ story's plans when its last task lands.
         │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
         │     • Check off completed acceptance criteria for this task
         │     • If all story tasks are closed, mark story status as Completed
-        │   - When that was the story's LAST open task, close its plan issues — no PR
-        │     ever targets a plan, so nothing else will:
+        │   - On that same condition — all story tasks closed — also close its plan
+        │     issues. No PR ever targets a plan, so nothing else will:
         │       gh issue list --search "[STORY-XXX]" --label plan --state open
         │       gh issue list --search "[STORY-XXX]" --label test-plan --state open
         │     Close each, naming the PR that finished the story. Both kinds orphan the

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -38,6 +38,8 @@ The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-X
 Its body holds the researched approach, acceptance criteria, and the commands/files it
 expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
 with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+Nothing auto-closes it — no PR targets a plan — so `dw-merge` closes it when the
+story's last task lands.
 
 Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
 before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -29,7 +29,9 @@ those docs to a runner and running them is the project's own layer.
 
 `qw-plan`'s scenarios persist as a **GitHub issue**, titled `[STORY-XXX] Test Plan`, labelled
 `test-plan` (distinct from dev's `[STORY-XXX] Plan`). `qw-review-plan` reviews it; `qw-cases`
-reads it and records the issue number in each `TS-*.md` `plan:` field.
+reads it and records the issue number in each `TS-*.md` `plan:` field. Closing it falls to
+`dw-merge`: this pipeline has no terminal gate of its own, and the docs reach the default
+branch through the dev-workflow like any other change.
 
 ## Producer → review pairing
 

--- a/docs/stories/STORY-008.md
+++ b/docs/stories/STORY-008.md
@@ -1,0 +1,58 @@
+# STORY-008: Close the plan issue when its story is done
+
+## User Story
+
+As someone running the dev-workflow,
+I want a story's plan issue to close when the work it planned is finished,
+So that my open-issue list shows what is actually outstanding, rather than a growing
+   pile of plans for work that shipped weeks ago.
+
+## The Need
+
+The plan issue is the parent of a story's task issues and the checkpoint a fresh session
+resumes from. It is the one issue in the pipeline that nothing ever closes.
+
+Task issues close themselves — a PR says `Closes #N` and GitHub does the rest. The plan
+is nobody's `Closes` target, because no PR delivers the plan; PRs deliver its tasks. So
+`dw-merge` merges the last task, marks the story Completed, and leaves the plan open
+behind it.
+
+This is not a slip anyone made. Both plan issues this repo has ever created ended up
+orphaned: STORY-005's sat open for six weeks after the story was marked Completed, and
+STORY-007's was open within the hour of its last task closing. A gap that catches every
+instance is in the pipeline, not in the person driving it.
+
+The cost is small per instance and compounds: an open-issue list that has to be read
+with a caveat is one nobody trusts at a glance, and the plan issue is exactly the thing
+someone scans for when asking "what is still in flight here?".
+
+## Success Looks Like
+
+- Finishing a story's last task leaves no open plan issue behind — without anyone
+  remembering to close it.
+- The open-issue list answers "what is still in flight?" honestly, with no mental
+  filtering for plans that have already shipped.
+- A plan whose story still has open tasks stays open — the close happens when the work
+  is done, not when any task merges.
+- A plan someone already closed by hand, or a story that never had one, causes no error
+  and no noise.
+- Every story that finishes gets the same treatment — the two plans orphaned here were
+  the symptom that surfaced this, not the scope of the fix.
+
+## Open Questions
+
+- What exactly triggers the close — the last task issue closing, or the story being
+  marked Completed? They coincide today; if they ever diverge, one has to be the trigger.
+- A story can end without every task merging: some are closed as won't-do, some
+  abandoned. Does "all tasks closed" cover that, or does it need to mean something
+  narrower?
+- The qa-workflow has the same shape — `qw-plan` creates a `[STORY-XXX] Test Plan`
+  issue, and nothing closes that either. Is this one fix covering both pipelines, or
+  does the qa side need its own?
+- Which unit owns the close? `dw-merge` is where the last task lands, but a story can
+  also be finished by hand, and then nothing runs.
+
+## Status
+
+- Created: 2026-08-03
+- Issues: #110


### PR DESCRIPTION
## Summary

- A plan issue is nobody's `Closes` target — no PR delivers the plan, PRs deliver its tasks — so nothing in the pipeline ever closed one. Both plans this repo has created were orphaned: STORY-005's for six weeks, STORY-007's within the hour of its last task closing.
- `dw-merge` Step 5 becomes **Close Out the Story**: on the condition it already computes for the story-file update — all story tasks closed — it now also closes the story's open plan issues.
- **Covers the qa side too.** `qw-plan`'s `[STORY-XXX] Test Plan` issue orphans identically, and the qa-workflow has no terminal gate of its own; its docs reach `main` through `dw-create-pr`/`dw-merge` like anything else. So one command owns both.
- Both rules now say who closes a plan — `dev-workflow.md` and `qa-workflow.md` each described the plan's lifecycle (created, parent, checkpoint) and stopped short of closure.

Closes #110

Part of STORY-008

## Known limit, recorded in the command

The close is hooked to a merge, so a story finished another way — tasks closed by hand, a PR merged in the GitHub UI — still leaves its plan open. That is STORY-008's fourth Open Question and is deliberately not solved here; anything wider needs a trigger other than a command nobody ran.

## Test plan

- [ ] A story whose last task merges has its `plan` and `test-plan` issues closed
- [ ] A story with tasks still open keeps its plan open
- [ ] A story with no plan issue, or one already closed, produces no error and no noise
- [ ] Cross-references resolve: `.claude/rules/agent-report.md`, and both labels declared in `project-profile.md` → Labels

**This PR cannot demonstrate its own change:** STORY-008 skipped the plan stage as trivial work, so there is no plan issue for `dw-merge` to close when it lands. First real exercise will be the next story that runs `dw-plan`.

Generated with [Claude Code](https://claude.com/claude-code)