### PR TITLE
Make the merge gate observable instead of inferred

### DIFF
--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -58,7 +58,8 @@ silently.
 - change-request noun: `PR` (GitLab: `MR`) — wording, which is the one thing derivation
   cannot supply
 - where the verbs differ: change requests `gh pr <verb>` / `glab mr <verb>` · comment on
-  an issue `gh issue comment` / `glab issue note` · label an issue
+  an issue `gh issue comment` / `glab issue note` · comment on a change request
+  `gh pr comment` / `glab mr note` · label an issue
   `gh issue edit --add-label` / `glab issue update --label`. The rest — `issue view`,
   `issue list`, `issue create`, `label create` — read the same on both.
 

--- a/plugins/agent-workflows/commands/dw-merge.md
+++ b/plugins/agent-workflows/commands/dw-merge.md
@@ -33,25 +33,47 @@ this step it survives on closed work forever.
     /dw-merge 30
         │
         ├─► Step 1: Verify Ready to Merge
-        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,reviewDecision
+        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,headRefOid,comments
         │   - Must be mergeable (no conflicts)
         │   - Run: gh pr checks <PR> — any CI checks must pass (if applicable)
-        │   - The merge gate is HUMAN review + test, not a GitHub approval. On a
-        │     solo repo GitHub blocks self-approval, so do NOT require
-        │     reviewDecision=APPROVED. Before merging, confirm a human has reviewed
-        │     and tested the change. If not yet reviewed/tested, stop and say so.
+        │   - Note headRefOid, the head SHA. Step 2's confirmation is pinned to it
         │
-        ├─► Step 2: Identify the Linked Issue
+        ├─► Step 2: The Human Gate — Look, Ask, Record
+        │   - The gate is HUMAN review + test, not a platform approval. On a solo
+        │     repo the host blocks self-approval, so do NOT require
+        │     reviewDecision=APPROVED — and do not read an empty review list as
+        │     either a yes or a no. It is not a signal in either direction.
+        │   - Look first, in the comments Step 1 already fetched. A confirmation
+        │     naming the current headRefOid IS the gate — say it was found and go
+        │     to Step 3 without asking again
+        │   - Otherwise ask the human outright: has this change been reviewed and
+        │     tested at <headRefOid>? A green /code-review-2axis or
+        │     reviewing-finish does not answer it — those are agent passes, and
+        │     this gate is a person's judgment on the change as a whole
+        │   - On no, or on no answer: do not merge. Stop here and report per Step 7,
+        │     with the missing confirmation as the finding — a refused gate is a
+        │     gate output, and it owes the human the same report a merge does
+        │   - On yes, record it before merging so the gate leaves a trace (the
+        │     comment verb is a project value — see project-profile → Platform):
+        │     gh pr comment <PR> --body "Human review + test confirmed at <SHA>."
+        │   - A confirmation covers the diff it was given for. If the head moved —
+        │     the only confirmation names an older SHA, or the head changes
+        │     mid-run — it does not carry. Ask again against the new head
+        │
+        ├─► Step 3: Identify the Linked Issue
         │   - Read the PR body for its closure keyword (see project-profile →
         │     Linking & branch) and note the issue number for label cleanup
-        │   - If the PR closes no issue, skip Step 4 and say so in the report
+        │   - If the PR closes no issue, skip Step 5 and say so in the report
         │
-        ├─► Step 3: Merge
+        ├─► Step 4: Merge
+        │   - Re-read headRefOid first. If it no longer matches the SHA Step 2
+        │     confirmed, the head moved under the gate: stop, say so, and go back
+        │     to Step 2 against the new head. Do not merge on a stale confirmation
         │   - Run: gh pr merge <PR> --merge --delete-branch
         │   - The merge strategy is a project value (see project-profile → Git)
         │   - --delete-branch cleans up the remote branch
         │
-        ├─► Step 4: Clear the Issue's Labels
+        ├─► Step 5: Clear the Issue's Labels
         │   - Remove the status label the ship tail set, and the triage state
         │     label (see project-profile → Labels):
         │     gh issue edit <N> --remove-label "status:needs-review" \
@@ -59,17 +81,17 @@ this step it survives on closed work forever.
         │   - A label the issue does not carry is not an error — skip it and say so
         │   - The issue auto-closes via its closure keyword — no manual close needed
         │
-        ├─► Step 5: Confirm the Branch Is Gone
+        ├─► Step 6: Confirm the Branch Is Gone
         │   - Switch to the repo's default branch and pull — derive it, don't
         │     hardcode `main` (see project-profile → Git):
         │     git checkout <default> && git pull
-        │   - Step 3 usually removed the local branch already. Confirm, and remove
+        │   - Step 4 usually removed the local branch already. Confirm, and remove
         │     it if it survived: git branch -d <branch-name>
-        │   - "branch not found" here means Step 3 did its job — not a failure
+        │   - "branch not found" here means Step 4 did its job — not a failure
         │
