### PR TITLE
Add reporting-outcomes: the report contract on ordinary chat replies

### DIFF
--- a/.claude/skills/reporting-outcomes/SKILL.md
+++ b/.claude/skills/reporting-outcomes/SKILL.md
@@ -128,9 +128,9 @@ cannot see it needs the shape. That is what a model-invoked skill is for.
 
 The `## Producer → review pairing` tables in `.claude/rules/*.md` pair every
 producer with a review. This produces nothing — no artifact, no file, no run,
-and no gate output of its own — so there is nothing for a review to check. It is a reference, not a deliverable
-as `project-profile.md` → Review semantics defines one: it changes only how a
-reply that was being written anyway is arranged.
+and no gate output of its own — so there is nothing for a review to check. It is
+a reference, not a deliverable as `project-profile.md` → Review semantics defines
+one: it changes only how a reply that was being written anyway is arranged.
 
 Written down because the gerund name reads like a producer and the
 `reviewing-artifacts` pairing question is right to ask — better answered here

--- a/.claude/skills/reporting-outcomes/SKILL.md
+++ b/.claude/skills/reporting-outcomes/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: reporting-outcomes
+description: |
+  Shapes the ordinary reply that reports back on work — the chat turn carrying
+  progress, a verdict, reasons, a summary and a status all at once. Use whenever
+  answering with what was done, what was found, whether it worked, where things
+  stand, or what is left, and the answer runs longer than a line. Not for
+  command or gate output, which already resolves the contract itself. Holds the
+  trigger and the mapping; the questions live in `.claude/rules/agent-report.md`
+  and the words in `project-profile.md` → Reports.
+---
+
+# reporting-outcomes
+
+## The shape this catches
+
+An agent finishes a piece of work and writes back. The reply contains, in
+whatever order they occurred to it:
+
+> some of what happened · whether it worked · why it was done that way · what is
+> still running · what broke · what it means · what is next
+
+Every one of those is worth saying. Together, unsorted, they are a narrative the
+reader has to mine. They open the message wanting one thing — *is this good, and
+what do I do now* — and get a story they must read to the end twice.
+
+This is the most common shape in an agentic session and the only one with no
+contract on it. Gate output has `agent-report.md` wired into the commands that
+produce it. A conversational report-back has nothing.
+
+## Where the format lives — do not restate it
+
+| You need | Read |
+|---|---|
+| The questions a report answers, and why | `.claude/rules/agent-report.md` |
+| Verdict words, section names, finding columns, empty marker | `.claude/rules/project-profile.md` → **Reports** |
+
+Resolve both from there each time. A copy here would go stale silently: nothing
+breaks when a duplicated verdict word drifts from the profile's, so nothing
+announces it — the skill simply starts teaching a shape the rest of the toolkit
+no longer uses. `agent-report.md` makes the same argument for itself under *Why
+this is a rule, not a template*.
+
+## Where each piece goes
+
+The pieces a chat reply mixes map onto the contract; they are not extra
+sections. The right-hand column names the contract's **questions** — the wording
+of any heading you actually type is the profile's.
+
+| What you are about to write | Where it belongs |
+|---|---|
+| whether it worked, is ready, is safe | the **verdict** — first, alone, before any narration |
+| what broke, what was found, what needs acting on | **findings** |
+| what you actually looked at or ran | **checked** — this is what scopes the verdict |
+| what you skipped on purpose | **not done** — a choice |
+| what you could not settle, or fixed without proving | **unresolved** — a risk |
+| files, commits, paths, IDs | **trace** |
+| the one thing to do now | **next** |
+| *why* you did it that way | inline with the finding it explains, or nowhere |
+
+Reasoning is the piece most often given its own paragraph and it rarely earns
+one. Attach it to the thing it justifies. If it justifies nothing the reader must
+act on, cut it.
+
+## Mid-flight is not a verdict
+
+A chat report-back is often not finished, and that changes the first line rather
+than removing it. What the reader decides is still the question — it is just a
+different question.
+
+| State | The first line answers |
+|---|---|
+| finished | did it pass |
+| still running | what is running, and what you will do when it lands |
+| blocked | what you need, and from whom |
+| partial | what is settled, and what is not |
+
+**Progress is not a verdict, and must not be dressed as one.** "Working through
+the scenarios" is a status. "Six of nine clear, three failing on the same
+cause" is a report.
+
+## When this does not fire
+
+Load-bearing, because a skill that fires on everything makes every reply a form.
+The rule says it plainly: a one-line reply, a confirmation, or a single fact
+asked for directly *is* the answer, and seven sections around it are ritual.
+
+Leave it alone when:
+
+- the answer is one fact and the fact is what was asked
+- it is an acknowledgement — "pushed", "done", "it is at X"
+- the work itself is the deliverable and this is just the covering note
+- it is a discussion, a design proposal, or thinking aloud — a report states a
+  conclusion, it does not develop one
+- nothing was judged. A status carrying no judgment is a status, and fine
+
+**The sections are a ceiling.** A small result answers the same questions in
+three lines and no headings. Reaching for the full shape on a small result is
+the failure mode, not the safe default.
+
+## What it prevents
+
+Four ways a report-back fails while still reading like a complete one.
+
+**The buried verdict.** The judgment lands after two paragraphs of how it was
+reached, so the reader spends the attention the report existed to save — and on
+a failure, spends it twice.
+
+**Choice collapsed into risk.** Something skipped deliberately and something
+still unknown read identically once they share a list. One needs nothing; the
+other is the reason to keep reading.
+
+**Silent omission.** An absent section cannot be told from a question never
+asked. "No issues found" and "did not look" are the same text when the text is
+missing.
+
+**Confidence not matched to method.** A thing fixed on reading and a thing
+reproduced then fixed are stated in the same voice. Only the writer knows the
+difference, so only the writer can record it.
+
+## Why a skill
+
+A command runs when a person types `/name`. This has to fire when nobody thought
+to ask — the reply is already being written, and the writer is the one who
+cannot see it needs the shape. That is what a model-invoked skill is for.
+
+## Why no paired review
+
+The `## Producer → review pairing` tables in `.claude/rules/*.md` pair every
+producer with a review. This produces nothing — no artifact, no file, no run,
+and no gate output of its own — so there is nothing for a review to check. It is a reference, not a deliverable
+as `project-profile.md` → Review semantics defines one: it changes only how a
+reply that was being written anyway is arranged.
+
+Written down because the gerund name reads like a producer and the
+`reviewing-artifacts` pairing question is right to ask — better answered here
+once than re-derived at every audit.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Slash commands that make an AI coding agent follow an **exact, documented order*
 - [Installation](#installation)
 - [Usage](#usage)
 - [Available commands](#available-commands)
-- [Review skills](#review-skills)
+- [Skills](#skills)
 - [Project structure](#project-structure)
 - [The agent family](#the-agent-family)
 - [License](#license)
@@ -35,7 +35,7 @@ No installer, no build step. The workflows are plain markdown files under `.clau
 ```
 git clone https://github.com/dogkeeper886/agent-workflows
 
-# copy the commands, review skills, and workflow rules into your repo
+# copy the commands, skills, and workflow rules into your repo
 cp -r agent-workflows/.claude/commands/dev-workflow  your-repo/.claude/commands/
 cp -r agent-workflows/.claude/commands/qa-workflow   your-repo/.claude/commands/
 cp -r agent-workflows/.claude/commands/doc-workflow  your-repo/.claude/commands/
@@ -91,11 +91,15 @@ Test-doc authoring, each producer paired with a review.
 
 `qw-plan` · `qw-review-plan` · `qw-cases` · `qw-review-cases`
 
-## Review skills
+## Skills
 
-Project-local skills in `.claude/skills/`. They review by judgment, not a scored checklist — a minimum bar, not an exhaustive one. Invoke them by hand.
+Project-local skills in `.claude/skills/`.
+
+**The review skills (`reviewing-*`)** judge finished work — by judgment, not a scored checklist; a minimum bar, not an exhaustive one. Invoke them by hand.
 
 ![Review skills: human-read docs go to reviewing-phrasing (words) + reviewing-typography (look); agent-read tooling goes to reviewing-artifacts](docs/diagrams/png/07-review-skills.png)
+
+**`reporting-outcomes`** shapes the reply an agent writes when it reports back in chat — the turn carrying progress, a verdict, reasons and a status at once. `agent-report.md` binds what a *command* prints at a gate; this puts the same shape on the conversational report-back, which nothing else covers. It fires on its own, not by hand, and states as carefully when it should stay out of the way.
 
 ## Project structure
 
@@ -106,7 +110,7 @@ agent-workflows/
 │   │   ├── dev-workflow/   # Dev lifecycle commands (dw-*)
 │   │   ├── qa-workflow/    # Test-doc authoring commands (qw-*)
 │   │   └── doc-workflow/   # README authoring commands (doc-*)
-│   ├── skills/             # Review skills (reviewing-*)
+│   ├── skills/             # Review skills (reviewing-*) + reporting-outcomes
 │   └── rules/              # The pipelines, the report contract, project-profile
 ├── templates/             # Sample CLAUDE.md for projects adopting these workflows
 ├── docs/


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/reporting-outcomes/` — the trigger and mapping that put `agent-report.md`'s shape on the reply an agent writes when it reports back in chat. Fifteen units cite that contract for gate output; the conversational report-back, which happens far more often, had nothing on it.
- Holds no format. The questions stay in `agent-report.md`, the words in `project-profile.md` → Reports, pointed at from three places because a skill is read alone with no rule beside it. A downstream renames its verdict words in its own profile and the skill follows — it never edits the shipped file.
- README: `.claude/skills/` is no longer review-only, and four places said it was — the Contents anchor, the section heading and lede, the install comment, and the structure tree.

Backported from `r1-test-cases@805ae4c`, which has been running it. The original cited `active/CLAUDE.md`, `testlink-format` and its own incident history; none exist here, so each claim was rewritten against what this repo actually has rather than carried across as a dangling reference.

Fixes #112

## Test plan

- [ ] Every reference in the skill resolves in this repo — `agent-report.md`, `project-profile.md` → Reports and → Review semantics, the `## Producer → review pairing` tables, `reviewing-artifacts`
- [ ] The skill declares no verdict words, section names or finding columns of its own
- [ ] No surviving link to the old `#review-skills` anchor
- [ ] `reviewing-artifacts` passes on the new skill
- [ ] Judgment call worth a second opinion: the mapping table shows the seven section names in lowercase as an illustrated default, with the deferral stated beside it

Generated with [Claude Code](https://claude.com/claude-code)