### PR TITLE
Correct how plugin edits take effect; close the gate's self-answer hole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,17 +131,24 @@ wording, or the artifact's fitness actually matters.
 
 ## 7. This repo runs the plugin it ships
 
-The units live in `plugins/agent-workflows/`, not in `.claude/`. The session loads the
-**installed** plugin — a snapshot pinned to a commit — so editing a unit here does not
-change the command you are running. That trade is [ADR-0001](docs/adr/0001-ship-as-one-dogfooded-plugin.md);
-the cost is one command and a restart:
+The units live in `plugins/agent-workflows/`, not in `.claude/` — this repo consumes the
+plugin it ships ([ADR-0001](docs/adr/0001-ship-as-one-dogfooded-plugin.md)). **How your
+edits take effect depends on how you placed it**, and the two cases differ enough to be
+worth knowing which you are in — check `~/.claude/plugins/known_marketplaces.json`:
 
-```
-claude plugin update agent-workflows@agent-workflows
-```
+| Placed from | What loads | To see an edit |
+|---|---|---|
+| a **directory** (`/plugin marketplace add <path to this repo>`) | the working tree | restart the session |
+| **GitHub** (`dogkeeper886/agent-workflows`, as the README tells downstreams) | a snapshot pinned to a commit | `claude plugin update agent-workflows@agent-workflows`, then restart |
 
-Qualify the name with the marketplace — the bare `agent-workflows` does not resolve.
-There is no version to bump: the commit is the version.
+Qualify the name with the marketplace — the bare `agent-workflows` does not resolve. There
+is no version to bump either way: the commit is the version.
+
+On a directory install, two things follow. A restart also picks up **uncommitted** edits —
+convenient while authoring a unit, a trap if you restart mid-edit with one half-written.
+And `~/.claude/plugins/` reads as authoritative when it is not: `installed_plugins.json`
+pins an `installPath` into a cache snapshot that may be many commits stale, and that
+snapshot is not what loads. Trust the tree.
 
 Only `.claude/rules/project-profile.md` stays in the repo — this project's values, loaded
 because the units cite it by name.

--- a/docs/adr/0001-ship-as-one-dogfooded-plugin.md
+++ b/docs/adr/0001-ship-as-one-dogfooded-plugin.md
@@ -26,6 +26,16 @@ reinstall first. That is a real cost for the one repo whose job is editing units
 is accepted deliberately: fidelity between tested and shipped is worth more than the
 inner loop.
 
+> **Correction, 2026-08-11.** That cost was predicted and never materialised for the repo
+> it was accepted for. Placed the way this repo is dogfooded — a marketplace added from a
+> *directory* rather than from GitHub — the plugin is served from the working tree, so an
+> edit takes effect on the next session restart with no reinstall. The cost is real only
+> for a GitHub placement, which is what downstreams use and what the README documents.
+>
+> The decision stands and its motive is unchanged: the tested copy and the shipped copy
+> are still one thing. Only the accepted cost was wrong, and in our favour. Observed by
+> finding a skill loaded in-session that existed in no cache snapshot.
+
 Doctrine and values separate by citation syntax rather than by convention.
 `${CLAUDE_PLUGIN_ROOT}/rules/…` means doctrine and resolves inside the plugin;
 `.claude/rules/project-profile.md` means values and resolves in the project. A project

--- a/plugins/agent-workflows/commands/dw-merge.md
+++ b/plugins/agent-workflows/commands/dw-merge.md
@@ -50,6 +50,9 @@ this step it survives on closed work forever.
         │     tested at <headRefOid>? A green /code-review-2axis or
         │     reviewing-finish does not answer it — those are agent passes, and
         │     this gate is a person's judgment on the change as a whole
+        │   - Nor does being told to run this command answer it. The instruction
+        │     is to open the gate, not to pass it: "merge PR <N>" is a request to
+        │     reach this question, never the answer to it. Ask, and wait
         │   - On no, or on no answer: do not merge. Stop here and report per Step 7,
         │     with the missing confirmation as the finding — a refused gate is a
         │     gate output, and it owes the human the same report a merge does


### PR DESCRIPTION
## Summary

- **CLAUDE.md §7 and ADR-0001 were wrong.** Both asserted the session loads a snapshot pinned to a commit, so "editing a unit here does not change the command you are running." For the way this repo is dogfooded that is false — the marketplace is added from a *directory*, so the plugin is served from the working tree and a session restart is enough.
- §7 now states the **condition** rather than one case: directory placement → tree + restart; GitHub placement → snapshot + `plugin update`. The latter is what the README tells downstreams, and the README is correct as written — untouched.
- ADR-0001 keeps its decision and gains a dated correction to the one consequence that never materialised.
- **`dw-merge` gate hardening.** Step 2 told the agent that green agent passes don't answer the gate, but never that *being told to run the command* doesn't either.

## Evidence for the plugin claim

`reviewing-finish` loads in-session and exists in **no** cache snapshot — there are four under `~/.claude/plugins/cache/agent-workflows/agent-workflows/`, none of which contain it. `installed_plugins.json` still pins `installPath` to `14ba4f2`, which is many commits stale and is not what loads.

Proven for skills. For the `dw-*` commands it follows from the shared `${CLAUDE_PLUGIN_ROOT}` — which resolved to the repo path when the harness handed over `reviewing-artifacts` — but has not been observed directly.

## Why the gate line matters

An auto-mode agent handed "merge PR N" can reason *the human told me to merge, therefore the human is satisfied*, and self-answer. That is issue #132's original bug verbatim, and it is the option this project **rejected** when it chose ask+record over "re-invocation is the confirmation." The command has to say so, or an agent will keep rediscovering the rejected option by accident.

## Test plan

- [ ] Merging this PR exercises the gate again — it should ask, and the ask should not be treated as pre-answered by the instruction to merge.
- [ ] After merge + restart, `/dw-merge` shows **Step 2: The Human Gate** with the new clause, which is itself the outstanding check that commands (not just skills) load from the tree.

## Notes

No issue behind this — found while answering "if I restart, will I have the latest version?". Branch is named without an `issue-<N>-` prefix for that reason.

`docs/stories/STORY-009.md:74` still records the old belief in a completed story's log. Left deliberately: it is history, and nothing cites it as rationale.

Generated with [Claude Code](https://claude.com/claude-code)