### PR TITLE
Rename dw-* to ship-*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,13 +67,13 @@ human decision (nothing auto-runs the next):
 
 ```
 /grill-with-docs → /to-spec → /to-tickets → /implement → /code-review-2axis
-                → reviewing-finish → dw-create-pr → [human review] → dw-merge
+                → reviewing-finish → ship-create-pr → [human review] → ship-merge
 ```
 
 **Idea through commit belongs to [`mattpocock/skills`](https://github.com/mattpocock/skills)**,
 which this repo installs. Don't rebuild any of it here — [ADR-0002](docs/adr/0002-complement-mattpocock-skills.md).
 
-**Commit through merge is ours** — the ship tail (`dw-create-pr` → `dw-merge`) plus
+**Commit through merge is ours** — the ship tail (`ship-create-pr` → `ship-merge`) plus
 `reviewing-finish`, the pass that runs the tooling and clears the leftovers a
 diff-reading review cannot see. Run it *after* `/code-review-2axis`, not instead of it.
 The full flow + pairing lives in `plugins/agent-workflows/rules/ship-tail.md`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These two are **complements, not alternatives**. Install both.
 
 Four things his set does not reach.
 
-**The ship tail.** `/implement` ends at *"commit your work to the current branch"* — nothing pushes, opens a change request, or merges. `dw-create-pr` pushes and opens the PR already linked to its issue; `dw-merge` merges, clears the labels, deletes the branch, and puts you back on the default branch. `/triage` applies a `ready-for-agent` state and nothing upstream ever clears it — the merge step is that label's only exit.
+**The ship tail.** `/implement` ends at *"commit your work to the current branch"* — nothing pushes, opens a change request, or merges. `ship-create-pr` pushes and opens the PR already linked to its issue; `ship-merge` merges, clears the labels, deletes the branch, and puts you back on the default branch. `/triage` applies a `ready-for-agent` state and nothing upstream ever clears it — the merge step is that label's only exit.
 
 **The finish review.** `/code-review-2axis` reads the diff. It cannot run your build, and it does not look for the debris a change leaves behind. `reviewing-finish` runs the project's own tooling, sweeps the debug prints and commented-out blocks and stray TODOs, and removes the imports and files *your* change orphaned. It runs **after** the two-axis review, never instead of it.
 
@@ -62,7 +62,7 @@ mkdir -p .claude/rules && curl -o .claude/rules/project-profile.md \
 Then edit it. What it declares:
 
 - where test docs and diagrams live, and how they're numbered
-- label names — including the triage state `dw-merge` clears
+- label names — including the triage state `ship-merge` clears
 - the branch-name pattern, the closure keyword, and the merge strategy
 - test-doc front matter and how staleness is detected
 - the change-request noun your host uses — `PR` or `MR`
@@ -86,9 +86,9 @@ Drive a change from idea to merged. The first five steps are Matt's; the last th
 /code-review-2axis                       # the diff, against standards and spec
                                          # ── the handoff ──
 reviewing-finish                         # run the tooling; clear leftovers and orphans
-/dw-create-pr      27                    # push, open the PR, link it (Fixes #27)
+/ship-create-pr    27                    # push, open the PR, link it (Fixes #27)
                                          # ── a human reviews and tests ──
-/dw-merge          30                    # merge, clear the labels, delete the branch
+/ship-merge        30                    # merge, clear the labels, delete the branch
 ```
 
 The qa-workflow turns a story into test docs the same gated way:
@@ -110,7 +110,7 @@ All of them live in [`plugins/agent-workflows/commands/`](plugins/agent-workflow
 
 | Group | Commands | Job |
 |-------|----------|-----|
-| **Ship tail** | `dw-create-pr` · `dw-merge` | commit → merged, with the branch and labels cleaned up |
+| **Ship tail** | `ship-create-pr` · `ship-merge` | commit → merged, with the branch and labels cleaned up |
 | **QA workflow** | `qw-plan` · `qw-review-plan` · `qw-cases` · `qw-review-cases` | a story → test docs, each producer paired with a review |
 | **Doc workflow** | `doc-gen-readme` · `doc-review-readme` | a codebase → its README, and the accuracy gate |
 

--- a/plugins/agent-workflows/commands/ship-create-pr.md
+++ b/plugins/agent-workflows/commands/ship-create-pr.md
@@ -28,7 +28,7 @@ preceding command it needs — run it straight after whatever produced the commi
 
 ## WORKFLOW
 
-    /dw-create-pr 27
+    /ship-create-pr 27
         │
         ├─► Step 1: Verify Readiness
         │   - Confirm you're on a feature branch, not the default branch —
@@ -77,13 +77,13 @@ preceding command it needs — run it straight after whatever produced the commi
         └─► Step 5: Report
             - Report per `agent-report`; Trace carries the PR URL
             - Next is the HUMAN review + test — stop here, don't auto-advance.
-              Merge with /dw-merge <PR> only once a human is satisfied.
+              Merge with /ship-merge <PR> only once a human is satisfied.
 
 ---
 
 ## EXAMPLE
 
-    /dw-create-pr 27
+    /ship-create-pr 27
 
 **Agent verifies, pushes, creates PR:**
 
@@ -97,7 +97,7 @@ preceding command it needs — run it straight after whatever produced the commi
 **Output:**
 
     PR #30 created: https://github.com/owner/repo/pull/30
-    A human reviews + tests it; merge with /dw-merge 30 when satisfied.
+    A human reviews + tests it; merge with /ship-merge 30 when satisfied.
 
 ---
 

--- a/plugins/agent-workflows/commands/ship-merge.md
+++ b/plugins/agent-workflows/commands/ship-merge.md
@@ -30,7 +30,7 @@ this step it survives on closed work forever.
 
 ## WORKFLOW
 
-    /dw-merge 30
+    /ship-merge 30
         │
         ├─► Step 1: Verify Ready to Merge
         │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,headRefOid,comments
@@ -103,7 +103,7 @@ this step it survives on closed work forever.
 
 ## EXAMPLE
 
-    /dw-merge 30
+    /ship-merge 30
 
 **Agent verifies, asks for the gate, records it, merges, cleans up:**
 

--- a/plugins/agent-workflows/rules/ship-tail.md
+++ b/plugins/agent-workflows/rules/ship-tail.md
@@ -13,10 +13,10 @@ work to the current branch"*. This is what picks it up there.
    reviewing-finish ──► run the project's tooling; clear the leftovers and
         │                orphans a diff-reading review cannot see
         ▼
-   dw-create-pr ─────► [human review + test]   push, open the change request,
-        │                                        link it to its issue
+   ship-create-pr ───► [human review + test]   push, open the change request,
+        │                                      link it to its issue
         ▼
-   dw-merge            merge · clear the labels · delete the branch · back to default
+   ship-merge          merge · clear the labels · delete the branch · back to default
 ```
 
 Each step stops for a human. None auto-runs the next.
@@ -33,11 +33,11 @@ does — those artifacts have no producer here. See
 
 ## Two kinds of label, and only one of them is ours
 
-`dw-create-pr` sets a **status** label and `dw-merge` clears it — that pair is this
+`ship-create-pr` sets a **status** label and `ship-merge` clears it — that pair is this
 pipeline's own bookkeeping, and it closes itself.
 
 The **triage state** label is different. Something upstream applies it to mark an issue
-ready to be worked, and nothing upstream ever removes it. `dw-merge` is that label's only
+ready to be worked, and nothing upstream ever removes it. `ship-merge` is that label's only
 exit; without this step it accumulates on closed work forever. Both names resolve from the
 profile.
 
@@ -45,17 +45,17 @@ profile.
 
 | Producer | Review | Covers |
 |----------|--------|--------|
-| `dw-create-pr` | **human review + test** (before the merge) | the change as a whole, on the change request |
-| `dw-merge` | *(is the terminal gate)* | mergeable, checks green, a human has reviewed |
+| `ship-create-pr` | **human review + test** (before the merge) | the change as a whole, on the change request |
+| `ship-merge` | *(is the terminal gate)* | mergeable, checks green, a human has reviewed |
 
 No producer ships without a review covering its output. The review paired with
-`dw-create-pr` is a **human gate**, not a command — the same shape as the human gate in
+`ship-create-pr` is a **human gate**, not a command — the same shape as the human gate in
 `doc-workflow`. The merge gate is a person's judgment, not a platform approval: on a solo
 repo the host blocks self-approval, so neither command may require one.
 
 A gate a person's judgment passes still has to be **observable**, or the command is left
 inferring it. An empty review list is not evidence either way — a carefully reviewed PR
-and an untouched one look identical. So `dw-merge` asks outright and records the answer on
+and an untouched one look identical. So `ship-merge` asks outright and records the answer on
 the change request against the head SHA, and reads that record on a later run. The
 judgment stays the human's; what changes is that it leaves a trace, and a trace pinned to
 a SHA stops covering the diff once the head moves.

--- a/plugins/agent-workflows/skills/reviewing-finish/SKILL.md
+++ b/plugins/agent-workflows/skills/reviewing-finish/SKILL.md
@@ -20,7 +20,7 @@ the issue asked for. Running this skill in its place leaves the change unreviewe
 axes. Running it *before* means sweeping debris out of code that may still be rewritten.
 
 Run it **after** the diff review, once the findings are settled, and before
-`/dw-create-pr`.
+`/ship-create-pr`.
 
 What it covers is what a reviewer reading a diff structurally cannot do:
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -67,13 +67,13 @@ human decision (nothing auto-runs the next):
 
 ```
 /grill-with-docs → /to-spec → /to-tickets → /implement → /code-review-2axis
-                → reviewing-finish → dw-create-pr → [human review] → dw-merge
+                → reviewing-finish → ship-create-pr → [human review] → ship-merge
 ```
 
 **Idea through commit** is [`mattpocock/skills`](https://github.com/mattpocock/skills) —
 install it alongside this plugin; nothing here duplicates it.
 
-**Commit through merge** is this plugin — the **ship tail** (`dw-create-pr` → `dw-merge`),
+**Commit through merge** is this plugin — the **ship tail** (`ship-create-pr` → `ship-merge`),
 which pushes, opens the change request linked to its issue, merges, clears the issue's
 labels, and deletes the branch. Plus `reviewing-finish`: the pass that runs this project's
 tooling and clears the leftovers and orphans a diff-reading review cannot see. Run it


### PR DESCRIPTION
## Summary

- `dw-create-pr` → `ship-create-pr`, `dw-merge` → `ship-merge`, via `git mv` so history follows.
- `dw-` abbreviated **dev-workflow**, the pipeline #126 deleted. The prefix named nothing; `ship-` names the concept these two actually implement, which is what `ship-tail.md` and CLAUDE.md §5 already call them.
- Seven live files updated. The two completed stories keep the old names as history.

## Why rename rather than drop

The bare form is invocable — the README documents `/dw-merge 30` unqualified — so `/merge` and `/create-pr` would be generic names in a namespace that already holds `resolving-merge-conflicts`. A prefix also keeps the group clustered in the `/` menu.

## Alignment

The new names are two characters longer, which silently shifts ASCII layout. Both diagrams were re-aligned by hand and verified programmatically:

- `ship-tail.md`'s flow keeps its original text column (23).
- README's command block keeps every `#` at column 41 and both arguments at column 19.

One incidental fix, flagged because it does not trace to this ticket: `ship-tail.md`'s continuation line had `link` at column 49 under `push` at 47 — a pre-existing 2-column misalignment. Rewriting those lines corrected it to 47. Reverting would have deliberately restored a broken diagram.

## Test plan

- [ ] After merge + restart, `/ship-merge` resolves and `/dw-merge` does not — which also settles the outstanding question of whether commands (not just skills) load from the working tree.

## Breaking

Anyone with muscle memory or docs pointing at `/dw-merge` must relearn. Cheap, but real.

Closes #135

Generated with [Claude Code](https://claude.com/claude-code)