### PR TITLE
Make the units project-agnostic

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -20,8 +20,7 @@ via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
         │   - Confirm you're on the correct branch (issue-<N>-<slug>)
         │   - Run: git status — check for uncommitted changes
         │   - Review the branch's commits against the repo's default branch —
-        │     derive it, don't hardcode `main` (gh repo view --json
-        │     defaultBranchRef -q .defaultBranchRef.name):
+        │     derive it, don't hardcode `main` (see project-profile → Git):
         │     git log --oneline <default>..HEAD
         │   - If no argument given, infer issue number from branch name
         │   - Run: gh issue view <N> — check if title contains [STORY-XXX]

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -33,8 +33,7 @@ and prepares for PR creation when done.
         │   - Branch name: issue-<N>-<short-slug>
         │     Example: issue-27-release-notes
         │   - Branch from the repo's default branch — derive it, don't hardcode
-        │     `main` (e.g. gh repo view --json defaultBranchRef -q
-        │     .defaultBranchRef.name); check it out and pull, then:
+        │     `main` (see project-profile → Git); check it out and pull, then:
         │     git checkout -b issue-<N>-<slug>
         │   - Comment on issue:
         │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -56,8 +56,8 @@ story's plans when its last task lands.
         │
         ├─► Step 6: Clean Up Local Branch
         │   - Switch to the repo's default branch and pull — derive it, don't
-        │     hardcode `main` (gh repo view --json defaultBranchRef -q
-        │     .defaultBranchRef.name): git checkout <default> && git pull
+        │     hardcode `main` (see project-profile → Git):
+        │     git checkout <default> && git pull
         │   - Run: git branch -d <branch-name>
         │
         └─► Step 7: Report

--- a/.claude/rules/agent-report.md
+++ b/.claude/rules/agent-report.md
@@ -71,5 +71,5 @@ when it finishes and hands a decision to a human. Below that, use judgment.
 A frozen block of headings is a *procedure* — no profile value can override it, so a
 project that reports differently would be forced to edit a shipped unit and its repo
 would then read as drifted when it was only working around us (see
-`project-profile.md` → what belongs here vs. not). State the questions; let the profile
-name the words.
+`profile-doctrine.md` → what belongs in the profile, and what does not). State the
+questions; let the profile name the words.

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -75,7 +75,13 @@ review passes plus a plan issue on a typo is ritual, not rigor.
 ## Project-specific values
 
 Story paths, the `STORY-XXX` id scheme, label names + colours, the `[STORY-XXX]` /
-`Part of #<plan>` linking patterns, the `issue-<N>-<slug>` branch name, and the merge
-strategy are **not** owned by the `dw-*` commands — they resolve from
+`Part of #<plan>` linking patterns, the `issue-<N>-<slug>` branch name, the merge
+strategy, and **the platform** — the CLI, the change-request noun, and the verbs that
+differ between hosts — are **not** owned by the `dw-*` commands. They resolve from
 `.claude/rules/project-profile.md`. The values a command shows are the defaults; change
 them in the profile, not the command.
+
+The `gh` invocations throughout these commands are that kind of illustrated default. A
+project on another host reads its equivalents from the profile's **Platform** section; no
+`dw-*` command names a hostname, an owner, or a repository path, and none should be edited
+to add one.