-        └─► Step 6: Report
-            - Report per `agent-report`; Trace carries the merged PR URL and the
-              labels cleared
+        └─► Step 7: Report
+            - Report per `agent-report`; Trace carries the merged PR URL, the head
+              SHA the gate was confirmed at, and the labels cleared
             - Next: nothing in this toolkit. The change has shipped — say so.
             - A follow-up the merge deliberately leaves behind is Not done (a choice);
               Unresolved is for what the merge left genuinely uncertain
@@ -80,10 +102,16 @@ this step it survives on closed work forever.
 
     /dw-merge 30
 
-**Agent verifies, merges, cleans up:**
+**Agent verifies, asks for the gate, records it, merges, cleans up:**
 
-    $ gh pr view 30 --json mergeStateStatus,headRefName,reviewDecision  # mergeable? (don't gate on self-approval)
+    $ gh pr view 30 --json mergeStateStatus,headRefName,headRefOid,comments
+                                       # mergeable? head SHA a1b2c3d; confirmed already? no
     $ gh pr checks 30
+
+    > Has PR #30 been reviewed and tested by a human at a1b2c3d?
+    < yes
+
+    $ gh pr comment 30 --body "Human review + test confirmed at a1b2c3d."
     $ gh pr merge 30 --merge --delete-branch
     $ gh issue edit 27 --remove-label "status:needs-review" --remove-label "ready-for-agent"
     $ git checkout <default-branch> && git pull
@@ -91,9 +119,13 @@ this step it survives on closed work forever.
 
 **Output:**
 
-    PR #30 merged: https://github.com/owner/repo/pull/30
+    PR #30 merged at a1b2c3d: https://github.com/owner/repo/pull/30
+    Human review + test confirmed and recorded on the PR.
     Issue #27 auto-closed; status:needs-review and ready-for-agent cleared.
     Branch issue-27-release-notes deleted (local + remote). You are on <default-branch>.
+
+Run it again on the same PR and Step 2 finds its own comment at the unchanged head
+SHA — the gate is satisfied from the record, and nobody is asked twice.
 
 ---
 
@@ -106,6 +138,9 @@ this step it survives on closed work forever.
   -d` on an already-deleted branch is a harmless error, and the checkout + pull is what
   leaves you somewhere sane either way.
 - If the PR is not mergeable or CI fails, report the blocker instead of merging
+- The gate comment is written by the agent on the human's answer, not by the human. That
+  is deliberate: a signal a solo maintainer has to remember to leave is one that stops
+  being left. Naming the SHA is what makes it a record rather than a rubber stamp
 - `git branch -d` refuses an unmerged branch — that refusal is a signal, not a
   nuisance. Report it; do not reach for `-D`.
 ```

--- a/plugins/agent-workflows/rules/ship-tail.md
+++ b/plugins/agent-workflows/rules/ship-tail.md
@@ -53,6 +53,13 @@ No producer ships without a review covering its output. The review paired with
 `doc-workflow`. The merge gate is a person's judgment, not a platform approval: on a solo
 repo the host blocks self-approval, so neither command may require one.
 
+A gate a person's judgment passes still has to be **observable**, or the command is left
+inferring it. An empty review list is not evidence either way — a carefully reviewed PR
+and an untouched one look identical. So `dw-merge` asks outright and records the answer on
+the change request against the head SHA, and reads that record on a later run. The
+judgment stays the human's; what changes is that it leaves a trace, and a trace pinned to
+a SHA stops covering the diff once the head moves.
+
 ## Project-specific values
 
 The label names, the closure keyword, the branch-name pattern, the merge strategy, the


### PR DESCRIPTION
## Summary

- `dw-merge`'s human gate becomes its own step: **look** for a confirmation comment pinned to the current head SHA, otherwise **ask** outright, **record** the answer on the PR, then merge. The judgment stays the human's; what changes is that it leaves a trace.
- `reviewDecision` is now called out as no signal *in either direction* — an unreviewed PR and a carefully reviewed one present identically on a solo repo, which is what made the old rule unfollowable. It is also no longer fetched, since nothing gates on it.
- Staleness is enforced, not just stated: Step 4 re-reads `headRefOid` and refuses to merge on a confirmation given for a different diff.
- `ship-tail.md` states the shape as doctrine; the profile gains the change-request comment verb (`gh pr comment` / `glab mr note`), which nothing needed until now.

Fixes #132

## Test plan

- [ ] This PR is the first exercise of the new gate — merging it should ask for confirmation, record it at the head SHA, and a second run should find its own comment instead of asking twice.

## Notes for the reviewer

Design choice, from the four options weighed on the issue: **ask + record**. Option 4 (`reviewing-finish` posts its report) was set aside for two reasons — that skill runs *before* `dw-create-pr`, so on a first pass there is no PR to post to and the branch would be dead in the normal flow; and it evidences the *tested* half only, leaving a human's read of the diff as unobservable as before.

The agent writes the record on the human's answer rather than asking them to leave one. That is deliberate — a signal a solo maintainer has to remember is one that stops being left — but it does mean the comment attests to an answer given, not independently to a human's read.

Generated with [Claude Code](https://claude.com/claude-code)