--- a/.claude/rules/profile-doctrine.md
+++ b/.claude/rules/profile-doctrine.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - ".claude/commands/**/*.md"
+  - ".claude/skills/**/*.md"
+---
+
+# profile-doctrine
+
+Where the line falls between what every project shares and what belongs to one project.
+This file is the same everywhere and is not edited downstream; the values it talks about
+live in the project, at `.claude/rules/project-profile.md`.
+
+## The profile
+
+The shipped commands and skills state their *intent* and resolve any project-specific
+value — a path, an ID scheme, a label, an integration, a format, an audience — **from the
+project's profile**, instead of hardcoding it. Customize a workflow by editing that file,
+not the units.
+
+**How a unit uses it.** Where a command or skill would otherwise bake in a value, it
+points at the matching section of the profile (e.g. "create the *plan* label — see
+project-profile → Labels"). The values a project starts with are **defaults**: they
+reproduce this toolkit's own behaviour, so a project that changes nothing behaves exactly
+as the toolkit does. Adoption is opt-in — change a line in the profile and every unit
+follows.
+
+**Two wiring styles, and when each applies.** A **skill** points at the profile at each
+point of use — it is read on its own, with no rule loaded beside it. A **command** may
+show a value inline as an illustrated default; its group rule (`.claude/rules/*.md`)
+carries the "these resolve from the profile" statement for the whole group, so the pointer
+is not repeated line by line. Both are correct. Which one applies is decided by whether
+the unit is read together with its rule — not by preference.
+
+**No profile, no defaults.** A project that has not declared its values does not fall back
+to another project's — a unit that needs a value it cannot resolve stops and says so. A
+silent fallback would run one project's paths, labels, and ID scheme inside another, with
+nothing in the session to reveal it.
+
+## What belongs in the profile, and what does not
+
+The profile is for **declarative** customization — a value or a list. A whole
+**procedure** (e.g. how to publish to Confluence and review the render) is *not* a value;
+it belongs in its own project-owned skill, never crammed into a general unit. Lists → the
+profile; procedures → a project skill. This is the rules files' "what this owns vs. what
+it hands off" boundary, made concrete.
+
+The same line binds the **units**. A value the profile can restate is safe for a unit to
+show inline; a *procedure* never is — how drift is detected, how files are laid out. No
+value can override a procedure, so a project that does it another way is forced to edit a
+shipped unit, and its repo then reads as drifted when it was only working around us. State
+the goal; let the profile or the project's own layer name the mechanism.
+
+## Where a project's own units live
+
+A project may have commands and skills of its own — ones no other project wants. They stay
+in the project, and they take a `<repo-name>-` prefix, so a project's unit can never be
+mistaken for, or collide with, one every project shares.
+
+Project-specific **rules** take no prefix. A rule is reached by path from the unit citing
+it, so it has no namespace to collide in, and `paths:` front-matter already scopes it to
+the files it governs. `workflow-patterns.md` scoped to `.github/workflows/**` is correctly
+named; `myrepo-workflow-patterns.md` would only be noise.

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -6,37 +6,14 @@ paths:
 
 # project-profile
 
-The one place a downstream project declares its specifics. The shipped commands and
-skills state their *intent* and resolve any project-specific value — a path, an ID
-scheme, a label, an integration, a format, an audience — **from this file**, instead of
-hardcoding it. Customize a workflow by editing this file, not the units.
+**The values this project declares.** Every unit resolves its project-specific values from
+here rather than hardcoding them, so a workflow is customized by editing this file and not
+the units. Change a line here and every unit follows.
 
-**How a unit uses it.** Where a command or skill would otherwise bake in a value, it
-points at the matching section here (e.g. "create the *plan* label — see
-project-profile → Labels"). The values below are the **defaults**: they reproduce this
-repo's current behaviour, so a project that changes nothing behaves exactly as it does
-now. Adoption is opt-in — change a line here and every unit follows.
-
-**Two wiring styles, and when each applies.** A **skill** points at this file at each point
-of use — it is read on its own, with no rule loaded beside it. A **command** may show a
-value inline as an illustrated default; its group rule (`.claude/rules/*.md`) carries the
-"these resolve from the profile" statement for the whole group, so the pointer is not
-repeated line by line. Both are correct. Which one applies is decided by whether the unit
-is read together with its rule — not by preference.
-
-**What belongs here vs. not.** This file is for **declarative** customization — a value
-or a list. A whole **procedure** (e.g. how to publish to Confluence and review the
-render) is *not* a value; it belongs in its own project-owned skill, never crammed into
-a general unit. Lists → here; procedures → a project skill. This is the rules files'
-"what this owns vs. what it hands off" boundary, made concrete.
-
-The same line binds the **units**. A value this file can restate is safe for a unit to show
-inline; a *procedure* never is — how drift is detected, how files are laid out. No value can
-override a procedure, so a project that does it another way is forced to edit the shipped
-unit, and its repo then reads as drifted when it was only working around us. State the goal;
-let this file or the project's own layer name the mechanism.
-
----
+How that resolution works — the two wiring styles, what belongs here rather than in a
+project skill, and what happens when a value cannot be resolved — is
+`.claude/rules/profile-doctrine.md`. That file is the same in every project; this one is
+not.
 
 ## Paths
 
@@ -71,9 +48,29 @@ project's choice.
 - issue closure (PR → issue): `Fixes #N` / `Closes #N`
 - feature branch name: `issue-<N>-<slug>`
 
+## Platform
+
+The code host and issue tracker. **Worked out, not written down** — a unit derives the
+host from `git remote get-url origin`. No hostname, owner, or repository path belongs in
+this file or in any unit; an address a person has to keep correct is one that goes stale
+silently.
+
+- CLI: `gh` (GitHub) · `glab` (GitLab) — both read the current repository from the git
+  remote, so neither takes a `-R` / `--repo` argument while inside the repo
+- change-request noun: `PR` (GitLab: `MR`) — wording, which is the one thing derivation
+  cannot supply
+- where the verbs differ: comment on an issue `gh issue comment` / `glab issue note` ·
+  label an issue `gh issue edit --add-label` / `glab issue update --label`
+
+A command shows one platform's commands inline as the illustrated default; a project on
+the other host resolves them here rather than editing the command (see
+`profile-doctrine.md` → Two wiring styles).
+
 ## Git
 
-- default branch: *derive it* (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`), don't assume `main`
+- default branch: *derive it* (`git symbolic-ref --quiet refs/remotes/origin/HEAD`, minus
+  the `refs/remotes/origin/` prefix), don't assume `main` — no network call and no
+  platform CLI, so it reads the same on every host
 - merge strategy: `--merge` (preserve history; switch to `--squash` only if the project requires)
 
 ## Front-matter & format contract (test docs)

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -59,12 +59,10 @@ silently.
   remote, so neither takes a `-R` / `--repo` argument while inside the repo
 - change-request noun: `PR` (GitLab: `MR`) — wording, which is the one thing derivation
   cannot supply
-- where the verbs differ: comment on an issue `gh issue comment` / `glab issue note` ·
-  label an issue `gh issue edit --add-label` / `glab issue update --label`
-
-A command shows one platform's commands inline as the illustrated default; a project on
-the other host resolves them here rather than editing the command (see
-`profile-doctrine.md` → Two wiring styles).
+- where the verbs differ: change requests `gh pr <verb>` / `glab mr <verb>` · comment on
+  an issue `gh issue comment` / `glab issue note` · label an issue
+  `gh issue edit --add-label` / `glab issue update --label`. The rest — `issue view`,
+  `issue list`, `issue create`, `label create` — read the same on both.
 
 ## Git
 

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -54,6 +54,11 @@ The format a test doc must follow is `docs/tests/README.md`.
 ## Project-specific values
 
 The `docs/tests/` path, the `test-plan` label + colour, the `TS-`/`TC-` id schemes, the
-test-doc front-matter fields, the drift anchor, and the default status are **not** owned
-by the `qw-*` commands — they resolve from `.claude/rules/project-profile.md`. The values
-a command shows are the defaults; change them in the profile, not the command.
+test-doc front-matter fields, the drift anchor, the default status, and **the platform** —
+the CLI and the verbs that differ between hosts — are **not** owned by the `qw-*` commands.
+They resolve from `.claude/rules/project-profile.md`. The values a command shows are the
+defaults; change them in the profile, not the command.
+
+The `gh` invocations in these commands are that kind of illustrated default; a project on
+another host reads its equivalents from the profile's **Platform** section rather than
+editing the command.

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -46,7 +46,8 @@ Ask these of any artifact. The artifact's type shifts which ones bite hardest.
    filenames, magic values that should be derived, rigid step-by-step where a principle
    would do, and references to tools or layouts that have moved.
    **Bakes in a mechanism?** Hardest bite of this question. A value `project-profile.md`
-   owns may appear inline as a default (see its "Two wiring styles"), but a *procedure* —
+   owns may appear inline as a default (see `profile-doctrine.md` → "Two wiring styles"),
+   but a *procedure* —
    how drift is detected, how files are laid out — cannot be overridden by any value, so a
    project that does it differently must edit the shipped unit. Flag every "compute X this
    way" or "write it at this path" that the profile cannot redirect; the fix is to state

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,43 @@
+# agent-workflows
+
+The toolkit that makes an AI coding agent follow an exact, documented order — the
+`dev-workflow`, `qa-workflow`, and `doc-workflow` pipelines, plus the rules and skills
+they read. This glossary fixes the words used to talk about the toolkit *itself*, as
+distinct from the stories, issues, and test docs it produces.
+
+## Language
+
+**Unit**:
+A command or a skill — one file an agent loads and follows. The pieces that ship
+identically to every project.
+_Avoid_: file, artifact, component
+
+**Rule**:
+A markdown file a unit cites by path for something too long to inline — a pipeline's
+shape, what a report owes its reader, a project's values.
+_Avoid_: doc, guideline, config
+
+**Profile doctrine**:
+The half of `project-profile.md` that explains what a profile is and how a unit resolves
+against it. Identical in every project, so it ships with the units.
+_Avoid_: preamble, header
+
+**Profile values**:
+The half of `project-profile.md` that declares one project's specifics — paths, ID
+schemes, labels, branch conventions, report vocabulary. Different in every project, so it
+stays in the repo.
+_Avoid_: config, settings, options
+
+**Placement**:
+Putting the units where an agent will load them. Happens once, for all projects.
+_Avoid_: install (it means placement and adoption at once)
+
+**Adoption**:
+Declaring a project's profile values so the placed units describe *that* project. Happens
+per project, and cannot be shared between them.
+_Avoid_: install, configuration, setup
+
+**Shadowing**:
+A project-local copy of a unit taking precedence over the placed one. Harmful when the
+local copy is the older of the two, because nothing in the session says which one ran.
+_Avoid_: overriding, drift, stale copy

--- a/docs/adr/0001-ship-as-one-dogfooded-plugin.md
+++ b/docs/adr/0001-ship-as-one-dogfooded-plugin.md
@@ -1,0 +1,34 @@
+# Ship as one plugin, dogfooded from the plugin directory
+
+The toolkit was placed by copying `.claude/` into each project, which left every
+downstream repo on a different version — seven repos frozen on one old copy, three forked
+only to swap `gh` for `glab`. We ship instead as a **single** Claude Code plugin named
+`agent-workflows`, placed once at user level from this repo's own marketplace manifest,
+and this repo consumes that plugin rather than its own `.claude/` — so the thing we test
+is the thing we ship.
+
+## Considered Options
+
+- **Three plugins** (`dev-workflow`, `qa-workflow`, `doc-workflow`). Rejected: 11 of 14
+  projects use at least two of them, and the pipelines are not independent — `qa-workflow`
+  and `doc-workflow` each define themselves as siblings of `dev-workflow`, and all three
+  share `agent-report.md` and one profile. Splitting would need a fourth "core" plugin or
+  three copies of the shared rules. Splitting later is easy; merging later is not.
+- **Keep `.claude/` as the source and build the plugin from it.** Rejected: reintroduces
+  a build step, and lets the tested copy and the shipped copy diverge.
+- **Keep both via symlink.** Rejected: breaks on any checkout that does not preserve
+  symlinks.
+
+## Consequences
+
+Editing a unit no longer takes effect in the current session — the plugin has to
+reinstall first. That is a real cost for the one repo whose job is editing units, and it
+is accepted deliberately: fidelity between tested and shipped is worth more than the
+inner loop.
+
+Doctrine and values separate by citation syntax rather than by convention.
+`${CLAUDE_PLUGIN_ROOT}/rules/…` means doctrine and resolves inside the plugin;
+`.claude/rules/project-profile.md` means values and resolves in the project. A project
+with no profile is a stop-and-tell-the-human gate — there is deliberately no fallback to
+a global profile, because a silent one would run another project's labels and paths with
+nothing in the session to say so.

--- a/docs/stories/STORY-009.md
+++ b/docs/stories/STORY-009.md
@@ -1,0 +1,76 @@
+# STORY-009: Place the toolkit once, instead of copying it into every project
+
+## User Story
+
+As someone running these workflows across many projects,
+I want the commands and skills placed once and updated once,
+So that every project runs the version I actually maintain, instead of whichever copy it
+   was given on the day it was set up.
+
+## The Need
+
+The toolkit is adopted by copying `.claude/` into a project. That copy is a snapshot, and
+nothing ever refreshes it. Fourteen projects on this machine have one; not one of them
+matches this repo.
+
+Seven — `local-agent-lab`, `ruckus1-mcp`, `test-framework-template`, `ldap`, `ollama37`,
+`testlink-mcp`, `ai-qa-step-graph` — are frozen on a single old version, byte-identical to
+each other and 120 changed lines behind across the dev-workflow commands alone, before the
+other two pipelines are counted. They are worse off than projects with nothing
+installed: a correct, current copy already sits at user level, and each project's stale
+copy takes precedence over it. The version that runs is the older one, and nothing in the
+session says so.
+
+Three more — `dory-bom-mcp`, `simtool-madACXAP`, `skill-eval-harness` — read as forks but
+are not. Their entire divergence is swapping one platform's CLI for another's, plus a
+hand-maintained address repeated twelve times in a single command file. That address is
+already wrong: it names a port the project's git remote does not use. A value nobody can
+keep correct is one the workflow should never have asked a person to hold.
+
+Even the file built for per-project difference has drifted for the wrong reason. Every
+copy of `project-profile.md` differs from this one, by 41 to 136 lines — but the largest
+differences are not a project's paths or labels. They are the file's own explanation of
+what a profile is, edited downstream. The file carries two things, only one of which
+varies by project, and the invariant half is the half that has drifted furthest.
+
+None of this is a mistake anyone made. A copy has no way to know it is stale, a hardcoded
+address has no way to notice the remote moved, and a file that mixes the shared with the
+specific gives no signal about which half to leave alone. The cost is paid every time a
+project is set up, every time the toolkit improves, and every time a project is picked up
+after months away and silently runs something other than what it says it runs.
+
+## Success Looks Like
+
+- Adopting the toolkit in a new project means stating what is specific to that project
+  and nothing else, so a new project cannot start out already behind.
+- An improvement to a command reaches every project at once, without visiting any of them.
+- A project hosted on GitLab runs the same commands as one hosted on GitHub, with no
+  edited files and no address for anyone to maintain.
+- A project cannot quietly run another project's paths, labels, or ID scheme; a project
+  that has not declared its own stops and says so.
+- No project runs an older version than the one placed, because no project holds a copy
+  that could be older.
+- A project can still have commands and skills of its own, and they cannot be confused
+  with the ones every project shares.
+- Someone adopting this from the public repo does less work than the README asks of them
+  today, not more.
+
+## Open Questions
+
+- The order the pieces land in. Working out a project's platform has to come before the
+  commands are placed, because one placed command cannot serve two hosts while a host is
+  written into it — the rest of the sequencing is a planning question.
+- Whether deriving the platform from the git remote holds for every project, including a
+  self-hosted instance reached over SSH on a non-default port.
+- What happens to the ten projects already holding a copy, and whether `ai-qa-studio` —
+  117 lines, with its own Confluence, Jira, and TestLink command sets — is one of them or
+  a separate toolkit that should be left alone. Deliberately deferred until this lands.
+- Whether the README can still honestly promise "no installer, no build step."
+- How much the dogfooding loop actually costs in practice: this repo edits commands for a
+  living, and a change to one will no longer be live in the session that made it.
+
+## Status
+
+- Created: 2026-08-11
+- Plan: #114
+- Issues: #115, #116, #117, #118, #119

--- a/docs/stories/STORY-009.md
+++ b/docs/stories/STORY-009.md
@@ -73,4 +73,4 @@ after months away and silently runs something other than what it says it runs.
 
 - Created: 2026-08-11
 - Plan: #114
-- Issues: #115, #116, #117, #118, #119
+- Issues: #115 (PR #120), #116 (PR #120), #117 (PR #120), #118, #119


### PR DESCRIPTION
## Summary

- **#115** — the platform is *worked out*, not written down. New `project-profile` → **Platform**: the host derives from `git remote get-url origin`, so no hostname, owner, or repository path belongs in the profile or any unit. Replaces the platform-specific default-branch call with `git symbolic-ref refs/remotes/origin/HEAD` — no network, no platform CLI — and removes it from `dw-implement`, `dw-create-pr`, `dw-merge`.
- **#116** — the profile splits. The explanatory half becomes `profile-doctrine.md`, which ships with the units and is not edited downstream; `project-profile.md` keeps values only, the one file adoption touches. Adds the no-fallback rule: a project that has not declared its values stops rather than silently resolving to another project's.
- **#117** — a project's own commands and skills stay in the project and take a `<repo-name>-` prefix. Project-specific rules take none: a rule is reached by path, and `paths:` front-matter already scopes it.

Part of STORY-009 · plan #114 · [ADR-0001](../blob/main/docs/adr/0001-ship-as-one-dogfooded-plugin.md)

Fixes #115
Fixes #116
Fixes #117

## Why this shape

Wired the way #101 established — one statement per group rule, not a pointer per command (#98 rejected that as bloat). `gh` still appears inline in the commands as an illustrated default, which the doctrine permits; only the *procedure* had to go, because no profile value can override a procedure.

Three downstream projects carry edited copies for GitLab. Their entire divergence is CLI verbs plus an address repeated 12 times in one file — already naming the wrong port, because it is hand-maintained.

## Test plan

- [x] `glab issue list` / `glab repo view` resolve the project from the git remote with no `-R`, against a self-hosted instance over SSH on a non-default port
- [x] `git symbolic-ref refs/remotes/origin/HEAD` resolves in **25 of 25** local repos, 0 unset — GitHub and self-hosted GitLab alike
- [x] No `defaultBranchRef` or `remote show origin` left in any unit
- [x] All six rules citations resolve; the two pointers into moved sections repointed
- [ ] **Not yet provable:** no `dw-*` command has *run* in a GitLab project reading the new Platform section. That needs the project's edited copy removed, which needs the plugin placed — #118.

Generated with [Claude Code](https://claude.com/claude-code)